### PR TITLE
feat: reposition quick questions in chatbot

### DIFF
--- a/index.html
+++ b/index.html
@@ -236,14 +236,11 @@
             font-weight: bold;
             animation: shake 0.4s;
         }
-        #chat-suggestions {
-            display: flex;
-            flex-direction: column;
-        }
         #chat-suggestions .assistant-bubble {
             cursor: pointer;
-            margin-bottom: 8px;
-            align-self: flex-start;
+            border: none;
+            outline: none;
+            font-size: 14px;
         }
         #chat-suggestions .assistant-bubble:hover {
             box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
@@ -538,12 +535,11 @@
                 <p class="mt-4 text-xl text-gray-500">Discutez avec notre assistant IA pour en savoir plus sur les profils MBTI et Ennéagramme.</p>
             </div>
             <div class="mt-8">
-                <div id="chat-box" class="h-64 overflow-y-auto border border-gray-200 rounded-lg p-4 mb-4 bg-gray-50">
-                    <div id="chat-suggestions" class="chat-suggestions fade-in">
-                        <div class="chat-bubble assistant-bubble suggestion-bubble" data-question="Quel type est compatible avec un ENFP ?">❤️ Quel type est compatible avec un ENFP ?</div>
-                        <div class="chat-bubble assistant-bubble suggestion-bubble" data-question="Comment est calculée la certitude globale ?">📊 Comment est calculée la certitude globale ?</div>
-                        <div class="chat-bubble assistant-bubble suggestion-bubble" data-question="Pourquoi demander l’avis de mes proches ?">🤝 Pourquoi demander l’avis de mes proches ?</div>
-                    </div>
+                <div id="chat-box" class="h-64 overflow-y-auto border border-gray-200 rounded-lg p-4 mb-4 bg-gray-50"></div>
+                <div id="chat-suggestions" class="chat-suggestions fade-in flex flex-wrap justify-between gap-2 mb-2 text-sm">
+                    <button class="chat-bubble assistant-bubble suggestion-bubble" data-question="Quel type est compatible avec un ENFP ?">❤️ Quel type est compatible avec un ENFP ?</button>
+                    <button class="chat-bubble assistant-bubble suggestion-bubble" data-question="Comment est calculée la certitude globale ?">📊 Comment est calculée la certitude globale ?</button>
+                    <button class="chat-bubble assistant-bubble suggestion-bubble" data-question="Pourquoi demander l’avis de mes proches ?">🤝 Pourquoi demander l’avis de mes proches ?</button>
                 </div>
                 <div class="flex">
                     <input id="chat-input" type="text" placeholder="Posez votre question..." class="flex-grow px-4 py-2 border border-gray-300 rounded-l-md focus:ring-blue-500 focus:border-blue-500">


### PR DESCRIPTION
## Summary
- Move predefined chatbot questions below chat history just above input
- Show questions horizontally with flex layout, spacing, and smaller text for better fit

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893bea73d748321a780ecd86588cc6d