### PR TITLE
Adjust spacing between logobanniere.jpeg and main title on MBTI/Enneagram/Blog pages to match homepage

### DIFF
--- a/public/blog.html
+++ b/public/blog.html
@@ -432,10 +432,6 @@
     </header>
 
     <main>
-        <div class="relative max-w-5xl mx-auto px-6 pb-16 text-center">
-            <img src="/logobanniere.jpeg" alt="Nouveau logo" class="mx-auto mb-8 w-36 sm:w-40 h-auto">
-        </div>
-
         <section id="hero" class="py-16 px-4 sm:px-6 lg:px-8 relative overflow-hidden pc-hero">
             <canvas id="pc-constellation" aria-hidden="true"></canvas>
             <div class="absolute inset-0 opacity-[0.02]">
@@ -444,8 +440,9 @@
             <div class="absolute top-1/4 right-1/4 w-2 h-2 bg-blue-400/20 rounded-full"></div>
             <div class="absolute bottom-1/3 left-1/5 w-1 h-1 bg-slate-400/30 rounded-full"></div>
             <div class="absolute top-2/3 right-1/3 w-1.5 h-1.5 bg-blue-300/25 rounded-full"></div>
-            <div class="relative max-w-4xl mx-auto">
-                <h1 class="text-3xl font-extrabold text-gray-900 sm:text-4xl mb-8 text-center">Nos articles de blog</h1>
+            <div class="relative max-w-4xl mx-auto px-6 pb-16 text-center">
+                <img src="/logobanniere.jpeg" alt="Nouveau logo" class="mx-auto mb-8 w-36 sm:w-40 h-auto">
+                <h1 class="text-3xl font-extrabold text-gray-900 sm:text-4xl mb-6">Nos articles de blog</h1>
                 <div class="grid gap-8 md:grid-cols-2">
                     <article class="border rounded-lg p-6 shadow-sm hover:shadow-md transition">
                         <a href="blog-mbti-4-dimensions.html" class="block">

--- a/public/enneagramme.html
+++ b/public/enneagramme.html
@@ -432,10 +432,6 @@
     </header>
 
     <main>
-        <div class="relative max-w-5xl mx-auto px-6 pb-16 text-center">
-            <img src="/logobanniere.jpeg" alt="Nouveau logo" class="mx-auto mb-8 w-36 sm:w-40 h-auto">
-        </div>
-
 <section id="hero" class="py-16 px-4 sm:px-6 lg:px-8 relative overflow-hidden pc-hero">
   <canvas id="pc-constellation" aria-hidden="true"></canvas>
   <div class="absolute inset-0 opacity-[0.02]">
@@ -444,8 +440,9 @@
   <div class="absolute top-1/4 right-1/4 w-2 h-2 bg-blue-400/20 rounded-full"></div>
   <div class="absolute bottom-1/3 left-1/5 w-1 h-1 bg-slate-400/30 rounded-full"></div>
   <div class="absolute top-2/3 right-1/3 w-1.5 h-1.5 bg-blue-300/25 rounded-full"></div>
-  <div class="relative max-w-3xl mx-auto text-center">
-    <h1 class="text-3xl font-extrabold text-gray-900 sm:text-4xl mb-4">Découvrir l'ennéagramme</h1>
+  <div class="relative max-w-3xl mx-auto px-6 pb-16 text-center">
+    <img src="/logobanniere.jpeg" alt="Nouveau logo" class="mx-auto mb-8 w-36 sm:w-40 h-auto">
+    <h1 class="text-3xl font-extrabold text-gray-900 sm:text-4xl mb-6">Découvrir l'ennéagramme</h1>
     <p class="text-lg text-gray-700">L'ennéagramme est un modèle de personnalité fondé sur 9 types, centré sur nos motivations profondes et nos blessures originelles.</p>
   </div>
 </section>

--- a/public/mbti.html
+++ b/public/mbti.html
@@ -432,10 +432,6 @@
     </header>
 
     <main>
-        <div class="relative max-w-5xl mx-auto px-6 pb-16 text-center">
-            <img src="/logobanniere.jpeg" alt="Nouveau logo" class="mx-auto mb-8 w-36 sm:w-40 h-auto">
-        </div>
-
 <section id="hero" class="py-16 px-4 sm:px-6 lg:px-8 relative overflow-hidden pc-hero">
   <canvas id="pc-constellation" aria-hidden="true"></canvas>
   <div class="absolute inset-0 opacity-[0.02]">
@@ -444,8 +440,9 @@
   <div class="absolute top-1/4 right-1/4 w-2 h-2 bg-blue-400/20 rounded-full"></div>
   <div class="absolute bottom-1/3 left-1/5 w-1 h-1 bg-slate-400/30 rounded-full"></div>
   <div class="absolute top-2/3 right-1/3 w-1.5 h-1.5 bg-blue-300/25 rounded-full"></div>
-  <div class="relative max-w-3xl mx-auto text-center">
-    <h1 class="text-3xl font-extrabold text-gray-900 sm:text-4xl mb-4">Comprendre le MBTI</h1>
+  <div class="relative max-w-3xl mx-auto px-6 pb-16 text-center">
+    <img src="/logobanniere.jpeg" alt="Nouveau logo" class="mx-auto mb-8 w-36 sm:w-40 h-auto">
+    <h1 class="text-3xl font-extrabold text-gray-900 sm:text-4xl mb-6">Comprendre le MBTI</h1>
     <p class="text-lg text-gray-700">Le MBTI est un outil de compréhension de soi basé sur 4 dimensions fondamentales de la personnalité...</p>
   </div>
 </section>


### PR DESCRIPTION
## Summary
- Remove extra container and move `logobanniere.jpeg` into each page's hero section to mirror homepage spacing.
- Align MBTI/Enneagram/Blog hero blocks with homepage by matching padding and margins on image and heading.

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689c7d91e1888321943f54cbf0dfe60d