### PR TITLE
Lighten alternating section background color

### DIFF
--- a/index.html
+++ b/index.html
@@ -164,7 +164,7 @@
         }
 
         .section-fonce {
-            background-color: #f5f5f5;
+            background-color: #fafafa;
         }
 
         /* Menu mobile caché par défaut */


### PR DESCRIPTION
## Summary
- use `#fafafa` for `.section-fonce` to ensure alternate sections remain visibly distinct while keeping a very subtle contrast

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68923ec6ca808321958aa4640a67c35a