### PR TITLE
fix: ensure Psycho'Bot descriptions scroll on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -301,16 +301,40 @@
           .pc-info-banner{ margin:12px 0; font-size:.93rem; }
         }
         @media (max-width: 768px){
-          .pc-psy-dialog{ max-height: calc(100dvh - 32px); overflow: hidden; }
-          .pc-psy-content{
-            overflow-y: auto; max-height: none;
-            -webkit-overflow-scrolling: touch;
+          /* Conteneur modal/carte qui porte le bloc Psycho'Bot */
+          .pc-psy-dialog{
+            /* container en colonne pour réserver une zone scrollable */
+            display: flex;
+            flex-direction: column;
+            max-height: 100dvh;           /* unités dynamiques fiables sur mobile */
+            overflow: hidden;             /* le scroll se fait dans .pc-psy-content */
           }
-          .pc-psy-content p{
-            white-space: normal; word-break: break-word; overflow-wrap: anywhere;
-            /* lève tout line-clamp éventuel */
-            -webkit-line-clamp: initial; -webkit-box-orient: initial;
-            display: block !important; max-height: none !important; overflow: visible !important;
+          /* Zone de contenu qui doit scroller */
+          .pc-psy-content{
+            flex: 1 1 auto;
+            overflow-y: auto;
+            -webkit-overflow-scrolling: touch;  /* inertie iOS */
+          }
+          .pc-psy-content p, .pc-psy-content .text, .pc-psy-content [class*="desc"]{
+            white-space: normal;
+            word-break: break-word;
+            overflow-wrap: anywhere;
+            /* lève toute tentative de line-clamp / masquage */
+            -webkit-line-clamp: unset !important;
+            -webkit-box-orient: unset !important;
+            display: block !important;
+            max-height: none !important;
+            overflow: visible !important;
+            mask-image: none !important;
+            -webkit-mask-image: none !important;
+          }
+          /* Si un dégradé/fade masque le bas du texte sur mobile */
+          .pc-psy-content .fade,
+          .pc-psy-content::after,
+          .pc-psy-content .fade-mask{
+            display: none !important;
+            mask-image: none !important;
+            -webkit-mask-image: none !important;
           }
         }
     </style>
@@ -5420,26 +5444,67 @@ function displayResults(results) {
 </script>
 <script>
 (function fixPsychoBotCut(){
-  const findNode = () => [...document.querySelectorAll('div,section,article')]
-    .find(el => /Psycho'?Bot/i.test(el.textContent));
-  function apply(el){
-    const dialog = el.closest('[role="dialog"], .modal, .dialog, .sheet, .drawer, .card') || el;
-    const content = dialog.querySelector('.content, .body, .scroll, [class*="content"], [class*="body"]') || dialog;
+  // Localisation robuste du bloc Psycho'Bot (titre ou libellé contenant Psycho'Bot)
+  function findPsyBlock(root = document){
+    return [...root.querySelectorAll('section, article, div')]
+      .find(el => /Psycho'?Bot/i.test(el.textContent));
+  }
+
+  function applyFix(target){
+    if(!target) return;
+    // Conteneur dialog/carte autour du bloc
+    const dialog = target.closest('[role="dialog"], .modal, .dialog, .sheet, .drawer, .card, section, article') || target;
+    // Zone de contenu (scroll)
+    const content = dialog.querySelector('.content, .body, .scroll, [class*="content"], [class*="body"]') || target;
+
+    // Ajouter les classes utilitaires (CSS ci-dessus)
     dialog.classList.add('pc-psy-dialog');
     content.classList.add('pc-psy-content');
-    [content, dialog].forEach(n=>{
-      ['maxHeight','height'].forEach(p=> n.style[p] = n.style[p] && '');
+
+    // Nettoyage des styles inline qui brident le texte
+    // (max-height/height/overflow/line-clamp/masques)
+    [dialog, content].forEach(n=>{
+      ['maxHeight','height'].forEach(p => { try{ n.style[p] = ''; }catch{} });
     });
-    content.querySelectorAll('p, .text, [class*="desc"]').forEach(p=>{
-      p.style.removeProperty('-webkit-line-clamp');
-      p.style.removeProperty('max-height');
-      p.style.removeProperty('overflow');
-      p.style.removeProperty('display');
+    content.querySelectorAll('p, .text, [class*="desc"]').forEach(n=>{
+      n.style.removeProperty('-webkit-line-clamp');
+      n.style.removeProperty('max-height');
+      n.style.removeProperty('overflow');
+      n.style.removeProperty('display');         // enlève -webkit-box
+      n.style.removeProperty('mask-image');
+      n.style.removeProperty('-webkit-mask-image');
+    });
+
+    // Si un gradient de fade existe, on le neutralise (classes/pseudos fréquents)
+    content.querySelectorAll('.fade, .fade-mask').forEach(el=>{
+      el.style.display = 'none';
     });
   }
-  const t = findNode(); if(t) apply(t);
-  const mo = new MutationObserver(()=>{ const x = findNode(); if(x) apply(x); });
-  mo.observe(document.body, { childList:true, subtree:true });
+
+  // 1) Au chargement
+  const first = findPsyBlock();
+  if(first) applyFix(first);
+
+  // 2) À l’injection/maj dynamique (SPA, API async)
+  const mo = new MutationObserver((muts)=>{
+    for(const m of muts){
+      if(m.addedNodes){
+        m.addedNodes.forEach(node=>{
+          if(!(node instanceof Element)) return;
+          const hit = findPsyBlock(node) || ( /Psycho'?Bot/i.test(node.textContent||'') ? node : null );
+          if(hit) applyFix(hit);
+        });
+      }
+    }
+  });
+  mo.observe(document.body, { childList: true, subtree: true });
+
+  // 3) Sur redimensionnement mobile (claviers / barre URL)
+  let resizeTimer=null;
+  window.addEventListener('resize', ()=>{
+    clearTimeout(resizeTimer);
+    resizeTimer = setTimeout(()=>{ const again = findPsyBlock(); if(again) applyFix(again); }, 120);
+  }, { passive:true });
 })();
 </script>
 </body>


### PR DESCRIPTION
## Summary
- make Psycho'Bot dialog flex-based on small screens to allow inner scroll
- add idempotent script to apply mobile scrolling fix and remove truncation styles

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68969a2b03908321b0a31d9105e35bd7