### PR TITLE
feat: switch to gpt-5-mini model

### DIFF
--- a/api/text.js
+++ b/api/text.js
@@ -8,7 +8,7 @@ export default async function handler(req, res) {
   try {
     const {
       messages = [],
-      model = 'gpt-3.5-turbo',
+      model = 'gpt-5-mini',
       temperature = 0.7,
       max_tokens,
     } = req.body;

--- a/index.html
+++ b/index.html
@@ -4750,7 +4750,7 @@ function displayResults(results) {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({
-                        model: 'gpt-3.5-turbo',
+                        model: 'gpt-5-mini',
                         temperature: 0.5,
                         max_tokens: 120,
                         messages: [
@@ -4997,7 +4997,7 @@ function displayResults(results) {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({
-          model: 'gpt-3.5-turbo',
+          model: 'gpt-5-mini',
           messages: [
             { role: 'system', content: 'Tu es un assistant spécialisé en MBTI et Ennéagramme.' },
             { role: 'user', content: message }


### PR DESCRIPTION
## Summary
- switch API calls to gpt-5-mini
- update client-side scripts to request gpt-5-mini

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896212eec6c8321b2066883aa78a549