### PR TITLE
Fix result finalization and improve chat configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,9 @@ Webapp HTML/JS combinant test MBTI + Ennéagramme, sans backend. Résultats anon
 - Test MBTI + Ennéagramme avec validation par des proches
 - Génération du profil final après 3 évaluations externes
 - Chatbot basé sur GPT‑3.5 pour répondre aux questions sur les profils
+
+## Configuration du chatbot
+
+Pour utiliser le chatbot, une clé API OpenAI est nécessaire. Lors de la première
+utilisation du chat, le navigateur vous invitera à saisir votre clé, qui sera
+stockée localement dans `localStorage`.

--- a/index.html
+++ b/index.html
@@ -4084,14 +4084,14 @@ const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBh
 
         async function checkProfileCode() {
             const code = document.getElementById('profile-code').value.trim().toUpperCase();
-            
+
             if (!code) {
                 alert('Veuillez entrer un code');
                 return;
             }
 
             // Récupération du profil via Supabase
-            const result = await fetchUserProfileFromSupabase(code);
+            let result = await fetchUserProfileFromSupabase(code);
             if (!result) {
                 // Afficher le message d'erreur
                 document.querySelectorAll('.profile-step').forEach(step => {
@@ -4100,6 +4100,19 @@ const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBh
                 document.getElementById('error-message').style.display = 'block';
                 return;
             }
+
+            // Si le résultat final n'est pas encore calculé mais que
+            // trois évaluations externes sont présentes, tenter de le générer.
+            if ((!result.user.result_mbti || !result.user.result_enneagram) &&
+                result.evaluations.length >= 3) {
+                await checkAndFinalizeResults(result.user.id);
+                result = await fetchUserProfileFromSupabase(code);
+                if (!result) {
+                    alert('Profil introuvable après mise à jour.');
+                    return;
+                }
+            }
+
             const { user, evaluations } = result;
             // Construire un objet de profil simplifié compatible avec displayProfile
             const simplifiedProfile = {
@@ -4242,11 +4255,13 @@ const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBh
             if (!result.user.result_mbti || !result.user.result_enneagram) {
                 if (result.evaluations.length >= 3) {
                     await checkAndFinalizeResults(result.user.id);
+                    // petite pause pour laisser le temps à la mise à jour
+                    await new Promise(r => setTimeout(r, 300));
                     result = await fetchUserProfileFromSupabase(code);
                 }
             }
             if (!result.user.result_mbti || !result.user.result_enneagram) {
-                alert('Le résultat final n’est pas encore prêt. Veuillez patienter jusqu’à ce que trois évaluations externes soient complétées.');
+                alert('Le résultat final n’est pas encore prêt. Veuillez patienter encore quelques instants.');
                 return;
             }
             const finalProfile = {
@@ -4573,24 +4588,41 @@ const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBh
     </div>
 
 <script>
-    const OPENAI_API_KEY = 'YOUR_OPENAI_API_KEY';
+    let OPENAI_API_KEY = localStorage.getItem('OPENAI_API_KEY');
     async function sendChatMessage(message) {
-        const response = await fetch('https://api.openai.com/v1/chat/completions', {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-                'Authorization': `Bearer ${OPENAI_API_KEY}`
-            },
-            body: JSON.stringify({
-                model: 'gpt-3.5-turbo',
-                messages: [
-                    { role: 'system', content: 'Tu es un assistant spécialisé en MBTI et Ennéagramme.' },
-                    { role: 'user', content: message }
-                ]
-            })
-        });
-        const data = await response.json();
-        return data.choices?.[0]?.message?.content?.trim() || "Une erreur s'est produite.";
+        if (!OPENAI_API_KEY) {
+            OPENAI_API_KEY = prompt('Pour utiliser le chat, entrez votre clé API OpenAI :');
+            if (OPENAI_API_KEY) {
+                localStorage.setItem('OPENAI_API_KEY', OPENAI_API_KEY);
+            } else {
+                return "Le service de chat n'est pas configuré. Veuillez fournir une clé API OpenAI.";
+            }
+        }
+        try {
+            const response = await fetch('https://api.openai.com/v1/chat/completions', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Authorization': `Bearer ${OPENAI_API_KEY}`
+                },
+                body: JSON.stringify({
+                    model: 'gpt-3.5-turbo',
+                    messages: [
+                        { role: 'system', content: 'Tu es un assistant spécialisé en MBTI et Ennéagramme.' },
+                        { role: 'user', content: message }
+                    ]
+                })
+            });
+            if (!response.ok) {
+                console.error('Erreur de l\u2019API OpenAI:', await response.text());
+                return "Impossible de contacter l'IA pour le moment.";
+            }
+            const data = await response.json();
+            return data.choices?.[0]?.message?.content?.trim() || "Réponse vide de l'IA.";
+        } catch (err) {
+            console.error('Exception lors de l\u2019appel OpenAI:', err);
+            return "Une erreur s'est produite lors de la communication avec l'IA.";
+        }
     }
     function appendMessage(role, text) {
         const chatBox = document.getElementById('chat-box');


### PR DESCRIPTION
## Summary
- ensure final personality results are computed once three external evaluations exist
- prompt for OpenAI API key and improve chatbot error handling
- document how to configure the chatbot

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688fb25eceb08321a226363828f713d9