### PR TITLE
fix: improve profile lookup and Supabase client usage

### DIFF
--- a/index.html
+++ b/index.html
@@ -1718,7 +1718,7 @@ function genererUniqueCode() {
 // 🔄 Envoie vers Supabase
 async function enregistrerQuestionsPourProches(questionsAutoEvaluation, userCode) {
   // Mettre à jour l'enregistrement existant avec les questions pour les proches
-  const { data, error } = await supabaseClient
+  const { data, error } = await supabase
     .from("users")
     .update({
       external_questions: questionsAutoEvaluation
@@ -2098,7 +2098,7 @@ const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBh
          */
          async function saveUserProfileToSupabase(userProfile) {
   try {
-    const { data, error } = await supabaseClient
+    const { data, error } = await supabase
       .from('users')
       .insert({
         code: userProfile.code,
@@ -2138,7 +2138,7 @@ const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBh
         async function saveExternalEvaluationToSupabase(code, relation, mbtiScores, enneagramScores) {
             try {
                 // Récupérer l'utilisateur par code
-                const { data: user, error: userError } = await supabaseClient
+                const { data: user, error: userError } = await supabase
                     .from('users')
                     .select('id, mbti_scores, enneagram_scores')
                     .eq('code', code)
@@ -2149,7 +2149,7 @@ const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBh
                 }
                 const userId = user.id;
                 // Insérer l'évaluation
-                const { error: insertError } = await supabaseClient
+                const { error: insertError } = await supabase
                     .from('external_evaluations')
                     .insert({
                         user_id: userId,
@@ -2176,7 +2176,7 @@ const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBh
         async function checkAndFinalizeResults(userId) {
             try {
                 // Récupérer l'utilisateur
-                const { data: user, error: userError } = await supabaseClient
+                const { data: user, error: userError } = await supabase
                     .from('users')
                     .select('id, mbti_scores, enneagram_scores, mbti_type, enneagram_type')
                     .eq('id', userId)
@@ -2187,7 +2187,7 @@ const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBh
                 }
 
                 // Récupérer les évaluations externes
-                const { data: evaluations, error: evalError } = await supabaseClient
+                const { data: evaluations, error: evalError } = await supabase
                     .from('external_evaluations')
                     .select('relation, mbti_scores, enneagram_scores, created_at')
                     .eq('user_id', userId);
@@ -2202,7 +2202,7 @@ const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBh
                 // Calculer le résultat pondéré
                 const { mbtiType, enneagramType, certainty } = computeWeightedResults(user.mbti_scores, user.enneagram_scores, evaluations);
                 // Mettre à jour l’utilisateur avec le résultat final
-                const { error: updateError } = await supabaseClient
+                const { error: updateError } = await supabase
                     .from('users')
                     .update({
                         result_mbti: mbtiType,
@@ -2299,7 +2299,7 @@ const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBh
          */
         async function fetchUserProfileFromSupabase(code) {
             try {
-                const { data: user, error: userError } = await supabaseClient
+                const { data: user, error: userError } = await supabase
                     .from('users')
                     .select('id, code, mbti_scores, enneagram_scores, mbti_type, enneagram_type, result_mbti, result_enneagram, result_certainty')
                     .eq('code', code)
@@ -2307,7 +2307,7 @@ const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBh
                 if (userError || !user) {
                     return null;
                 }
-                const { data: evaluations, error: evalError } = await supabaseClient
+                const { data: evaluations, error: evalError } = await supabase
                     .from('external_evaluations')
                     .select('relation, mbti_scores, enneagram_scores, created_at')
                     .eq('user_id', user.id);
@@ -4524,16 +4524,11 @@ const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBh
 
 <script>
   // Initialisation correcte du client Supabase
-  const { createClient } = supabase;
-  const supabaseClient = createClient(
-    'https://swjnpvfkloubshksobau.supabase.co',
-    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InN3am5wdmZrbG91YnNoa3NvYmF1Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTQwOTUxMzEsImV4cCI6MjA2OTY3MTEzMX0.A6rnIJyfIIxDT0c2XW_zGeUXpdYCgBFd6MTzBGFZ-Cg'
-  );
-
+  const supabase = window.supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
   console.log('✅ Supabase client initialisé correctement');
 
   async function afficherProfilUtilisateur() {
-    const code = document.getElementById("code-saisi").value.trim();
+    const code = document.getElementById("code-saisi").value.trim().toUpperCase();
     const profilDiv = document.getElementById("profil-resultat");
 
     if (!code) {
@@ -4541,14 +4536,19 @@ const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBh
       return;
     }
 
-    const { data, error } = await supabaseClient
+    // Animation de chargement
+    profilDiv.innerHTML = '<div class="flex justify-center mt-4"><div class="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-blue-500"></div></div>';
+
+    const { data, error } = await supabase
       .from("users")
       .select("mbti_type, enneagram_type, certainty_score")
       .eq("code", code)
       .single();
 
+    console.log(data, error);
+
     if (error || !data) {
-      profilDiv.innerHTML = "<p class='text-red-600'>❌ Aucun profil trouvé pour ce code.</p>";
+      profilDiv.innerHTML = "<p class='text-red-600'>❌ Code introuvable. Vérifiez les majuscules ou réessayez.</p>";
       return;
     }
 


### PR DESCRIPTION
## Summary
- standardize Supabase client initialization and usage
- uppercase profile code input and log Supabase responses
- show loading state and improved error message during profile lookup

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f919d89748321b4970ece9eac651f