### PR TITLE
Fix duplicate Supabase constants breaking analytics

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5732,9 +5732,7 @@ addChatStyles();
    ======================== */
 
 // ====== CONFIG SUPABASE ======
-const SUPABASE_URL = 'https://swjnpvfkloubshksobau.supabase.co';
-const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InN3am5wdmZrbG91YnNoa3NvYmF1Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTQwOTUxMzEsImV4cCI6MjA2OTY3MTEzMX0.A6rnIJyfIIxDT0c2XW_zGeUXpdYCgBFd6MTzBGFZ-Cg';
-
+// Utilise les constantes déclarées plus haut pour créer le client Supabase
 const supabase = window.supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
 
 // ====== Utils ======


### PR DESCRIPTION
## Summary
- remove redundant Supabase constant declarations that caused `Identifier 'SUPABASE_URL' has already been declared`
- rely on initial constants to initialize Supabase client for analytics

## Testing
- `rg -n SUPABASE public/index.html`
- `node - <<'NODE' ... NODE` (simulate analytics script; trackEvent function is defined)


------
https://chatgpt.com/codex/tasks/task_e_689c2298a7c08321808126be81899ff7