### PR TITLE
Fix result button and add MBTI chatbot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # personnalite-comparee
 Webapp HTML/JS combinant test MBTI + Ennéagramme, sans backend. Résultats anonymes stockés via Supabase. Front hébergé sur GitHub Pages.
+
+## Fonctionnalités
+
+- Test MBTI + Ennéagramme avec validation par des proches
+- Génération du profil final après 3 évaluations externes
+- Chatbot basé sur GPT‑3.5 pour répondre aux questions sur les profils

--- a/index.html
+++ b/index.html
@@ -449,6 +449,23 @@
         </div>
     </div>
 
+    <!-- Chatbot Section -->
+    <section id="profil-chatbot" class="bg-white py-16 px-4 sm:px-6 lg:px-8">
+        <div class="max-w-3xl mx-auto">
+            <div class="text-center">
+                <h2 class="text-3xl font-extrabold text-gray-900 sm:text-4xl">Questions sur les profils</h2>
+                <p class="mt-4 text-xl text-gray-500">Discutez avec notre assistant IA pour en savoir plus sur les profils MBTI et Ennéagramme.</p>
+            </div>
+            <div class="mt-8">
+                <div id="chat-box" class="h-64 overflow-y-auto border border-gray-200 rounded-lg p-4 mb-4 bg-gray-50"></div>
+                <div class="flex">
+                    <input id="chat-input" type="text" placeholder="Posez votre question..." class="flex-grow px-4 py-2 border border-gray-300 rounded-l-md focus:ring-blue-500 focus:border-blue-500">
+                    <button id="chat-send" class="px-4 py-2 bg-blue-600 text-white rounded-r-md hover:bg-blue-700">Envoyer</button>
+                </div>
+            </div>
+        </div>
+    </section>
+
     <section id="retourver-profil" class="bg-white py-16 px-4 sm:px-6 lg:px-8">
         <div class="max-w-3xl mx-auto">
           <div class="text-center">
@@ -4143,7 +4160,7 @@ const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBh
             
             // Afficher/cacher le bouton "Voir mes résultats"
             const viewResultsBtn = document.getElementById('view-results-btn');
-            if (profile.results && completedEvaluations >= totalEvaluationsRequired) {
+            if (completedEvaluations >= totalEvaluationsRequired) {
                 viewResultsBtn.style.display = 'block';
             } else {
                 viewResultsBtn.style.display = 'none';
@@ -4216,12 +4233,18 @@ const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBh
 
         async function viewResults() {
             const code = document.getElementById('display-code').textContent;
-            const result = await fetchUserProfileFromSupabase(code);
+            let result = await fetchUserProfileFromSupabase(code);
             if (!result) {
                 alert('Profil introuvable.');
                 return;
             }
-            // Vérifier qu’il y a un résultat final
+            // Calculer le résultat final si nécessaire
+            if (!result.user.result_mbti || !result.user.result_enneagram) {
+                if (result.evaluations.length >= 3) {
+                    await checkAndFinalizeResults(result.user.id);
+                    result = await fetchUserProfileFromSupabase(code);
+                }
+            }
             if (!result.user.result_mbti || !result.user.result_enneagram) {
                 alert('Le résultat final n’est pas encore prêt. Veuillez patienter jusqu’à ce que trois évaluations externes soient complétées.');
                 return;
@@ -4545,9 +4568,61 @@ const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBh
                         </button>
                     </div>
                 </div>
-            </div>
+    </div>
         </div>
     </div>
+
+<script>
+    const OPENAI_API_KEY = 'YOUR_OPENAI_API_KEY';
+    async function sendChatMessage(message) {
+        const response = await fetch('https://api.openai.com/v1/chat/completions', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'Authorization': `Bearer ${OPENAI_API_KEY}`
+            },
+            body: JSON.stringify({
+                model: 'gpt-3.5-turbo',
+                messages: [
+                    { role: 'system', content: 'Tu es un assistant spécialisé en MBTI et Ennéagramme.' },
+                    { role: 'user', content: message }
+                ]
+            })
+        });
+        const data = await response.json();
+        return data.choices?.[0]?.message?.content?.trim() || "Une erreur s'est produite.";
+    }
+    function appendMessage(role, text) {
+        const chatBox = document.getElementById('chat-box');
+        if (!chatBox) return;
+        const wrapper = document.createElement('div');
+        wrapper.className = role === 'user' ? 'text-right mb-2' : 'text-left mb-2';
+        wrapper.innerHTML = `<span class="inline-block px-3 py-2 rounded-lg ${role === 'user' ? 'bg-blue-600 text-white' : 'bg-gray-200 text-gray-800'}">${text}</span>`;
+        chatBox.appendChild(wrapper);
+        chatBox.scrollTop = chatBox.scrollHeight;
+    }
+    document.addEventListener('DOMContentLoaded', () => {
+        const sendBtn = document.getElementById('chat-send');
+        const input = document.getElementById('chat-input');
+        if (sendBtn && input) {
+            const sendMessage = async () => {
+                const question = input.value.trim();
+                if (!question) return;
+                appendMessage('user', question);
+                input.value = '';
+                const answer = await sendChatMessage(question);
+                appendMessage('assistant', answer);
+            };
+            sendBtn.addEventListener('click', sendMessage);
+            input.addEventListener('keydown', e => {
+                if (e.key === 'Enter') {
+                    e.preventDefault();
+                    sendMessage();
+                }
+            });
+        }
+    });
+</script>
 
 <script type="module">
   import { createClient } from "https://cdn.jsdelivr.net/npm/@supabase/supabase-js/+esm";


### PR DESCRIPTION
## Summary
- ensure results button appears once three external evaluations are complete
- compute and store results on demand when user views profile
- add GPT-3.5 based chatbot section for MBTI/Enneagram questions

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_688fafe07b4c8321a1b14a74cdca23fa