### PR TITLE
Remove duplicate social icons from footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -1611,22 +1611,8 @@ Oui. Vous pouvez interroger Psycho’Bot dans la section "Parler avec Psycho’B
                     </ul>
                 </div>
             </div>
-            <div class="mt-8 border-t border-gray-700 pt-8 md:flex md:items-center md:justify-between">
-                <div class="flex space-x-6 md:order-2">
-                    <a href="#" class="text-gray-400 hover:text-white transition-colors">
-                        <span class="sr-only">Facebook</span>
-                        <i class="fab fa-facebook-f"></i>
-                    </a>
-                    <a href="#" class="text-gray-400 hover:text-white transition-colors">
-                        <span class="sr-only">Instagram</span>
-                        <i class="fab fa-instagram"></i>
-                    </a>
-                    <a href="#" class="text-gray-400 hover:text-white transition-colors">
-                        <span class="sr-only">TikTok</span>
-                        <i class="fab fa-tiktok"></i>
-                    </a>
-                </div>
-                <p class="mt-8 text-base text-gray-400 md:mt-0 md:order-1">
+            <div class="mt-8 border-t border-gray-700 pt-8">
+                <p class="text-base text-gray-400 text-center">
                     &copy; 2025 Personnalité Comparée. Tous droits réservés.
                 </p>
             </div>


### PR DESCRIPTION
## Summary
- remove redundant social icons group from footer leaving only contact column icons

## Testing
- `npm test` (fails: missing package.json)


------
https://chatgpt.com/codex/tasks/task_e_6898c30e632c832189e0b572d1b47cd9