### PR TITLE
Fix footer navigation links

### DIFF
--- a/index.html
+++ b/index.html
@@ -382,7 +382,7 @@
     </style>
 
 </head>
-<body class="font-sans bg-white text-gray-900">
+<body id="top" class="font-sans bg-white text-gray-900">
     <!-- Navigation -->
     <header id="site-header" class="sticky-header">
         <div class="flex items-center">
@@ -1565,7 +1565,7 @@ Oui. Vous pouvez interroger Psycho’Bot dans la section "Parler avec Psycho’B
                 <div>
                     <h3 class="text-sm font-semibold text-gray-400 tracking-wider uppercase">Personnalité Comparée</h3>
                     <ul class="mt-4 space-y-4">
-                        <li><a href="#" class="text-base text-gray-300 hover:text-white transition-colors">Accueil</a></li>
+                        <li><a href="#top" class="text-base text-gray-300 hover:text-white transition-colors">Accueil</a></li>
                         <li><a href="#mbti" class="text-base text-gray-300 hover:text-white transition-colors">MBTI</a></li>
                         <li><a href="#enneagram" class="text-base text-gray-300 hover:text-white transition-colors">Ennéagramme</a></li>
                        <li><a href="#profil-chatbot" class="text-base text-gray-300 hover:text-white transition-colors">IA spécialisée</a></li>
@@ -1578,8 +1578,7 @@ Oui. Vous pouvez interroger Psycho’Bot dans la section "Parler avec Psycho’B
                     <ul class="mt-4 space-y-4">
                         <li><a href="#auto-evaluation" class="text-base text-gray-300 hover:text-white transition-colors">Auto-évaluation</a></li>
                         <li><a href="#evaluation-proche" class="text-base text-gray-300 hover:text-white transition-colors">Évaluer un proche</a></li>
-                        <li><a href="#" class="text-base text-gray-300 hover:text-white transition-colors">Mon profil</a></li>
-                        <li><a href="#" class="text-base text-gray-300 hover:text-white transition-colors">Mes résultats</a></li>
+                        <li><a href="#retourver-profil" class="text-base text-gray-300 hover:text-white transition-colors">Mon profil</a></li>
                     </ul>
                 </div>
                 <div>


### PR DESCRIPTION
## Summary
- Scroll to top via functional footer "Accueil" link and top anchor.
- Simplify footer test section: remove "Mes résultats" and point "Mon profil" to profile retrieval.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898a24362188321a8dfbb44e4be1307