### PR TITLE
Add banner logo to admin page

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -55,6 +55,8 @@
     </div>
   </header>
 
+  <img src="/logobanniere.jpeg" alt="Nouveau logo" class="mx-auto my-8 w-36 sm:w-40 h-auto">
+
   <!-- Conteneur -->
   <main class="max-w-7xl mx-auto px-5 py-6 space-y-8" id="root">
     <!-- KPIs -->


### PR DESCRIPTION
## Summary
- show banner logo centered below admin dashboard heading

## Testing
- `npm test` *(fails: Missing script: "test"*)

------
https://chatgpt.com/codex/tasks/task_e_689c0f83296883219543aea0d0ecd9a8