### PR TITLE
Enable modal details for Enneagram types 2–9

### DIFF
--- a/index.html
+++ b/index.html
@@ -1071,7 +1071,7 @@
                             </div>
                         </div>
                         <div class="mt-5">
-                            <button class="text-sm font-medium text-blue-600 hover:text-blue-500">
+                            <button onclick="showEnneagramDetails('2')" class="text-sm font-medium text-blue-600 hover:text-blue-500">
                                 En savoir plus <i class="fas fa-arrow-right ml-1"></i>
                             </button>
                         </div>
@@ -1102,7 +1102,7 @@
                             </div>
                         </div>
                         <div class="mt-5">
-                            <button class="text-sm font-medium text-blue-600 hover:text-blue-500">
+                            <button onclick="showEnneagramDetails('3')" class="text-sm font-medium text-blue-600 hover:text-blue-500">
                                 En savoir plus <i class="fas fa-arrow-right ml-1"></i>
                             </button>
                         </div>
@@ -1133,7 +1133,7 @@
                             </div>
                         </div>
                         <div class="mt-5">
-                            <button class="text-sm font-medium text-blue-600 hover:text-blue-500">
+                            <button onclick="showEnneagramDetails('4')" class="text-sm font-medium text-blue-600 hover:text-blue-500">
                                 En savoir plus <i class="fas fa-arrow-right ml-1"></i>
                             </button>
                         </div>
@@ -1164,7 +1164,7 @@
                             </div>
                         </div>
                         <div class="mt-5">
-                            <button class="text-sm font-medium text-blue-600 hover:text-blue-500">
+                            <button onclick="showEnneagramDetails('5')" class="text-sm font-medium text-blue-600 hover:text-blue-500">
                                 En savoir plus <i class="fas fa-arrow-right ml-1"></i>
                             </button>
                         </div>
@@ -1195,7 +1195,7 @@
                             </div>
                         </div>
                         <div class="mt-5">
-                            <button class="text-sm font-medium text-blue-600 hover:text-blue-500">
+                            <button onclick="showEnneagramDetails('6')" class="text-sm font-medium text-blue-600 hover:text-blue-500">
                                 En savoir plus <i class="fas fa-arrow-right ml-1"></i>
                             </button>
                         </div>
@@ -1226,7 +1226,7 @@
                             </div>
                         </div>
                         <div class="mt-5">
-                            <button class="text-sm font-medium text-blue-600 hover:text-blue-500">
+                            <button onclick="showEnneagramDetails('7')" class="text-sm font-medium text-blue-600 hover:text-blue-500">
                                 En savoir plus <i class="fas fa-arrow-right ml-1"></i>
                             </button>
                         </div>
@@ -1257,7 +1257,7 @@
                             </div>
                         </div>
                         <div class="mt-5">
-                            <button class="text-sm font-medium text-blue-600 hover:text-blue-500">
+                            <button onclick="showEnneagramDetails('8')" class="text-sm font-medium text-blue-600 hover:text-blue-500">
                                 En savoir plus <i class="fas fa-arrow-right ml-1"></i>
                             </button>
                         </div>
@@ -1288,7 +1288,7 @@
                             </div>
                         </div>
                         <div class="mt-5">
-                            <button class="text-sm font-medium text-blue-600 hover:text-blue-500">
+                            <button onclick="showEnneagramDetails('9')" class="text-sm font-medium text-blue-600 hover:text-blue-500">
                                 En savoir plus <i class="fas fa-arrow-right ml-1"></i>
                             </button>
                         </div>


### PR DESCRIPTION
## Summary
- Wire "En savoir plus" buttons for Enneagram types 2–9 to display their detailed descriptions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f4ffdffe48321bce68aa595697563