### PR TITLE
feat: show enneagram type with MBTI

### DIFF
--- a/index.html
+++ b/index.html
@@ -4063,7 +4063,9 @@ console.log("📊 Certitude (certainty_score) :", result.user?.certainty_score);
             const { user, evaluations } = result;
             // Construire un objet de profil simplifié compatible avec displayProfile
             const simplifiedProfile = {
-                name: user.mbti_type || 'Profil',
+                name: user.mbti_type && user.enneagram_type
+                    ? `${user.mbti_type} — type ${user.enneagram_type}`
+                    : user.mbti_type || 'Profil',
                 selfEvaluationCompleted: true,
                 externalEvaluations: evaluations.map(ev => ({
                     relation: ev.relation,
@@ -4225,7 +4227,7 @@ console.log("📊 Certitude (certainty_score) :", result.user?.certainty_score);
             );
 
             const finalProfile = {
-                name: result.user.mbti_type,
+                name: `${result.user.mbti_type} — type ${result.user.enneagram_type}`,
                 results: {
                     mbti: result.user.mbti_type,
                     mbtiCertainty,


### PR DESCRIPTION
## Summary
- include enneagram type next to MBTI when naming a profile
- show combined MBTI and enneagram type in detailed results modal

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68924c8647dc83219f33fae2076a088d