### PR TITLE
Align "Un peu d'histoire" headers with site section styles

### DIFF
--- a/public/enneagramme.html
+++ b/public/enneagramme.html
@@ -449,8 +449,10 @@
 
 <section class="py-16 px-4 sm:px-6 lg:px-8 bg-gray-50">
   <div class="max-w-3xl mx-auto">
-    <h2 class="text-2xl font-bold text-gray-900 mb-6">Un peu d'histoire</h2>
-    <div class="text-gray-700 space-y-6 leading-relaxed">
+    <div class="text-center">
+      <h2 class="text-3xl font-extrabold text-gray-900 sm:text-4xl">Un peu d'histoire</h2>
+    </div>
+    <div class="mt-12 text-gray-700 space-y-6 leading-relaxed">
       
       <div>
         <h3 class="text-xl font-semibold text-gray-800 mb-2">1. Étymologie & origines anciennes</h3>

--- a/public/mbti.html
+++ b/public/mbti.html
@@ -449,8 +449,10 @@
 
 <section class="py-16 px-4 sm:px-6 lg:px-8 bg-gray-50">
   <div class="max-w-3xl mx-auto">
-    <h2 class="text-2xl font-bold text-gray-900 mb-6">Un peu d'histoire</h2>
-    <div class="text-gray-700 space-y-6 leading-relaxed">
+    <div class="text-center">
+      <h2 class="text-3xl font-extrabold text-gray-900 sm:text-4xl">Un peu d'histoire</h2>
+    </div>
+    <div class="mt-12 text-gray-700 space-y-6 leading-relaxed">
       
       <div>
         <h3 class="text-xl font-semibold text-gray-800 mb-2">1. Les origines – Carl Jung</h3>


### PR DESCRIPTION
## Summary
- Apply consistent heading style to "Un peu d'histoire" sections on MBTI and Enneagram pages
- Center-align and adjust margins to match other site section headers

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689c8e40b54c832180943d428046bd19