### PR TITLE
Adjust background alternation and lighten gray sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -164,7 +164,7 @@
         }
 
         .section-fonce {
-            background-color: #e5e7eb;
+            background-color: #f5f5f5;
         }
 
         /* Menu mobile caché par défaut */
@@ -220,7 +220,7 @@
     </nav>
 
     <!-- Hero Section Premium -->
-    <div class="relative flex items-center justify-center overflow-hidden bg-gradient-to-br from-gray-50 via-white to-blue-50/30" style="min-height: 80vh;">
+    <div class="section-clair relative flex items-center justify-center overflow-hidden" style="min-height: 80vh;">
         <!-- Grille subtile en arrière-plan -->
         <div class="absolute inset-0 opacity-[0.02]">
             <div class="absolute inset-0" style="background-image: radial-gradient(circle at 1px 1px, rgb(15 23 42) 1px, transparent 0); background-size: 40px 40px;"></div>
@@ -289,7 +289,7 @@
     </div>
 
     <!-- How it works -->
-    <div class="bg-white py-16 px-4 sm:px-6 lg:px-8">
+    <div class="section-fonce py-16 px-4 sm:px-6 lg:px-8">
         <div class="max-w-7xl mx-auto">
             <div class="text-center">
                 <h2 class="text-3xl font-extrabold text-gray-900 sm:text-4xl">
@@ -340,7 +340,7 @@
     </div>
 
     <!-- Auto-evaluation Section -->
-    <div id="auto-evaluation" class="section-fonce py-16 px-4 sm:px-6 lg:px-8">
+    <div id="auto-evaluation" class="section-clair py-16 px-4 sm:px-6 lg:px-8">
         <div class="max-w-3xl mx-auto">
             <div class="text-center">
                 <h2 class="text-3xl font-extrabold text-gray-900 sm:text-4xl">
@@ -373,7 +373,7 @@
 
 
     <!-- Evaluate a friend Section -->
-    <div id="evaluation-proche" class="section-clair py-16 px-4 sm:px-6 lg:px-8">
+    <div id="evaluation-proche" class="section-fonce py-16 px-4 sm:px-6 lg:px-8">
         <div class="max-w-3xl mx-auto">
             <div class="text-center">
                 <h2 class="text-3xl font-extrabold text-gray-900 sm:text-4xl">
@@ -454,7 +454,7 @@
     </div>
 
     <!-- Chatbot Section -->
-    <section id="profil-chatbot" class="section-fonce py-16 px-4 sm:px-6 lg:px-8">
+    <section id="profil-chatbot" class="section-clair py-16 px-4 sm:px-6 lg:px-8">
         <div class="max-w-3xl mx-auto">
             <div class="text-center">
                 <h2 class="text-3xl font-extrabold text-gray-900 sm:text-4xl">Parler avec Psycho'Bot</h2>
@@ -470,7 +470,7 @@
         </div>
     </section>
 
-    <section id="retourver-profil" class="section-clair py-16 px-4 sm:px-6 lg:px-8">
+    <section id="retourver-profil" class="section-fonce py-16 px-4 sm:px-6 lg:px-8">
         <div class="max-w-3xl mx-auto">
           <div class="text-center">
             <h2 class="text-3xl font-extrabold text-gray-900 sm:text-4xl flex justify-center items-center gap-2">
@@ -494,7 +494,7 @@
       </section>
 
     <!-- MBTI Types Section -->
-    <div id="mbti" class="section-fonce py-16 px-4 sm:px-6 lg:px-8">
+    <div id="mbti" class="section-clair py-16 px-4 sm:px-6 lg:px-8">
         <div class="max-w-7xl mx-auto">
             <div class="text-center">
                 <h2 class="text-3xl font-extrabold text-gray-900 sm:text-4xl">
@@ -875,7 +875,7 @@
 
 
     <!-- Enneagram Types Section -->
-    <div id="enneagram" class="section-clair py-16 px-4 sm:px-6 lg:px-8">
+    <div id="enneagram" class="section-fonce py-16 px-4 sm:px-6 lg:px-8">
         <div class="max-w-7xl mx-auto">
             <div class="text-center">
                 <h2 class="text-3xl font-extrabold text-gray-900 sm:text-4xl">
@@ -1171,7 +1171,7 @@
 
 
     <!-- FAQ Section -->
-    <div id="faq" class="section-fonce py-16 px-4 sm:px-6 lg:px-8">
+    <div id="faq" class="section-clair py-16 px-4 sm:px-6 lg:px-8">
         <div class="max-w-3xl mx-auto">
             <div class="text-center">
                 <h2 class="text-3xl font-extrabold text-gray-900 sm:text-4xl">
@@ -1277,7 +1277,7 @@
     </div>
 
     <!-- About Section -->
-    <div class="section-clair py-16 px-4 sm:px-6 lg:px-8">
+    <div class="section-fonce py-16 px-4 sm:px-6 lg:px-8">
         <div class="max-w-3xl mx-auto text-center">
             <h2 class="text-3xl font-extrabold text-gray-900 sm:text-4xl">
                 À propos du projet


### PR DESCRIPTION
## Summary
- Use a very light gray (#f5f5f5) for `section-fonce` backgrounds
- Start page with a white banner and apply alternating white/gray backgrounds down the page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68923c97c6548321911965b22d912f7f