### PR TITLE
feat: add retry logic to evaluation submission

### DIFF
--- a/index.html
+++ b/index.html
@@ -4166,27 +4166,32 @@ function displayResults(results) {
             const btn = document.getElementById('submit-eval');
             if (!form || !btn) return;
 
+            const statusEl = document.createElement('span');
+            statusEl.className = 'sr-only';
+            statusEl.setAttribute('aria-live', 'polite');
+            btn.after(statusEl);
+
             function setLoadingState() {
                 btn.disabled = true;
                 btn.classList.remove('bg-green-500', 'bg-red-500');
-                btn.removeAttribute('aria-live');
                 btn.innerHTML = '<span class="spinner"></span> Veuillez patienter, nous enregistrons vos réponses...';
+                statusEl.textContent = 'Enregistrement en cours...';
             }
 
             function setSuccessState() {
                 btn.disabled = true;
                 btn.classList.remove('bg-red-500', 'bg-green-600', 'hover:bg-green-700');
                 btn.classList.add('bg-green-500', 'text-white');
-                btn.removeAttribute('aria-live');
                 btn.innerHTML = 'Succès ✅';
+                statusEl.textContent = 'Enregistrement réussi';
             }
 
-            function setErrorState() {
-                btn.disabled = true;
+            function setRetryState() {
+                btn.disabled = false;
                 btn.classList.remove('bg-green-500', 'bg-green-600', 'hover:bg-green-700');
                 btn.classList.add('bg-red-500', 'text-white');
-                btn.innerHTML = 'Erreur ❌';
-                btn.setAttribute('aria-live', 'polite');
+                btn.innerHTML = 'Réessayer';
+                statusEl.textContent = 'Échec, réessayez';
             }
 
             form.addEventListener('submit', async function(e) {
@@ -4216,7 +4221,7 @@ function displayResults(results) {
                         console.error(err);
                         alert('Une erreur est survenue lors de l\'enregistrement.');
                     }
-                    setErrorState();
+                    setRetryState();
                 } finally {
                     clearTimeout(timeoutId);
                 }


### PR DESCRIPTION
## Summary
- add retry state to evaluation submission button
- announce loading, error, and success via aria-live status element
- ensure repeated attempts reuse original data and prevent double submissions

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897f17fbe3483219bd787a6a9711db7