### PR TITLE
fix: prevent horizontal scrolling

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,6 +39,9 @@
     <!-- Supabase JS library -->
    
     <style>
+        html, body {
+            overflow-x: hidden;
+        }
         body {
             transition: background-color 0.3s, color 0.3s;
         }


### PR DESCRIPTION
## Summary
- hide horizontal overflow site-wide to avoid stray scrollbars

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68939b27f6d48321a82e53ed6597a563