### PR TITLE
Ensure header sticks only on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -184,7 +184,11 @@
         }
         #site-header {
             position: static;
-            height: 64px;
+            height: auto;
+        }
+
+        body {
+            padding-top: 0;
         }
 
         .mobile-menu {
@@ -207,17 +211,16 @@
                 left: 0;
                 right: 0;
                 z-index: 1000;
-                background: #fff;
+                background: inherit;
                 box-shadow: 0 2px 10px rgba(0,0,0,0.06);
-                backdrop-filter: saturate(180%) blur(8px);
                 height: 56px;
             }
             body {
                 padding-top: 56px;
             }
-            .section,
-            #profil-chatbot {
-                scroll-margin-top: 72px;
+            [id],
+            .section {
+                scroll-margin-top: 64px;
             }
         }
 


### PR DESCRIPTION
## Summary
- Prevent header from being sticky on desktop by resetting `#site-header` to `position: static` and removing body padding.
- Add a mobile-only rule that fixes the header at the top with matching body padding and scroll margin for anchored sections.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897f9b0ae288321afceb98bbde956a1