### PR TITLE
fix: handle missing user in profile lookup

### DIFF
--- a/index.html
+++ b/index.html
@@ -4027,7 +4027,7 @@ console.log("📘 MBTI :", result.user?.mbti_type);
 console.log("📗 Ennéagramme :", result.user?.enneagram_type);
 console.log("📊 Certitude (certainty_score) :", result.user?.certainty_score);
 
-            if (!result) {
+            if (!result || !result.user) {
                 // Afficher le message d'erreur
                 document.querySelectorAll('.profile-step').forEach(step => {
                     step.style.display = 'none';


### PR DESCRIPTION
## Summary
- prevent TypeError by ensuring fetched profile includes a `user`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6892122ea87c8321b05af71e0529e368