### PR TITLE
Handle missing analytics context and sanitize admin data

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -205,24 +205,34 @@
 
     // ====== Fetch (inclut un panneau "Sessions récentes") ======
     async function fetchRecentSessions() {
+      const sanitize = (r) => ({
+        ...r,
+        country: r.country ?? 'Inconnu',
+        city: r.city ?? 'Inconnu',
+        device_type: r.device_type ?? 'unknown',
+        ip: r.ip ?? '—',
+        tz_offset: r.tz_offset ?? 0,
+        viewport: r.viewport ?? { width: 0, height: 0 },
+        screen: r.screen ?? { width: 0, height: 0 }
+      });
       try {
         const q = await supabase
           .from('sessions')
-          .select('session_id,country,city,device_type,last_activity_at,ip')
+          .select('session_id,country,city,device_type,last_activity_at,ip,tz_offset,viewport,screen')
           .order('last_activity_at', { ascending: false })
           .limit(20);
         if (q.error) {
           console.warn('recent sessions with ip failed', q.error);
           const q2 = await supabase
             .from('sessions')
-            .select('session_id,country,city,device_type,last_activity_at')
+            .select('session_id,country,city,device_type,last_activity_at,tz_offset,viewport,screen')
             .order('last_activity_at', { ascending: false })
             .limit(20);
-          if (!q2.error) return q2.data || [];
+          if (!q2.error) return (q2.data || []).map(sanitize);
           console.error('recent sessions fallback error', q2.error);
           return [];
         }
-        return q.data || [];
+        return (q.data || []).map(sanitize);
       } catch (err) {
         console.error('recent sessions exception', err);
         return [];
@@ -267,6 +277,14 @@
         result.eventsParJour = res[1].value?.data ?? [];
         result.deviceTypes = res[2].value?.data ?? [];
         let countries = res[3].value?.data ?? [];
+        if (countries.length) {
+          const mapCountries = {};
+          countries.forEach(r => {
+            const c = r.country && r.country.trim() ? r.country : 'Inconnu';
+            mapCountries[c] = (mapCountries[c] || 0) + (r.sessions || 0);
+          });
+          countries = Object.entries(mapCountries).map(([country, sessions]) => ({ country, sessions }));
+        }
         result.topPages = res[4].value?.data ?? [];
         result.entryPages = res[5].value?.data ?? [];
         result.exitPages = res[6].value?.data ?? [];
@@ -279,12 +297,11 @@
         if (!countries.length) {
           const { data: sess, error } = await supabase
             .from('sessions')
-            .select('country')
-            .not('country', 'is', null);
+            .select('country');
           if (!error && sess) {
             const map = {};
             (sess || []).forEach(r => {
-              const c = r.country || 'Inconnu';
+              const c = r.country && r.country.trim() ? r.country : 'Inconnu';
               map[c] = (map[c] || 0) + 1;
             });
             countries = Object.entries(map)
@@ -293,7 +310,7 @@
               .slice(0, 20);
           }
         }
-        result.countries = (countries || []).map(c => ({ ...c, country: c.country || 'Inconnu' }));
+        result.countries = countries;
       } catch (err) {
         console.error('fetchStats error', err);
       }

--- a/public/index.html
+++ b/public/index.html
@@ -5772,10 +5772,18 @@ if (!firstUtm && currentUtm) {
 }
 
 // ====== Contexte navigateur ======
-const deviceType = /Mobi|Android/i.test(navigator.userAgent) ? 'mobile' : 'desktop';
-const viewport = { width: window.innerWidth, height: window.innerHeight };
-const screenSize = { width: screen.width, height: screen.height };
-const tzOffset = new Date().getTimezoneOffset();
+const userAgent = (typeof navigator !== 'undefined' && navigator.userAgent) ? navigator.userAgent : 'unknown';
+const isBot = /vercel-screenshot|bot|crawl|spider/i.test(userAgent);
+const deviceType = userAgent !== 'unknown' && /Mobi|Android/i.test(userAgent) ? 'mobile' : 'desktop';
+const language = (typeof navigator !== 'undefined' && (navigator.language || (navigator.languages && navigator.languages[0]))) || 'unknown';
+const viewport = (typeof window !== 'undefined' && typeof window.innerWidth === 'number' && typeof window.innerHeight === 'number')
+  ? { width: window.innerWidth, height: window.innerHeight }
+  : { width: 0, height: 0 };
+const screenSize = (typeof screen !== 'undefined' && typeof screen.width === 'number' && typeof screen.height === 'number')
+  ? { width: screen.width, height: screen.height }
+  : { width: 0, height: 0 };
+let tzOffset = 0;
+try { tzOffset = new Date().getTimezoneOffset(); } catch { tzOffset = 0; }
 
 // ====== Geo sans cache ======
 async function getGeoData() {
@@ -5783,53 +5791,68 @@ async function getGeoData() {
     const res = await fetch('https://get.geojs.io/v1/ip/geo.json', { cache: 'no-store' });
     const data = await res.json();
     console.log('🌍 Geo brut:', data);
+    const country = data.country_name || data.country || data.country_code || data.country_code3;
+    const city = data.city || data.region;
     return {
-      country: data.country_name || data.country || data.country_code || data.country_code3 || 'Inconnu',
-      city: data.city || data.region || 'Inconnu',
-      ip: data.ip || null
+      country: country && country.trim() ? country : 'Inconnu',
+      city: city && city.trim() ? city : 'Inconnu',
+      ip: data.ip || 'unknown'
     };
   } catch (err) {
     console.error('❌ Geo fetch error:', err);
-    return { country: 'Inconnu', city: 'Inconnu', ip: null };
+    return { country: 'Inconnu', city: 'Inconnu', ip: 'unknown' };
   }
 }
 
 // ====== Création / MAJ de la session ======
 async function upsertSession(initialEventName = 'page_view') {
-  if (!supabase) return;
+  if (!supabase) return false;
+  if (isBot) return false;
   try {
     const geo = await getGeoData();
     const payload = {
       session_id: sessionId,
-      first_referrer: firstReferrer || null,
-      first_utm: firstUtm,
-      user_agent: navigator.userAgent,
-      device_type: deviceType,
-      language: navigator.language,
-      tz_offset: tzOffset,
-      viewport,
-      screen: screenSize,
-      is_returning: isReturning,
-      last_page_url: location.href,
-      last_event_name: initialEventName,
+      first_referrer: firstReferrer ?? null,
+      first_utm: firstUtm ?? null,
+      user_agent: userAgent ?? 'unknown',
+      device_type: deviceType ?? 'desktop',
+      language: language ?? 'unknown',
+      tz_offset: tzOffset ?? 0,
+      viewport: viewport ?? { width: 0, height: 0 },
+      screen: screenSize ?? { width: 0, height: 0 },
+      engagement_ms: 0,
+      is_returning: isReturning ?? false,
+      last_page_url: location.href ?? '',
+      last_event_name: initialEventName ?? '',
       last_activity_at: new Date().toISOString(),
-      country: geo.country,
-      city: geo.city,
-      ip: geo.ip
+      country: geo.country ?? 'Inconnu',
+      city: geo.city ?? 'Inconnu',
+      ip: geo.ip ?? 'unknown'
     };
+    const required = ['session_id','user_agent','device_type','language','tz_offset','viewport','screen','country','city','ip'];
+    const hasAll = required.every(k => payload[k] !== undefined && payload[k] !== null);
+    if (!hasAll) {
+      console.warn('❗ Missing keys in session payload', payload);
+      return false;
+    }
     console.log('➡️ Session upsert payload:', payload);
     const { error } = await supabase
       .from('sessions')
       .upsert(payload, { onConflict: ['session_id'] });
-    if (error) console.error('❌ Session upsert error:', error);
+    if (error) {
+      console.error('❌ Session upsert error:', error);
+      return false;
+    }
+    return true;
   } catch (err) {
     console.error('❌ upsertSession exception:', err);
+    return false;
   }
 }
 
 // ====== Envoi d’événements ======
 async function trackEvent(eventName, meta = {}) {
-  if (!supabase) return;
+  if (!supabase || isBot) return;
   try {
     const event_category = eventName.includes('click') ? 'Interaction' : 'Navigation';
     const { error: e1 } = await supabase.from('events').insert({
@@ -5839,7 +5862,7 @@ async function trackEvent(eventName, meta = {}) {
       page_url: location.href,
       referrer: document.referrer || null,
       utm: currentUtm,
-      user_agent: navigator.userAgent,
+      user_agent: userAgent,
       meta,
       element_selector: meta.element || null
     });
@@ -5860,7 +5883,8 @@ async function trackEvent(eventName, meta = {}) {
 
 // ====== Init ======
 (async () => {
-  await upsertSession('page_view');
+  const ok = await upsertSession('page_view');
+  if (!ok) return;
   await trackEvent('page_view');
 
   document.addEventListener('click', (e) => {


### PR DESCRIPTION
## Summary
- ensure browser context detection provides defaults and bot filtering
- always populate analytics session payload with sane values
- sanitize admin dashboard data and aggregate unknown countries

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689c0b90c8e4832197919870e0a63b4b