### PR TITLE
Improve analytics tracking and admin dashboard

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -205,109 +205,107 @@
 
     // ====== Fetch (inclut un panneau "Sessions récentes") ======
     async function fetchRecentSessions() {
-      // On essaie avec ip ; si erreur (colonne absente), on retombe sans ip
-      let recent = [];
-      let q = await supabase
-        .from('sessions')
-        .select('session_id,country,city,device_type,last_activity_at,ip')
-        .order('last_activity_at', { ascending: false })
-        .limit(20);
-      if (q.error) {
-        const q2 = await supabase
+      try {
+        const q = await supabase
           .from('sessions')
-          .select('session_id,country,city,device_type,last_activity_at')
+          .select('session_id,country,city,device_type,last_activity_at,ip')
           .order('last_activity_at', { ascending: false })
           .limit(20);
-        if (!q2.error) recent = q2.data || [];
-      } else {
-        recent = q.data || [];
+        if (q.error) {
+          console.warn('recent sessions with ip failed', q.error);
+          const q2 = await supabase
+            .from('sessions')
+            .select('session_id,country,city,device_type,last_activity_at')
+            .order('last_activity_at', { ascending: false })
+            .limit(20);
+          if (!q2.error) return q2.data || [];
+          console.error('recent sessions fallback error', q2.error);
+          return [];
+        }
+        return q.data || [];
+      } catch (err) {
+        console.error('recent sessions exception', err);
+        return [];
       }
-      return recent;
     }
 
     async function fetchStats() {
-      const queries = [
-        supabase.from('stats_sessions_par_jour').select('jour,sessions').order('jour', { ascending: true }),
-        supabase.from('stats_events_par_jour').select('jour,events').order('jour', { ascending: true }),
-        supabase.from('stats_device_type').select('device_type,sessions'),
-        supabase.from('stats_pays').select('country,sessions'),
-        supabase.from('stats_top_pages').select('page_url,vues'),
-        supabase.from('stats_pages_entree').select('first_page_url,nb'),
-        supabase.from('stats_pages_sortie').select('last_page_url,nb'),
-        supabase.from('stats_nouveaux_vs_revenants').select('is_returning,sessions'),
-        supabase.from('stats_categories_events').select('category,nb'),
-        supabase.from('stats_elements_cliques').select('element_selector,clics'),
-        supabase.from('stats_engagement_moyen').select('engagement_sec'),
-        supabase.from('stats_daily_global').select('jour,sessions_uniques,total_events').order('jour',{ascending:true})
-      ];
+      const result = {
+        sessionsParJour: [],
+        eventsParJour: [],
+        deviceTypes: [],
+        countries: [],
+        topPages: [],
+        entryPages: [],
+        exitPages: [],
+        newVsReturning: [],
+        categories: [],
+        clicks: [],
+        avgEngagement: [],
+        dailyGlobal: [],
+        recentSessions: []
+      };
 
-      const [
-        { data: sessionsParJour, error: e1 },
-        { data: eventsParJour, error: e2 },
-        { data: deviceTypes, error: e3 },
-        { data: countries, error: e4 },
-        { data: topPages, error: e5 },
-        { data: entryPages, error: e6 },
-        { data: exitPages, error: e7 },
-        { data: newVsReturning, error: e8 },
-        { data: categories, error: e9 },
-        { data: clicks, error: e10 },
-        { data: avgEngagement, error: e11 },
-        { data: dailyGlobal, error: e12 },
-      ] = await Promise.all(queries);
+      try {
+        const queries = [
+          supabase.from('stats_sessions_par_jour').select('jour,sessions').order('jour', { ascending: true }),
+          supabase.from('stats_events_par_jour').select('jour,events').order('jour', { ascending: true }),
+          supabase.from('stats_device_type').select('device_type,sessions'),
+          supabase.from('stats_pays').select('country,sessions'),
+          supabase.from('stats_top_pages').select('page_url,vues'),
+          supabase.from('stats_pages_entree').select('first_page_url,nb'),
+          supabase.from('stats_pages_sortie').select('last_page_url,nb'),
+          supabase.from('stats_nouveaux_vs_revenants').select('is_returning,sessions'),
+          supabase.from('stats_categories_events').select('category,nb'),
+          supabase.from('stats_elements_cliques').select('element_selector,clics'),
+          supabase.from('stats_engagement_moyen').select('engagement_sec'),
+          supabase.from('stats_daily_global').select('jour,sessions_uniques,total_events').order('jour',{ascending:true})
+        ];
 
-// après le Promise.all(...)
-let countriesFixed = countries || [];
-if (!countriesFixed?.length) {
-  // fallback: on agrège depuis public.sessions
-  const { data: sess } = await supabase
-    .from('sessions')
-    .select('country')
-    .not('country', 'is', null);
+        const res = await Promise.allSettled(queries);
+        result.sessionsParJour = res[0].value?.data ?? [];
+        result.eventsParJour = res[1].value?.data ?? [];
+        result.deviceTypes = res[2].value?.data ?? [];
+        let countries = res[3].value?.data ?? [];
+        result.topPages = res[4].value?.data ?? [];
+        result.entryPages = res[5].value?.data ?? [];
+        result.exitPages = res[6].value?.data ?? [];
+        result.newVsReturning = res[7].value?.data ?? [];
+        result.categories = res[8].value?.data ?? [];
+        result.clicks = res[9].value?.data ?? [];
+        result.avgEngagement = res[10].value?.data ?? [];
+        result.dailyGlobal = res[11].value?.data ?? [];
 
-  const map = {};
-  (sess || []).forEach(r => {
-    const c = r.country || 'Inconnu';
-    map[c] = (map[c] || 0) + 1;
-  });
-  countriesFixed = Object.entries(map)
-    .map(([country, sessions]) => ({ country, sessions }))
-    .sort((a,b) => b.sessions - a.sessions)
-    .slice(0, 20);
-}
-// Correction des valeurs NULL ou vides pour les pays
-const countriesFixed = (countries || []).map(c => ({
-  ...c,
-  country: c.country || 'Inconnu'
-}));
+        if (!countries.length) {
+          const { data: sess, error } = await supabase
+            .from('sessions')
+            .select('country')
+            .not('country', 'is', null);
+          if (!error && sess) {
+            const map = {};
+            (sess || []).forEach(r => {
+              const c = r.country || 'Inconnu';
+              map[c] = (map[c] || 0) + 1;
+            });
+            countries = Object.entries(map)
+              .map(([country, sessions]) => ({ country, sessions }))
+              .sort((a, b) => b.sessions - a.sessions)
+              .slice(0, 20);
+          }
+        }
+        result.countries = (countries || []).map(c => ({ ...c, country: c.country || 'Inconnu' }));
+      } catch (err) {
+        console.error('fetchStats error', err);
+      }
 
-// et dans le return de fetchStats, remplace `countries` par `countries: countriesFixed`
-return {
-  sessionsParJour, eventsParJour, deviceTypes, countries: countriesFixed,
-  topPages, entryPages, exitPages, newVsReturning,
-  categories, clicks, avgEngagement, dailyGlobal,
-  recentSessions
-};
+      try {
+        result.recentSessions = await fetchRecentSessions();
+      } catch (err) {
+        console.error('recentSessions fetch error', err);
+      }
 
-// sessions récentes (debug)
-const recentSessions = await fetchRecentSessions();
-
-const errs = [e1, e2, e3, e4, e5, e6, e7, e8, e9, e10, e11, e12].filter(Boolean);
-if (errs.length) {
-  console.error('Erreurs Supabase:', errs);
-  showMessage('error', 'Certaines données n’ont pas pu être chargées. Réessaie plus tard ou clique sur “Actualiser”.');
-} else {
-  document.getElementById('dashboard-messages').innerHTML = '';
-}
-
-return {
-  sessionsParJour, eventsParJour, deviceTypes, countries: countriesFixed,
-  topPages, entryPages, exitPages, newVsReturning,
-  categories, clicks, avgEngagement, dailyGlobal,
-  recentSessions
-};
-
-
+      return result;
+    }
     // ====== KPI ======
     function renderKPIs(stats) {
       const box = document.getElementById('kpi-row');

--- a/public/index.html
+++ b/public/index.html
@@ -5742,10 +5742,7 @@ function generateSessionId() {
 function parseUTM() {
   const params = new URLSearchParams(window.location.search);
   const utm = {};
-  ['utm_source', 'utm_medium', 'utm_campaign', 'utm_term', 'utm_content'].forEach((k) => {
-    const v = params.get(k);
-    if (v) utm[k] = v;
-  });
+  ['utm_source','utm_medium','utm_campaign','utm_term','utm_content'].forEach(k=>{ const v=params.get(k); if(v) utm[k]=v; });
   return Object.keys(utm).length ? utm : null;
 }
 
@@ -5757,109 +5754,104 @@ if (!sessionId) {
   sessionId = generateSessionId();
   localStorage.setItem('session_id', sessionId);
 }
-if (!hasVisited) localStorage.setItem('hasVisited', 'true');
+if (!hasVisited) localStorage.setItem('hasVisited','true');
+
+const firstRefKey = 'pc_first_referrer';
+let firstReferrer = localStorage.getItem(firstRefKey);
+if (!firstReferrer && document.referrer) {
+  firstReferrer = document.referrer;
+  localStorage.setItem(firstRefKey, firstReferrer);
+}
+const firstUtmKey = 'pc_first_utm';
+let firstUtm = null;
+try { firstUtm = JSON.parse(localStorage.getItem(firstUtmKey) || 'null'); } catch {}
+const currentUtm = parseUTM();
+if (!firstUtm && currentUtm) {
+  firstUtm = currentUtm;
+  localStorage.setItem(firstUtmKey, JSON.stringify(firstUtm));
+}
 
 // ====== Contexte navigateur ======
 const deviceType = /Mobi|Android/i.test(navigator.userAgent) ? 'mobile' : 'desktop';
 const viewport = { width: window.innerWidth, height: window.innerHeight };
 const screenSize = { width: screen.width, height: screen.height };
 const tzOffset = new Date().getTimezoneOffset();
-const utmParams = parseUTM();
 
-// ====== Geo (CORS OK) + cache local 10 min ======
+// ====== Geo sans cache ======
 async function getGeoData() {
-  const cacheKey = 'geo_cache_json';
-  const cacheTsKey = 'geo_cache_ts';
-  const now = Date.now();
-  const ts = Number(localStorage.getItem(cacheTsKey) || 0);
-
-  if (now - ts < 10 * 60 * 1000) {
-    try {
-      const cached = JSON.parse(localStorage.getItem(cacheKey) || '{}');
-      if (cached && (cached.country || cached.city)) return cached;
-    } catch (_) {}
-  }
-
   try {
     const res = await fetch('https://get.geojs.io/v1/ip/geo.json', { cache: 'no-store' });
     const data = await res.json();
-    const geo = {
-      country: data.country || data.country_code || null,
-      city: data.city || null,
+    console.log('🌍 Geo brut:', data);
+    return {
+      country: data.country_name || data.country || data.country_code || data.country_code3 || 'Inconnu',
+      city: data.city || data.region || 'Inconnu',
       ip: data.ip || null
     };
-    localStorage.setItem(cacheKey, JSON.stringify(geo));
-    localStorage.setItem(cacheTsKey, String(now));
-    return geo;
-  } catch {
-    return { country: null, city: null, ip: null };
+  } catch (err) {
+    console.error('❌ Geo fetch error:', err);
+    return { country: 'Inconnu', city: 'Inconnu', ip: null };
   }
 }
 
 // ====== Création / MAJ de la session ======
 async function upsertSession(initialEventName = 'page_view') {
-  const geo = await getGeoData();
-  console.log("🌍 Geo brut:", geo);
-
-  const payload = {
-    session_id: sessionId,
-    first_referrer: document.referrer || null,
-    first_utm: utmParams,
-    user_agent: navigator.userAgent,
-    device_type: deviceType,
-    language: navigator.language,
-    tz_offset: tzOffset,
-    viewport,
-    screen: screenSize,
-    is_returning: isReturning,
-    last_page_url: window.location.href,
-    last_event_name: initialEventName,
-    last_activity_at: new Date().toISOString(),
-    country: geo.country_name || geo.country || geo.country_code || geo.country_code3 || null,
-    city: geo.city || geo.region || null,
-    ip: geo.ip || null
-  };
-
-  console.log("➡️ Mappé pour DB:", payload);
-
-  const { data, error } = await supabase
-    .from('sessions')
-    .upsert(payload, { onConflict: ['session_id'] });
-
-  if (error) {
-    console.error('❌ Session upsert error:', error);
-  } else {
-    console.log("✅ Session mise à jour:", data);
+  if (!supabase) return;
+  try {
+    const geo = await getGeoData();
+    const payload = {
+      session_id: sessionId,
+      first_referrer: firstReferrer || null,
+      first_utm: firstUtm,
+      user_agent: navigator.userAgent,
+      device_type: deviceType,
+      language: navigator.language,
+      tz_offset: tzOffset,
+      viewport,
+      screen: screenSize,
+      is_returning: isReturning,
+      last_page_url: location.href,
+      last_event_name: initialEventName,
+      last_activity_at: new Date().toISOString(),
+      country: geo.country,
+      city: geo.city,
+      ip: geo.ip
+    };
+    console.log('➡️ Session upsert payload:', payload);
+    const { error } = await supabase
+      .from('sessions')
+      .upsert(payload, { onConflict: ['session_id'] });
+    if (error) console.error('❌ Session upsert error:', error);
+  } catch (err) {
+    console.error('❌ upsertSession exception:', err);
   }
 }
 
 // ====== Envoi d’événements ======
 async function trackEvent(eventName, meta = {}) {
+  if (!supabase) return;
   try {
     const event_category = eventName.includes('click') ? 'Interaction' : 'Navigation';
-
     const { error: e1 } = await supabase.from('events').insert({
       session_id: sessionId,
       event_name: eventName,
       event_category,
-      page_url: window.location.href,
+      page_url: location.href,
       referrer: document.referrer || null,
-      utm: utmParams,
+      utm: currentUtm,
       user_agent: navigator.userAgent,
       meta,
       element_selector: meta.element || null
     });
     if (e1) console.error('❌ Event insert error:', e1);
-
     const { error: e2 } = await supabase
       .from('sessions')
       .update({
         last_activity_at: new Date().toISOString(),
         last_event_name: eventName,
-        last_page_url: window.location.href
+        last_page_url: location.href
       })
       .eq('session_id', sessionId);
-
     if (e2) console.error('❌ Session update error:', e2);
   } catch (err) {
     console.error('❌ trackEvent exception:', err);
@@ -5873,11 +5865,10 @@ async function trackEvent(eventName, meta = {}) {
 
   document.addEventListener('click', (e) => {
     let selector = '';
-    if (e.target.id) selector = '#'+e.target.id;
+    if (e.target.id) selector = '#' + e.target.id;
     else if (e.target.className) {
-      selector = e.target.tagName.toLowerCase()+'.'+e.target.className.toString().replace(/\s+/g,'.');
+      selector = e.target.tagName.toLowerCase() + '.' + e.target.className.toString().trim().replace(/\s+/g, '.');
     } else selector = e.target.tagName.toLowerCase();
-
     trackEvent('click', { element: selector });
   });
 })();


### PR DESCRIPTION
## Summary
- Rebuild client-side tracking to upsert sessions/events with robust geo, referrer and UTM handling
- Add resilient stats fetching with fallbacks and recent sessions debug panel on admin dashboard

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689c0383ffec83219ceaddb862769584