### PR TITLE
fix: prevent horizontal scroll in admin dashboard

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -21,6 +21,7 @@
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 
   <style>
+    html, body { overflow-x: hidden; }
     .hint { position: relative; cursor: help; }
     .hint:hover .hint-bubble { opacity: 1; transform: translateY(0); pointer-events: auto; }
     .hint-bubble {


### PR DESCRIPTION
## Summary
- hide horizontal overflow on admin dashboard by applying `overflow-x: hidden` to `html` and `body`

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689c1b23c96c8321a8ff5172d069dd32