### PR TITLE
Fix footer links and adjust logo spacing on MBTI/Enneagram/Blog pages to match homepage

### DIFF
--- a/public/blog.html
+++ b/public/blog.html
@@ -432,7 +432,7 @@
     </header>
 
     <main>
-        <section id="hero" class="py-16 px-4 sm:px-6 lg:px-8 relative overflow-hidden pc-hero">
+        <section id="hero" class="px-4 sm:px-6 lg:px-8 relative overflow-hidden pc-hero mt-8 sm:mt-12">
             <canvas id="pc-constellation" aria-hidden="true"></canvas>
             <div class="absolute inset-0 opacity-[0.02]">
                 <div class="absolute inset-0" style="background-image: radial-gradient(circle at 1px 1px, rgb(15 23 42) 1px, transparent 0); background-size: 40px 40px;"></div>
@@ -473,17 +473,17 @@
                         <li><a href="mbti.html" class="text-base text-gray-300 hover:text-white transition-colors">MBTI</a></li>
                         <li><a href="enneagramme.html" class="text-base text-gray-300 hover:text-white transition-colors">Ennéagramme</a></li>
                         <li><a href="blog.html" class="text-base text-gray-300 hover:text-white transition-colors">Blog</a></li>
-                       <li><a href="#profil-chatbot" class="text-base text-gray-300 hover:text-white transition-colors">IA spécialisée</a></li>
-                        <li><a href="#faq" class="text-base text-gray-300 hover:text-white transition-colors">FAQ</a></li>
+                       <li><a href="index.html#profil-chatbot" class="text-base text-gray-300 hover:text-white transition-colors">IA spécialisée</a></li>
+                        <li><a href="index.html#faq" class="text-base text-gray-300 hover:text-white transition-colors">FAQ</a></li>
 
                     </ul>
                 </div>
                 <div>
                     <h3 class="text-sm font-semibold text-gray-400 tracking-wider uppercase">Tests</h3>
                     <ul class="mt-4 space-y-4">
-                        <li><a href="#auto-evaluation" class="text-base text-gray-300 hover:text-white transition-colors">Auto-évaluation</a></li>
-                        <li><a href="#evaluation-proche" class="text-base text-gray-300 hover:text-white transition-colors">Évaluer un proche</a></li>
-                        <li><a href="#retourver-profil" class="text-base text-gray-300 hover:text-white transition-colors">Mon profil</a></li>
+                        <li><a href="index.html#auto-evaluation" class="text-base text-gray-300 hover:text-white transition-colors">Auto-évaluation</a></li>
+                        <li><a href="index.html#evaluation-proche" class="text-base text-gray-300 hover:text-white transition-colors">Évaluer un proche</a></li>
+                        <li><a href="index.html#retourver-profil" class="text-base text-gray-300 hover:text-white transition-colors">Mon profil</a></li>
                     </ul>
                 </div>
                 <div>

--- a/public/enneagramme.html
+++ b/public/enneagramme.html
@@ -432,7 +432,7 @@
     </header>
 
     <main>
-<section id="hero" class="py-16 px-4 sm:px-6 lg:px-8 relative overflow-hidden pc-hero">
+<section id="hero" class="px-4 sm:px-6 lg:px-8 relative overflow-hidden pc-hero mt-8 sm:mt-12">
   <canvas id="pc-constellation" aria-hidden="true"></canvas>
   <div class="absolute inset-0 opacity-[0.02]">
     <div class="absolute inset-0" style="background-image: radial-gradient(circle at 1px 1px, rgb(15 23 42) 1px, transparent 0); background-size: 40px 40px;"></div>
@@ -761,17 +761,17 @@
                         <li><a href="mbti.html" class="text-base text-gray-300 hover:text-white transition-colors">MBTI</a></li>
                         <li><a href="enneagramme.html" class="text-base text-gray-300 hover:text-white transition-colors">Ennéagramme</a></li>
                         <li><a href="blog.html" class="text-base text-gray-300 hover:text-white transition-colors">Blog</a></li>
