### PR TITLE
feat: add legacy Psycho'Bot code

### DIFF
--- a/psycho-bot-legacy/profil-chatbot.css
+++ b/psycho-bot-legacy/profil-chatbot.css
@@ -1,0 +1,72 @@
+#chat-window {
+  display: flex;
+  flex-direction: column;
+}
+
+.chat-row {
+  display: flex;
+  margin-bottom: 0.75rem;
+}
+
+.chat-row.user {
+  justify-content: flex-end;
+}
+
+.chat-row.assistant {
+  justify-content: flex-start;
+}
+
+.user-bubble,
+.assistant-bubble {
+  max-width: 75%;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.5rem;
+  line-height: 1.4;
+}
+
+.user-bubble {
+  background: #3b82f6;
+  color: #fff;
+}
+
+.assistant-bubble {
+  background: #e5e7eb;
+  color: #1f2937;
+}
+
+.question-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.suggestion-bubble {
+  background: #f3f4f6;
+  color: #1f2937;
+  padding: 0.5rem 0.75rem;
+  border-radius: 9999px;
+  font-size: 0.875rem;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.suggestion-bubble:hover {
+  background: #e5e7eb;
+}
+
+.limit-error {
+  animation: shake 0.4s;
+  background: #fee2e2;
+  color: #991b1b;
+}
+
+@keyframes shake {
+  0%,100% { transform: translateX(0); }
+  25% { transform: translateX(-3px); }
+  75% { transform: translateX(3px); }
+}
+
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}

--- a/psycho-bot-legacy/profil-chatbot.html
+++ b/psycho-bot-legacy/profil-chatbot.html
@@ -1,0 +1,21 @@
+<section id="profil-chatbot" class="py-12 px-4">
+  <div class="max-w-3xl mx-auto text-center">
+    <h2 class="text-3xl font-bold">Parler à Psycho'Bot</h2>
+    <p class="mt-2 text-gray-600">Pose-lui une question sur la personnalité et il te répondra.</p>
+  </div>
+  <div id="chat-window" class="mt-8 bg-white rounded-lg shadow flex flex-col">
+    <div id="chat-box" class="flex-1 p-4 overflow-y-auto space-y-4"></div>
+    <div id="chat-suggestions" class="question-buttons p-4 flex flex-wrap gap-2">
+      <button class="suggestion-bubble" data-question="Qui es-tu ?">Qui es-tu ?</button>
+      <button class="suggestion-bubble" data-question="Comment fonctionne ce test ?">Comment fonctionne ce test ?</button>
+      <button class="suggestion-bubble" data-question="Puis-je refaire le test ?">Puis-je refaire le test ?</button>
+    </div>
+    <div class="p-4 flex items-center gap-2 border-t">
+      <input id="chat-input" type="text" class="flex-1 px-4 py-2 border rounded" placeholder="Écris ton message..." />
+      <button id="chat-send" class="px-4 py-2 bg-blue-600 text-white rounded">Envoyer</button>
+    </div>
+  </div>
+</section>
+
+<script src="https://cdn.jsdelivr.net/npm/typed.js@2.0.12"></script>
+<script src="profil-chatbot.js"></script>

--- a/psycho-bot-legacy/profil-chatbot.js
+++ b/psycho-bot-legacy/profil-chatbot.js
@@ -1,0 +1,87 @@
+const LIMIT_MESSAGE = "Tu as atteint la limite quotidienne. Reviens demain.";
+
+async function sendChatMessage(message) {
+  try {
+    const res = await fetch('/api/chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model: 'gpt-5-mini', message })
+    });
+    if (res.status === 429) {
+      return { message: LIMIT_MESSAGE, limitError: true };
+    }
+    const data = await res.json();
+    return { message: data.message };
+  } catch (e) {
+    return { message: "Désolé, une erreur est survenue." };
+  }
+}
+
+function isNearBottom(el) {
+  return el.scrollHeight - el.scrollTop - el.clientHeight < 50;
+}
+
+function safeScrollToBottom(el) {
+  if (isNearBottom(el)) {
+    el.scrollTo({ top: el.scrollHeight, behavior: 'smooth' });
+  }
+}
+
+function appendMessage(role, text, { limitError = false } = {}) {
+  const row = document.createElement('div');
+  row.className = `chat-row ${role}`;
+
+  const bubble = document.createElement('div');
+  bubble.className = role === 'assistant' ? 'assistant-bubble' : 'user-bubble';
+  if (limitError) bubble.classList.add('limit-error');
+  bubble.dataset.fullText = text;
+  row.appendChild(bubble);
+
+  const chatBox = document.getElementById('chat-box');
+  chatBox.appendChild(row);
+  safeScrollToBottom(chatBox);
+
+  if (role === 'assistant') {
+    const scrollInterval = setInterval(() => safeScrollToBottom(chatBox), 50);
+    new Typed(bubble, {
+      strings: [text],
+      typeSpeed: 20,
+      onComplete: () => clearInterval(scrollInterval)
+    });
+  } else {
+    bubble.textContent = text;
+    safeScrollToBottom(chatBox);
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const chatInput = document.getElementById('chat-input');
+  const chatSend = document.getElementById('chat-send');
+
+  function removeSuggestions() {
+    const sug = document.getElementById('chat-suggestions');
+    if (sug) sug.remove();
+  }
+
+  async function handleSend(message) {
+    if (!message.trim()) return;
+    appendMessage('user', message);
+    removeSuggestions();
+    chatInput.value = '';
+    const { message: reply, limitError } = await sendChatMessage(message);
+    appendMessage('assistant', reply, { limitError });
+  }
+
+  chatSend.addEventListener('click', () => handleSend(chatInput.value));
+
+  chatInput.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      handleSend(chatInput.value);
+    }
+  });
+
+  document.querySelectorAll('.suggestion-bubble').forEach(btn => {
+    btn.addEventListener('click', () => handleSend(btn.dataset.question));
+  });
+});


### PR DESCRIPTION
## Summary
- add archived Psycho'Bot chat section HTML
- include original styles for chat bubbles and suggestions
- restore chat logic with typed.js and rate-limit handling

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896ad5a384c83218197c48b15037034