### PR TITLE
Clarify dark section backgrounds

### DIFF
--- a/index.html
+++ b/index.html
@@ -164,7 +164,7 @@
         }
 
         .section-fonce {
-            background-color: #fafafa;
+            background-color: #fdfdfd;
         }
 
         /* Menu mobile caché par défaut */


### PR DESCRIPTION
## Summary
- Lighten darker sections by changing `.section-fonce` background to `#fdfdfd` for a subtler contrast with white sections

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68923ff87fd88321b5d8c2fab30e753b