### PR TITLE
Fix incomplete AI description on results page

### DIFF
--- a/api/psy-results.js
+++ b/api/psy-results.js
@@ -10,92 +10,63 @@ module.exports = async function handler(req, res) {
 
   try {
     const { messages = [], max_tokens } = req.body || {};
-    const payload = {
-      model: 'gpt-4o-mini',
-      stream: true,
-      max_tokens: Math.max(800, max_tokens || 900),
-      messages,
-    };
+    const maxTokens = max_tokens !== undefined ? max_tokens : 1600;
 
-    const response = await fetch('https://api.openai.com/v1/chat/completions', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${OPENAI_API_KEY}`,
-      },
-      body: JSON.stringify(payload),
-    });
+    let fullContent = '';
+    let finish_reason = null;
+    let currentMessages = [...messages];
 
-    if (!response.ok) {
-      const errorText = await response.text().catch(() => '');
-      console.error('Erreur API OpenAI:', errorText);
-      return res.status(500).json({ error: "Erreur de l'API OpenAI", details: errorText });
-    }
+    for (let i = 0; i < 5; i++) {
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), 60000);
 
-    res.writeHead(200, {
-      // on envoie du texte simple en flux (ton front concatène)
-      'Content-Type': 'text/plain; charset=utf-8',
-      'Transfer-Encoding': 'chunked',
-      'Cache-Control': 'no-cache',
-      'Connection': 'keep-alive',
-    });
+      const payload = {
+        model: 'gpt-4o-mini',
+        max_tokens: maxTokens,
+        messages: currentMessages,
+      };
 
-    const decoder = new TextDecoder('utf-8');
-    let buffer = '';
+      const response = await fetch('https://api.openai.com/v1/chat/completions', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${OPENAI_API_KEY}`,
+        },
+        body: JSON.stringify(payload),
+        signal: controller.signal,
+      }).finally(() => clearTimeout(timeout));
 
-    // lecture du flux OpenAI (SSE "data: ...")
-    for await (const chunk of response.body) {
-      buffer += decoder.decode(chunk, { stream: true });
-
-      let lines = buffer.split('\n');
-      buffer = lines.pop(); // on garde la dernière ligne potentiellement incomplète
-
-      for (const line of lines) {
-        if (!line.startsWith('data: ')) continue;
-        const data = line.slice(6);
-        if (data === '[DONE]') {
-          // flush final du decoder au cas où
-          const tail = decoder.decode();
-          if (tail) res.write(tail);
-          return res.end();
-        }
-        try {
-          const json = JSON.parse(data);
-          const text = json.choices?.[0]?.delta?.content || '';
-          if (text) res.write(text);
-        } catch {
-          // ignore
-        }
+      if (!response.ok) {
+        const errorText = await response.text().catch(() => '');
+        console.error('Erreur API OpenAI:', errorText);
+        return res
+          .status(500)
+          .json({ error: "Erreur de l'API OpenAI", details: errorText });
       }
-    }
 
-    // >>>> ICI: TRAITER LE RESTE (bug fixé)
-    // flush final du decoder et traitement du buffer résiduel
-    const tailFlush = decoder.decode(); // vide le decoder
-    if (tailFlush) buffer += tailFlush;
+      const data = await response.json();
+      const choice = data.choices?.[0];
+      const content = choice?.message?.content || '';
+      finish_reason = choice?.finish_reason;
+      fullContent += content;
 
-    if (buffer) {
-      const lines = buffer.split('\n');
-      for (const line of lines) {
-        if (!line.startsWith('data: ')) continue;
-        const data = line.slice(6);
-        if (data && data !== '[DONE]') {
-          try {
-            const json = JSON.parse(data);
-            const text = json.choices?.[0]?.delta?.content || '';
-            if (text) res.write(text);
-          } catch { /* ignore */ }
-        }
+      if (finish_reason !== 'length' && finish_reason !== 'incomplete') {
+        break;
       }
+
+      currentMessages = [
+        ...currentMessages,
+        { role: 'assistant', content },
+        { role: 'user', content: 'continue' },
+      ];
     }
 
-    res.end();
+    res.status(200).json({ content: fullContent, finish_reason });
   } catch (error) {
     console.error('Erreur API OpenAI:', error);
-    // si on avait commencé à écrire, on termine proprement
-    try { res.end(); } catch {}
     if (!res.headersSent) {
       res.status(500).json({ error: error.message || 'Erreur serveur' });
     }
   }
 };
