### PR TITLE
feat: add banner depth parallax effect

### DIFF
--- a/index.html
+++ b/index.html
@@ -338,6 +338,33 @@
         /* le conteneur de la bannière doit déjà être positionné ; sinon: */
         .pc-hero { position: relative; isolation: isolate; }
 
+        /* Banner depth effect */
+        .banner {
+          position: relative;
+          overflow: hidden;
+        }
+        .banner::before {
+          content: "";
+          position: absolute;
+          inset: 0;
+          background: inherit;
+          background-size: cover;
+          background-position: center;
+          filter: blur(4px) brightness(0.9);
+          transform: translateY(var(--parallax-offset, 0));
+          transition: transform 0.2s ease-out;
+          z-index: 0;
+        }
+        .banner-content {
+          position: relative;
+          z-index: 1;
+          text-shadow: 0 4px 10px rgba(0,0,0,0.3);
+        }
+        .banner-content a,
+        .banner-content button {
+          box-shadow: 0 4px 15px rgba(0,0,0,0.25);
+        }
+
         #pc-constellation{
           position: absolute; inset: 0; width: 100%; height: 100%;
           pointer-events: none; z-index: 0; /* contenu texte reste au-dessus */
@@ -423,7 +450,7 @@
 
 
     <!-- Hero Section Premium -->
-    <div data-aos="fade-up" class="section section-clair relative flex items-center justify-center overflow-hidden pc-hero" data-hero style="min-height: 80vh;">
+    <div data-aos="fade-up" class="section section-clair relative flex items-center justify-center overflow-hidden pc-hero banner" data-hero style="min-height: 80vh;">
         <canvas id="pc-constellation" aria-hidden="true"></canvas>
         <!-- Grille subtile en arrière-plan -->
         <div class="absolute inset-0 opacity-[0.02]">
@@ -435,7 +462,7 @@
         <div class="absolute bottom-1/3 left-1/5 w-1 h-1 bg-slate-400/30 rounded-full"></div>
         <div class="absolute top-2/3 right-1/3 w-1.5 h-1.5 bg-blue-300/25 rounded-full"></div>
         
-        <div class="relative max-w-5xl mx-auto px-6 py-16 text-center">
+        <div class="relative max-w-5xl mx-auto px-6 py-16 text-center banner-content">
 <img src="nouveau logo.JPEG" alt="Nouveau logo" class="mx-auto mb-8 w-28 sm:w-32 h-auto">
             
             <!-- Titre principal avec hiérarchie claire -->
@@ -5615,6 +5642,15 @@ function displayResults(results) {
   }
   frame();
 })();
+</script>
+<script>
+  window.addEventListener('scroll', () => {
+    const banner = document.querySelector('.banner');
+    const scrollY = window.scrollY;
+    if (banner) {
+      banner.style.setProperty('--parallax-offset', `${scrollY * 0.3}px`);
+    }
+  });
 </script>
 <style>
   /* Arrondis forcés pour la fenêtre de chat et la zone de saisie */


### PR DESCRIPTION
## Summary
- blur and darken banner background and add parallax scroll
- highlight banner text and buttons with soft shadows

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689882bc480c8321a1632c90ad5da7b3