-                       <li><a href="#profil-chatbot" class="text-base text-gray-300 hover:text-white transition-colors">IA spécialisée</a></li>
-                        <li><a href="#faq" class="text-base text-gray-300 hover:text-white transition-colors">FAQ</a></li>
+                       <li><a href="index.html#profil-chatbot" class="text-base text-gray-300 hover:text-white transition-colors">IA spécialisée</a></li>
+                        <li><a href="index.html#faq" class="text-base text-gray-300 hover:text-white transition-colors">FAQ</a></li>
 
                     </ul>
                 </div>
                 <div>
                     <h3 class="text-sm font-semibold text-gray-400 tracking-wider uppercase">Tests</h3>
                     <ul class="mt-4 space-y-4">
-                        <li><a href="#auto-evaluation" class="text-base text-gray-300 hover:text-white transition-colors">Auto-évaluation</a></li>
-                        <li><a href="#evaluation-proche" class="text-base text-gray-300 hover:text-white transition-colors">Évaluer un proche</a></li>
-                        <li><a href="#retourver-profil" class="text-base text-gray-300 hover:text-white transition-colors">Mon profil</a></li>
+                        <li><a href="index.html#auto-evaluation" class="text-base text-gray-300 hover:text-white transition-colors">Auto-évaluation</a></li>
+                        <li><a href="index.html#evaluation-proche" class="text-base text-gray-300 hover:text-white transition-colors">Évaluer un proche</a></li>
+                        <li><a href="index.html#retourver-profil" class="text-base text-gray-300 hover:text-white transition-colors">Mon profil</a></li>
                     </ul>
                 </div>
                 <div>

--- a/public/mbti.html
+++ b/public/mbti.html
@@ -432,7 +432,7 @@
     </header>
 
     <main>
-<section id="hero" class="py-16 px-4 sm:px-6 lg:px-8 relative overflow-hidden pc-hero">
+<section id="hero" class="px-4 sm:px-6 lg:px-8 relative overflow-hidden pc-hero mt-8 sm:mt-12">
   <canvas id="pc-constellation" aria-hidden="true"></canvas>
   <div class="absolute inset-0 opacity-[0.02]">
     <div class="absolute inset-0" style="background-image: radial-gradient(circle at 1px 1px, rgb(15 23 42) 1px, transparent 0); background-size: 40px 40px;"></div>
@@ -846,17 +846,17 @@
                         <li><a href="mbti.html" class="text-base text-gray-300 hover:text-white transition-colors">MBTI</a></li>
                         <li><a href="enneagramme.html" class="text-base text-gray-300 hover:text-white transition-colors">Ennéagramme</a></li>
                         <li><a href="blog.html" class="text-base text-gray-300 hover:text-white transition-colors">Blog</a></li>
-                       <li><a href="#profil-chatbot" class="text-base text-gray-300 hover:text-white transition-colors">IA spécialisée</a></li>
-                        <li><a href="#faq" class="text-base text-gray-300 hover:text-white transition-colors">FAQ</a></li>
+                       <li><a href="index.html#profil-chatbot" class="text-base text-gray-300 hover:text-white transition-colors">IA spécialisée</a></li>
+                        <li><a href="index.html#faq" class="text-base text-gray-300 hover:text-white transition-colors">FAQ</a></li>
 
                     </ul>
                 </div>
                 <div>
                     <h3 class="text-sm font-semibold text-gray-400 tracking-wider uppercase">Tests</h3>
                     <ul class="mt-4 space-y-4">
-                        <li><a href="#auto-evaluation" class="text-base text-gray-300 hover:text-white transition-colors">Auto-évaluation</a></li>
-                        <li><a href="#evaluation-proche" class="text-base text-gray-300 hover:text-white transition-colors">Évaluer un proche</a></li>
-                        <li><a href="#retourver-profil" class="text-base text-gray-300 hover:text-white transition-colors">Mon profil</a></li>
+                        <li><a href="index.html#auto-evaluation" class="text-base text-gray-300 hover:text-white transition-colors">Auto-évaluation</a></li>
+                        <li><a href="index.html#evaluation-proche" class="text-base text-gray-300 hover:text-white transition-colors">Évaluer un proche</a></li>
+                        <li><a href="index.html#retourver-profil" class="text-base text-gray-300 hover:text-white transition-colors">Mon profil</a></li>
                     </ul>
                 </div>
                 <div>


### PR DESCRIPTION
## Summary
- Align MBTI, Enneagram, and Blog hero sections with homepage spacing so the banner logo sits closer to the top menu
- Point footer links on MBTI, Enneagram, and Blog pages to homepage sections for working navigation

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689c7feda09083219c9dc03353c8bad4