+

--- a/index.html
+++ b/index.html
@@ -4612,7 +4612,7 @@ function displayResults(results) {
 
         <div id="ai-profile-summary" class="mt-6 bg-gray-50 rounded-lg p-5 shadow-sm mb-6">
             <h4 class="font-semibold text-gray-900 text-lg mb-3">Description succincte du profil par Psycho'Bot</h4>
-            <div id="ai-summary-content" class="text-sm leading-relaxed text-gray-700">Génération en cours…</div>
+            <div id="ai-summary-content" class="text-sm leading-relaxed text-gray-700 max-h-80 overflow-y-auto">Génération en cours…</div>
         </div>
 
                             <!-- Détail des évaluations -->
@@ -4832,36 +4832,49 @@ function displayResults(results) {
             console.info('[AI Summary]', 'cache miss', cacheKey);
             container.setAttribute('data-loading', '1');
 
-            try {
-                const response = await fetch('/api/chat', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({
-                        model: 'gpt-5-mini',
-                        temperature: 0.5,
-                        max_tokens: 120,
-                        messages: [
-                            { role: 'system', content: 'Tu es un psychologue pédagogique. Écris en français, clair et nuancé, sans jargon.' },
-                            { role: 'user', content: `Profil combiné : MBTI=${mbti}, Ennéagramme=${enneagram}.\nRédige une description concise (max 150 mots) :\n1) forces principales, 2) point faible récurrent, 3) piste d’amélioration.\nLangage clair, ton positif, phrases courtes.` }
-                        ]
-                    })
-                });
+            let messages = [
+                { role: 'system', content: 'Tu es un psychologue pédagogique. Écris en français, clair et nuancé, sans jargon.' },
+                { role: 'user', content: `Profil combiné : MBTI=${mbti}, Ennéagramme=${enneagram}.\nRédige une description concise (max 150 mots) :\n1) forces principales, 2) point faible récurrent, 3) piste d’amélioration.\nLangage clair, ton positif, phrases courtes.` }
+            ];
 
-                if (!response.ok) throw new Error('bad response');
-                const data = await response.json();
-                const message = data.message?.trim();
-                if (message) {
-                    container.textContent = message;
-                    localStorage.setItem(cacheKey, message);
-                } else {
-                    container.textContent = "Description indisponible pour le moment.";
+            let totalText = '';
+            let attempts = 0;
+
+            while (true) {
+                try {
+                    const response = await fetch('/api/psy-results', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ messages })
+                    });
+
+                    if (!response.ok) throw new Error('bad response');
+                    const data = await response.json();
+                    totalText += data.content || '';
+
+                    if (data.finish_reason && data.finish_reason !== 'stop') {
+                        messages.push({ role: 'assistant', content: data.content || '' });
+                        messages.push({ role: 'user', content: 'continue' });
+                        continue;
+                    }
+
+                    const finalText = totalText.trim();
+                    container.textContent = finalText || "Description indisponible pour le moment.";
+                    if (finalText) localStorage.setItem(cacheKey, finalText);
+                    break;
+                } catch (e) {
+                    console.error('Erreur IA:', e);
+                    attempts++;
+                    if (attempts < 2) {
+                        container.textContent = "Échec de la génération, nouvelle tentative…";
+                        continue;
+                    }
+                    container.textContent = "Impossible de terminer la description";
+                    break;
                 }
-            } catch (e) {
-                console.error('Erreur IA:', e);
-                container.textContent = "Erreur lors de la génération de la description.";
-            } finally {
-                container.removeAttribute('data-loading');
             }
+
+            container.removeAttribute('data-loading');
         }
 
         function closeResultsModal() {


### PR DESCRIPTION
## Summary
- ensure `/api/psy-results` retrieves full completion with retry when truncated and default to 1600 max tokens
- read final description on results modal with automatic continuation and better error handling
- allow result description container to scroll for long texts

## Testing
- `node -e "require('./api/psy-results.js'); console.log('loaded psy');"`
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896fe8af3dc8321a1d9fec886ee7a8a