### PR TITLE
Fix footer IA link

### DIFF
--- a/index.html
+++ b/index.html
@@ -1568,7 +1568,7 @@ Oui. Vous pouvez interroger Psycho’Bot dans la section "Parler avec Psycho’B
                         <li><a href="#" class="text-base text-gray-300 hover:text-white transition-colors">Accueil</a></li>
                         <li><a href="#mbti" class="text-base text-gray-300 hover:text-white transition-colors">MBTI</a></li>
                         <li><a href="#enneagram" class="text-base text-gray-300 hover:text-white transition-colors">Ennéagramme</a></li>
-                       <li><a href="#IA spécialisée" class="text-base text-gray-300 hover:text-white transition-colors">IA spécialisée</a></li>
+                       <li><a href="#profil-chatbot" class="text-base text-gray-300 hover:text-white transition-colors">IA spécialisée</a></li>
                         <li><a href="#faq" class="text-base text-gray-300 hover:text-white transition-colors">FAQ</a></li>
 
                     </ul>


### PR DESCRIPTION
## Summary
- Make the "IA spécialisée" footer link scroll to the Psycho'Bot section

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68989fbd3360832199c9a2304fb25631