### PR TITLE
Rendre l'adresse e-mail de support cliquable

### DIFF
--- a/index.html
+++ b/index.html
@@ -3797,7 +3797,7 @@ function showPrivacyPolicy() {
                     
                     <div class="bg-blue-50 p-4 rounded-lg">
                         <h4 class="font-semibold text-blue-900">Email</h4>
-                        <p class="text-blue-700">contact@personnalitecomparee.com</p>
+                        <p class="text-blue-700"><a href="mailto:contact@personnalitecomparee.com?subject=Support%20Personnalit%C3%A9%20Compar%C3%A9e" class="text-blue-700 hover:underline">contact@personnalitecomparee.com</a></p>
                     </div>
                     
                     <div class="bg-blue-50 p-4 rounded-lg">


### PR DESCRIPTION
## Summary
- Rendre l'adresse de support cliquable avec un lien mailto et objet prérempli

## Testing
- `npm test` *(échoue: package.json manquant)*

------
https://chatgpt.com/codex/tasks/task_e_6898bb5384a48321bd184be25f587bd8