### PR TITLE
Add banner logo and white background to admin page

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -35,7 +35,7 @@
   </style>
 </head>
 
-<body class="h-full bg-gray-50 text-gray-800">
+  <body class="h-full bg-white text-gray-800">
   <!-- Topbar -->
   <header class="sticky top-0 z-30 bg-white/90 backdrop-blur shadow-sm">
     <div class="max-w-7xl mx-auto px-5 py-4 flex items-center gap-4">
@@ -54,6 +54,8 @@
       </div>
     </div>
   </header>
+
+  <img src="/logobanniere.jpeg" alt="Nouveau logo" class="mx-auto my-8 w-36 sm:w-40 h-auto">
 
   <!-- Conteneur -->
   <main class="max-w-7xl mx-auto px-5 py-6 space-y-8" id="root">


### PR DESCRIPTION
## Summary
- show banner logo centered below admin dashboard heading
- set admin page background to white

## Testing
- `npm test` *(fails: Missing script: "test"*)

------
https://chatgpt.com/codex/tasks/task_e_689c0f83296883219543aea0d0ecd9a8