### PR TITLE
feat: add smooth auto scroll to chat

### DIFF
--- a/index.html
+++ b/index.html
@@ -5026,6 +5026,16 @@ function displayResults(results) {
   let currentTyped = null;
   let limitErrorShown = false;
 
+  function isNearBottom(el) {
+    return el.scrollHeight - el.scrollTop - el.clientHeight < 80;
+  }
+
+  function safeScrollToBottom(el) {
+    if (isNearBottom(el)) {
+      el.scrollTo({ top: el.scrollHeight, behavior: 'smooth' });
+    }
+  }
+
   function appendMessage(role, text, options = {}) {
     const { limitError = false } = options;
     if (limitError && limitErrorShown) return;
@@ -5040,6 +5050,7 @@ function displayResults(results) {
     bubble.className = classes;
     wrapper.appendChild(bubble);
     chatBox.appendChild(wrapper);
+    safeScrollToBottom(chatBox);
 
     if (role === 'assistant') {
       if (currentTyped) {
@@ -5048,6 +5059,8 @@ function displayResults(results) {
           currentTyped.el.dataset.fullText || currentTyped.el.innerHTML;
       }
       bubble.dataset.fullText = text;
+      const observer = new MutationObserver(() => safeScrollToBottom(chatBox));
+      observer.observe(bubble, { childList: true, subtree: true, characterData: true });
       currentTyped = new Typed(bubble, {
         strings: [text],
         typeSpeed: 30,
@@ -5055,18 +5068,19 @@ function displayResults(results) {
         loop: false,
         contentType: 'html',
         onStringTyped: () => {
-          chatBox.scrollTop = chatBox.scrollHeight;
+          safeScrollToBottom(chatBox);
         },
         onComplete: () => {
-          chatBox.scrollTop = chatBox.scrollHeight;
+          safeScrollToBottom(chatBox);
           currentTyped = null;
+          observer.disconnect();
         },
       });
     } else {
       bubble.textContent = text;
     }
 
-    chatBox.scrollTop = chatBox.scrollHeight;
+    safeScrollToBottom(chatBox);
   }
 
   document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## Summary
- add `isNearBottom` and `safeScrollToBottom` helpers for chat window
- use `MutationObserver` and smooth scrolling to keep view on latest messages without interrupting the user

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68963424312c8321af0e6b4e0c16e636