### PR TITLE
Remove uses_count limit from external evaluation

### DIFF
--- a/index.html
+++ b/index.html
@@ -4638,16 +4638,12 @@ return data.message || "Réponse vide de l'IA.";
       try {
         const { data: user, error } = await supabase
           .from("users")
-          .select("uses_count")
+          .select("id")
           .eq("code", encodedCode)
           .single();
 
         if (error || !user) {
           alert("Code invalide ou introuvable.");
-          return;
-        } else if (user.uses_count >= 3) {
-          alert("Ce code a déjà été utilisé 3 fois. Il n’est plus possible de l’utiliser pour une nouvelle évaluation.");
-          window.location.href = "/";
           return;
         } else if (externalForm) {
           externalForm.style.display = "";
@@ -4661,33 +4657,11 @@ return data.message || "Réponse vide de l'IA.";
   }
 
   if (externalForm) {
-    externalForm.addEventListener("submit", async (e) => {
+    externalForm.addEventListener("submit", (e) => {
       e.preventDefault();
-      try {
-        const { data: user, error } = await supabase
-          .from("users")
-          .select("uses_count")
-          .eq("code", encodedCode)
-          .single();
-        if (error || !user) {
-          alert("Erreur lors de la récupération du compteur.");
-          return;
-        }
-        const { error: updateError } = await supabase
-          .from("users")
-          .update({ uses_count: user.uses_count + 1 })
-          .eq("code", encodedCode);
-        if (updateError) {
-          alert("Erreur lors de la mise à jour du compteur.");
-          return;
-        }
-        alert("Merci pour votre participation. Les résultats sont disponibles dans la section 'Mon profil'.");
-        externalForm.reset();
-        externalForm.style.display = "none";
-      } catch (err) {
-        console.error("Erreur lors de l'incrémentation de uses_count :", err);
-        alert("Une erreur est survenue.");
-      }
+      alert("Merci pour votre participation. Les résultats sont disponibles dans la section 'Mon profil'.");
+      externalForm.reset();
+      externalForm.style.display = "none";
     });
   }
 </script>


### PR DESCRIPTION
## Summary
- remove `uses_count` checks for external evaluation codes
- show evaluation form if code exists regardless of usage
- drop unnecessary Supabase calls related to `uses_count`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689232b63c70832186ae4a64b39c5146