### PR TITLE
fix: ignore code validation when parameter missing

### DIFF
--- a/index.html
+++ b/index.html
@@ -4624,16 +4624,15 @@ return data.message || "Réponse vide de l'IA.";
   window.supabase = supabase;
 
   const externalForm = document.getElementById("external-form");
-  if (externalForm) {
-    externalForm.style.display = "none";
-  }
 
   const params = new URLSearchParams(window.location.search);
   const code = params.get("code")?.toUpperCase();
 
-  if (!code) {
-    alert("Code invalide ou introuvable.");
-  } else {
+  if (code) {
+    if (externalForm) {
+      externalForm.style.display = "none";
+    }
+
     try {
       const { data, error } = await supabase
         .from("users")
@@ -4655,39 +4654,39 @@ return data.message || "Réponse vide de l'IA.";
       console.error("Erreur lors de la vérification du code :", err);
       alert("Code invalide ou introuvable.");
     }
-  }
 
-  if (externalForm) {
-    externalForm.addEventListener("submit", async (e) => {
-      e.preventDefault();
-      try {
-        const { data, error } = await supabase
-          .from("users")
-          .select("uses_count")
-          .eq("code", code)
-          .single();
-        if (error || !data) {
-          alert("Erreur lors de la récupération du compteur.");
-          return;
+    if (externalForm) {
+      externalForm.addEventListener("submit", async (e) => {
+        e.preventDefault();
+        try {
+          const { data, error } = await supabase
+            .from("users")
+            .select("uses_count")
+            .eq("code", code)
+            .single();
+          if (error || !data) {
+            alert("Erreur lors de la récupération du compteur.");
+            return;
+          }
+          const { error: updateError } = await supabase
+            .from("users")
+            .update({ uses_count: data.uses_count + 1 })
+            .eq("code", code);
+          if (updateError) {
+            alert("Erreur lors de la mise à jour du compteur.");
+            return;
+          }
+          alert(
+            "Merci pour votre participation. Les résultats sont disponibles dans la section 'Mon profil'."
+          );
+          externalForm.reset();
+          externalForm.style.display = "none";
+        } catch (err) {
+          console.error("Erreur lors de l'incrémentation de uses_count :", err);
+          alert("Une erreur est survenue.");
         }
-        const { error: updateError } = await supabase
-          .from("users")
-          .update({ uses_count: data.uses_count + 1 })
-          .eq("code", code);
-        if (updateError) {
-          alert("Erreur lors de la mise à jour du compteur.");
-          return;
-        }
-        alert(
-          "Merci pour votre participation. Les résultats sont disponibles dans la section 'Mon profil'."
-        );
-        externalForm.reset();
-        externalForm.style.display = "none";
-      } catch (err) {
-        console.error("Erreur lors de l'incrémentation de uses_count :", err);
-        alert("Une erreur est survenue.");
-      }
-    });
+      });
+    }
   }
 </script>
 


### PR DESCRIPTION
## Summary
- verify user code only when present in the URL

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68920b13f8888321b070f860aba8c9dc