### PR TITLE
Refactor main nav: add section-based dropdowns for Accueil, MBTI, Ennéagramme; keep IA, Blog, FAQ as simple links.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vercel
+node_modules

--- a/public/blog-enneagramme-instincts.html
+++ b/public/blog-enneagramme-instincts.html
@@ -407,17 +407,43 @@
                 <div id="home-menu" class="invisible opacity-0 group-hover:visible group-hover:opacity-100 transition absolute left-0 mt-2 w-64 rounded-xl shadow-lg bg-white ring-1 ring-black/5 z-50">
                     <ul class="py-2 text-sm">
                         <li><a href="index.html#home-hero" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Présentation</a></li>
-                        <li><a href="index.html#home-mbti" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">MBTI</a></li>
-                        <li><a href="index.html#home-enneagramme" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Ennéagramme</a></li>
-                        <li><a href="index.html#home-blog" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Blog</a></li>
-                        <li><a href="index.html#home-ia" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">IA spécialisée</a></li>
+                        <li><a href="index.html#home-mbti" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Section MBTI</a></li>
+                        <li><a href="index.html#home-enneagramme" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Section Ennéagramme</a></li>
                         <li><a href="index.html#home-faq" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">FAQ</a></li>
                     </ul>
                 </div>
             </div>
-            <a href="mbti.html" class="text-gray-500 hover:text-gray-700 inline-flex items-center px-1 pt-1 text-sm font-medium">MBTI</a>
-            <a href="enneagramme.html" class="text-gray-500 hover:text-gray-700 inline-flex items-center px-1 pt-1 text-sm font-medium">Ennéagramme</a>
+            <div id="mbti-menu-container" class="relative group">
+                <button id="mbti-menu-button" class="inline-flex items-center gap-2 text-gray-500 hover:text-gray-700 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
+                    MBTI
+                    <svg class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
+                </button>
+                <div id="mbti-menu" class="invisible opacity-0 group-hover:visible group-hover:opacity-100 transition absolute left-0 mt-2 w-64 rounded-xl shadow-lg bg-white ring-1 ring-black/5 z-50">
+                    <ul class="py-2 text-sm">
+                        <li><a href="mbti.html#mbti-hero" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Comprendre le MBTI</a></li>
+                        <li><a href="mbti.html#mbti-history" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Un peu d'histoire</a></li>
+                        <li><a href="mbti.html#mbti-types" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Les 16 types</a></li>
+                        <li><a href="mbti.html#mbti-faq" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">FAQ MBTI</a></li>
+                    </ul>
+                </div>
+            </div>
+            <div id="ennea-menu-container" class="relative group">
+                <button id="ennea-menu-button" class="inline-flex items-center gap-2 text-gray-500 hover:text-gray-700 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
+                    Ennéagramme
+                    <svg class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
+                </button>
+                <div id="ennea-menu" class="invisible opacity-0 group-hover:visible group-hover:opacity-100 transition absolute left-0 mt-2 w-64 rounded-xl shadow-lg bg-white ring-1 ring-black/5 z-50">
+                    <ul class="py-2 text-sm">
+                        <li><a href="enneagramme.html#ennea-hero" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Comprendre l’Ennéagramme</a></li>
+                        <li><a href="enneagramme.html#ennea-history" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Un peu d'histoire</a></li>
+                        <li><a href="enneagramme.html#ennea-types" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Les 9 types</a></li>
+                        <li><a href="enneagramme.html#ennea-faq" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">FAQ Ennéagramme</a></li>
+                    </ul>
+                </div>
+            </div>
+            <a href="index.html#home-ia" class="text-gray-500 hover:text-gray-700 inline-flex items-center px-1 pt-1 text-sm font-medium">IA spécialisée</a>
             <a href="blog.html" class="text-gray-500 hover:text-gray-700 inline-flex items-center px-1 pt-1 text-sm font-medium">Blog</a>
+            <a href="index.html#home-faq" class="text-gray-500 hover:text-gray-700 inline-flex items-center px-1 pt-1 text-sm font-medium">FAQ</a>
             <button id="profile-btn-desktop" onclick="openProfileModal()" class="ml-4 inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-black hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black">
                 Mon profil
             </button>
@@ -438,16 +464,38 @@
                     </button>
                     <div id="mobile-home-menu" class="hidden pl-4 space-y-1">
                         <a href="index.html#home-hero" class="block px-3 py-2 rounded-md text-sm text-gray-700">Présentation</a>
-                        <a href="index.html#home-mbti" class="block px-3 py-2 rounded-md text-sm text-gray-700">MBTI</a>
-                        <a href="index.html#home-enneagramme" class="block px-3 py-2 rounded-md text-sm text-gray-700">Ennéagramme</a>
-                        <a href="index.html#home-blog" class="block px-3 py-2 rounded-md text-sm text-gray-700">Blog</a>
-                        <a href="index.html#home-ia" class="block px-3 py-2 rounded-md text-sm text-gray-700">IA spécialisée</a>
+                        <a href="index.html#home-mbti" class="block px-3 py-2 rounded-md text-sm text-gray-700">Section MBTI</a>
+                        <a href="index.html#home-enneagramme" class="block px-3 py-2 rounded-md text-sm text-gray-700">Section Ennéagramme</a>
                         <a href="index.html#home-faq" class="block px-3 py-2 rounded-md text-sm text-gray-700">FAQ</a>
                     </div>
                 </div>
-                <a href="mbti.html" class="text-gray-500 hover:text-gray-700 block px-3 py-2 rounded-md text-base font-medium">MBTI</a>
-                <a href="enneagramme.html" class="text-gray-500 hover:text-gray-700 block px-3 py-2 rounded-md text-base font-medium">Ennéagramme</a>
+                <div>
+                    <button id="mobile-mbti-button" class="w-full flex items-center justify-between px-3 py-2 rounded-md text-base font-medium text-gray-500" aria-expanded="false">
+                        MBTI
+                        <svg id="mobile-mbti-caret" class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
+                    </button>
+                    <div id="mobile-mbti-menu" class="hidden pl-4 space-y-1">
+                        <a href="mbti.html#mbti-hero" class="block px-3 py-2 rounded-md text-sm text-gray-700">Comprendre le MBTI</a>
+                        <a href="mbti.html#mbti-history" class="block px-3 py-2 rounded-md text-sm text-gray-700">Un peu d'histoire</a>
+                        <a href="mbti.html#mbti-types" class="block px-3 py-2 rounded-md text-sm text-gray-700">Les 16 types</a>
+                        <a href="mbti.html#mbti-faq" class="block px-3 py-2 rounded-md text-sm text-gray-700">FAQ MBTI</a>
+                    </div>
+                </div>
+                <div>
+                    <button id="mobile-ennea-button" class="w-full flex items-center justify-between px-3 py-2 rounded-md text-base font-medium text-gray-500" aria-expanded="false">
+                        Ennéagramme
+                        <svg id="mobile-ennea-caret" class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
+                    </button>
+                    <div id="mobile-ennea-menu" class="hidden pl-4 space-y-1">
+                        <a href="enneagramme.html#ennea-hero" class="block px-3 py-2 rounded-md text-sm text-gray-700">Comprendre l’Ennéagramme</a>
+                        <a href="enneagramme.html#ennea-history" class="block px-3 py-2 rounded-md text-sm text-gray-700">Un peu d'histoire</a>
+                        <a href="enneagramme.html#ennea-types" class="block px-3 py-2 rounded-md text-sm text-gray-700">Les 9 types</a>
+                        <a href="enneagramme.html#ennea-faq" class="block px-3 py-2 rounded-md text-sm text-gray-700">FAQ Ennéagramme</a>
+                    </div>
+                </div>
+                <a href="index.html#home-ia" class="text-gray-500 hover:text-gray-700 block px-3 py-2 rounded-md text-base font-medium">IA spécialisée</a>
                 <a href="blog.html" class="text-gray-500 hover:text-gray-700 block px-3 py-2 rounded-md text-base font-medium">Blog</a>
+                <a href="index.html#home-faq" class="text-gray-500 hover:text-gray-700 block px-3 py-2 rounded-md text-base font-medium">FAQ</a>
                 <button id="profile-btn-mobile" onclick="openProfileModal()" class="w-full mt-2 inline-flex items-center justify-center px-4 py-2 border border-transparent text-base font-medium rounded-md shadow-sm text-white bg-black hover:bg-gray-800">
                     Mon profil
                 </button>
@@ -573,5 +621,6 @@
   });
   function openProfileModal() {}
 </script>
+<script src="nav.js"></script>
 </body>
 </html>

--- a/public/blog-mbti-4-dimensions.html
+++ b/public/blog-mbti-4-dimensions.html
@@ -407,17 +407,43 @@
                 <div id="home-menu" class="invisible opacity-0 group-hover:visible group-hover:opacity-100 transition absolute left-0 mt-2 w-64 rounded-xl shadow-lg bg-white ring-1 ring-black/5 z-50">
                     <ul class="py-2 text-sm">
                         <li><a href="index.html#home-hero" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Présentation</a></li>
-                        <li><a href="index.html#home-mbti" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">MBTI</a></li>
-                        <li><a href="index.html#home-enneagramme" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Ennéagramme</a></li>
-                        <li><a href="index.html#home-blog" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Blog</a></li>
-                        <li><a href="index.html#home-ia" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">IA spécialisée</a></li>
+                        <li><a href="index.html#home-mbti" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Section MBTI</a></li>
+                        <li><a href="index.html#home-enneagramme" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Section Ennéagramme</a></li>
                         <li><a href="index.html#home-faq" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">FAQ</a></li>
                     </ul>
                 </div>
             </div>
-            <a href="mbti.html" class="text-gray-500 hover:text-gray-700 inline-flex items-center px-1 pt-1 text-sm font-medium">MBTI</a>
-            <a href="enneagramme.html" class="text-gray-500 hover:text-gray-700 inline-flex items-center px-1 pt-1 text-sm font-medium">Ennéagramme</a>
+            <div id="mbti-menu-container" class="relative group">
+                <button id="mbti-menu-button" class="inline-flex items-center gap-2 text-gray-500 hover:text-gray-700 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
+                    MBTI
+                    <svg class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
+                </button>
+                <div id="mbti-menu" class="invisible opacity-0 group-hover:visible group-hover:opacity-100 transition absolute left-0 mt-2 w-64 rounded-xl shadow-lg bg-white ring-1 ring-black/5 z-50">
+                    <ul class="py-2 text-sm">
+                        <li><a href="mbti.html#mbti-hero" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Comprendre le MBTI</a></li>
+                        <li><a href="mbti.html#mbti-history" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Un peu d'histoire</a></li>
+                        <li><a href="mbti.html#mbti-types" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Les 16 types</a></li>
+                        <li><a href="mbti.html#mbti-faq" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">FAQ MBTI</a></li>
+                    </ul>
+                </div>
+            </div>
+            <div id="ennea-menu-container" class="relative group">
+                <button id="ennea-menu-button" class="inline-flex items-center gap-2 text-gray-500 hover:text-gray-700 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
+                    Ennéagramme
+                    <svg class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
+                </button>
+                <div id="ennea-menu" class="invisible opacity-0 group-hover:visible group-hover:opacity-100 transition absolute left-0 mt-2 w-64 rounded-xl shadow-lg bg-white ring-1 ring-black/5 z-50">
+                    <ul class="py-2 text-sm">
+                        <li><a href="enneagramme.html#ennea-hero" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Comprendre l’Ennéagramme</a></li>
+                        <li><a href="enneagramme.html#ennea-history" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Un peu d'histoire</a></li>
+                        <li><a href="enneagramme.html#ennea-types" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Les 9 types</a></li>
+                        <li><a href="enneagramme.html#ennea-faq" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">FAQ Ennéagramme</a></li>
+                    </ul>
+                </div>
+            </div>
+            <a href="index.html#home-ia" class="text-gray-500 hover:text-gray-700 inline-flex items-center px-1 pt-1 text-sm font-medium">IA spécialisée</a>
             <a href="blog.html" class="text-gray-500 hover:text-gray-700 inline-flex items-center px-1 pt-1 text-sm font-medium">Blog</a>
+            <a href="index.html#home-faq" class="text-gray-500 hover:text-gray-700 inline-flex items-center px-1 pt-1 text-sm font-medium">FAQ</a>
             <button id="profile-btn-desktop" onclick="openProfileModal()" class="ml-4 inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-black hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black">
                 Mon profil
             </button>
@@ -438,16 +464,38 @@
                     </button>
                     <div id="mobile-home-menu" class="hidden pl-4 space-y-1">
                         <a href="index.html#home-hero" class="block px-3 py-2 rounded-md text-sm text-gray-700">Présentation</a>
-                        <a href="index.html#home-mbti" class="block px-3 py-2 rounded-md text-sm text-gray-700">MBTI</a>
-                        <a href="index.html#home-enneagramme" class="block px-3 py-2 rounded-md text-sm text-gray-700">Ennéagramme</a>
-                        <a href="index.html#home-blog" class="block px-3 py-2 rounded-md text-sm text-gray-700">Blog</a>
-                        <a href="index.html#home-ia" class="block px-3 py-2 rounded-md text-sm text-gray-700">IA spécialisée</a>
+                        <a href="index.html#home-mbti" class="block px-3 py-2 rounded-md text-sm text-gray-700">Section MBTI</a>
+                        <a href="index.html#home-enneagramme" class="block px-3 py-2 rounded-md text-sm text-gray-700">Section Ennéagramme</a>
                         <a href="index.html#home-faq" class="block px-3 py-2 rounded-md text-sm text-gray-700">FAQ</a>
                     </div>
                 </div>
-                <a href="mbti.html" class="text-gray-500 hover:text-gray-700 block px-3 py-2 rounded-md text-base font-medium">MBTI</a>
-                <a href="enneagramme.html" class="text-gray-500 hover:text-gray-700 block px-3 py-2 rounded-md text-base font-medium">Ennéagramme</a>
+                <div>
+                    <button id="mobile-mbti-button" class="w-full flex items-center justify-between px-3 py-2 rounded-md text-base font-medium text-gray-500" aria-expanded="false">
+                        MBTI
+                        <svg id="mobile-mbti-caret" class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
+                    </button>
+                    <div id="mobile-mbti-menu" class="hidden pl-4 space-y-1">
+                        <a href="mbti.html#mbti-hero" class="block px-3 py-2 rounded-md text-sm text-gray-700">Comprendre le MBTI</a>
+                        <a href="mbti.html#mbti-history" class="block px-3 py-2 rounded-md text-sm text-gray-700">Un peu d'histoire</a>
+                        <a href="mbti.html#mbti-types" class="block px-3 py-2 rounded-md text-sm text-gray-700">Les 16 types</a>
+                        <a href="mbti.html#mbti-faq" class="block px-3 py-2 rounded-md text-sm text-gray-700">FAQ MBTI</a>
+                    </div>
+                </div>
+                <div>
+                    <button id="mobile-ennea-button" class="w-full flex items-center justify-between px-3 py-2 rounded-md text-base font-medium text-gray-500" aria-expanded="false">
+                        Ennéagramme
+                        <svg id="mobile-ennea-caret" class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
+                    </button>
+                    <div id="mobile-ennea-menu" class="hidden pl-4 space-y-1">
+                        <a href="enneagramme.html#ennea-hero" class="block px-3 py-2 rounded-md text-sm text-gray-700">Comprendre l’Ennéagramme</a>
+                        <a href="enneagramme.html#ennea-history" class="block px-3 py-2 rounded-md text-sm text-gray-700">Un peu d'histoire</a>
+                        <a href="enneagramme.html#ennea-types" class="block px-3 py-2 rounded-md text-sm text-gray-700">Les 9 types</a>
+                        <a href="enneagramme.html#ennea-faq" class="block px-3 py-2 rounded-md text-sm text-gray-700">FAQ Ennéagramme</a>
+                    </div>
+                </div>
+                <a href="index.html#home-ia" class="text-gray-500 hover:text-gray-700 block px-3 py-2 rounded-md text-base font-medium">IA spécialisée</a>
                 <a href="blog.html" class="text-gray-500 hover:text-gray-700 block px-3 py-2 rounded-md text-base font-medium">Blog</a>
+                <a href="index.html#home-faq" class="text-gray-500 hover:text-gray-700 block px-3 py-2 rounded-md text-base font-medium">FAQ</a>
                 <button id="profile-btn-mobile" onclick="openProfileModal()" class="w-full mt-2 inline-flex items-center justify-center px-4 py-2 border border-transparent text-base font-medium rounded-md shadow-sm text-white bg-black hover:bg-gray-800">
                     Mon profil
                 </button>
@@ -573,5 +621,6 @@
   });
   function openProfileModal() {}
 </script>
+<script src="nav.js"></script>
 </body>
 </html>

--- a/public/blog.html
+++ b/public/blog.html
@@ -407,17 +407,43 @@
                 <div id="home-menu" class="invisible opacity-0 group-hover:visible group-hover:opacity-100 transition absolute left-0 mt-2 w-64 rounded-xl shadow-lg bg-white ring-1 ring-black/5 z-50">
                     <ul class="py-2 text-sm">
                         <li><a href="index.html#home-hero" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Présentation</a></li>
-                        <li><a href="index.html#home-mbti" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">MBTI</a></li>
-                        <li><a href="index.html#home-enneagramme" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Ennéagramme</a></li>
-                        <li><a href="index.html#home-blog" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Blog</a></li>
-                        <li><a href="index.html#home-ia" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">IA spécialisée</a></li>
+                        <li><a href="index.html#home-mbti" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Section MBTI</a></li>
+                        <li><a href="index.html#home-enneagramme" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Section Ennéagramme</a></li>
                         <li><a href="index.html#home-faq" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">FAQ</a></li>
                     </ul>
                 </div>
             </div>
-            <a href="mbti.html" class="text-gray-500 hover:text-gray-700 inline-flex items-center px-1 pt-1 text-sm font-medium">MBTI</a>
-            <a href="enneagramme.html" class="text-gray-500 hover:text-gray-700 inline-flex items-center px-1 pt-1 text-sm font-medium">Ennéagramme</a>
+            <div id="mbti-menu-container" class="relative group">
+                <button id="mbti-menu-button" class="inline-flex items-center gap-2 text-gray-500 hover:text-gray-700 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
+                    MBTI
+                    <svg class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
+                </button>
+                <div id="mbti-menu" class="invisible opacity-0 group-hover:visible group-hover:opacity-100 transition absolute left-0 mt-2 w-64 rounded-xl shadow-lg bg-white ring-1 ring-black/5 z-50">
+                    <ul class="py-2 text-sm">
+                        <li><a href="mbti.html#mbti-hero" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Comprendre le MBTI</a></li>
+                        <li><a href="mbti.html#mbti-history" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Un peu d'histoire</a></li>
+                        <li><a href="mbti.html#mbti-types" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Les 16 types</a></li>
+                        <li><a href="mbti.html#mbti-faq" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">FAQ MBTI</a></li>
+                    </ul>
+                </div>
+            </div>
+            <div id="ennea-menu-container" class="relative group">
+                <button id="ennea-menu-button" class="inline-flex items-center gap-2 text-gray-500 hover:text-gray-700 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
+                    Ennéagramme
+                    <svg class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
+                </button>
+                <div id="ennea-menu" class="invisible opacity-0 group-hover:visible group-hover:opacity-100 transition absolute left-0 mt-2 w-64 rounded-xl shadow-lg bg-white ring-1 ring-black/5 z-50">
+                    <ul class="py-2 text-sm">
+                        <li><a href="enneagramme.html#ennea-hero" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Comprendre l’Ennéagramme</a></li>
+                        <li><a href="enneagramme.html#ennea-history" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Un peu d'histoire</a></li>
+                        <li><a href="enneagramme.html#ennea-types" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Les 9 types</a></li>
+                        <li><a href="enneagramme.html#ennea-faq" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">FAQ Ennéagramme</a></li>
+                    </ul>
+                </div>
+            </div>
+            <a href="index.html#home-ia" class="text-gray-500 hover:text-gray-700 inline-flex items-center px-1 pt-1 text-sm font-medium">IA spécialisée</a>
             <a href="blog.html" class="text-gray-500 hover:text-gray-700 inline-flex items-center px-1 pt-1 text-sm font-medium">Blog</a>
+            <a href="index.html#home-faq" class="text-gray-500 hover:text-gray-700 inline-flex items-center px-1 pt-1 text-sm font-medium">FAQ</a>
             <button id="profile-btn-desktop" onclick="openProfileModal()" class="ml-4 inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-black hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black">
                 Mon profil
             </button>
@@ -438,16 +464,38 @@
                     </button>
                     <div id="mobile-home-menu" class="hidden pl-4 space-y-1">
                         <a href="index.html#home-hero" class="block px-3 py-2 rounded-md text-sm text-gray-700">Présentation</a>
-                        <a href="index.html#home-mbti" class="block px-3 py-2 rounded-md text-sm text-gray-700">MBTI</a>
-                        <a href="index.html#home-enneagramme" class="block px-3 py-2 rounded-md text-sm text-gray-700">Ennéagramme</a>
-                        <a href="index.html#home-blog" class="block px-3 py-2 rounded-md text-sm text-gray-700">Blog</a>
-                        <a href="index.html#home-ia" class="block px-3 py-2 rounded-md text-sm text-gray-700">IA spécialisée</a>
+                        <a href="index.html#home-mbti" class="block px-3 py-2 rounded-md text-sm text-gray-700">Section MBTI</a>
+                        <a href="index.html#home-enneagramme" class="block px-3 py-2 rounded-md text-sm text-gray-700">Section Ennéagramme</a>
                         <a href="index.html#home-faq" class="block px-3 py-2 rounded-md text-sm text-gray-700">FAQ</a>
                     </div>
                 </div>
-                <a href="mbti.html" class="text-gray-500 hover:text-gray-700 block px-3 py-2 rounded-md text-base font-medium">MBTI</a>
-                <a href="enneagramme.html" class="text-gray-500 hover:text-gray-700 block px-3 py-2 rounded-md text-base font-medium">Ennéagramme</a>
+                <div>
+                    <button id="mobile-mbti-button" class="w-full flex items-center justify-between px-3 py-2 rounded-md text-base font-medium text-gray-500" aria-expanded="false">
+                        MBTI
+                        <svg id="mobile-mbti-caret" class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
+                    </button>
+                    <div id="mobile-mbti-menu" class="hidden pl-4 space-y-1">
+                        <a href="mbti.html#mbti-hero" class="block px-3 py-2 rounded-md text-sm text-gray-700">Comprendre le MBTI</a>
+                        <a href="mbti.html#mbti-history" class="block px-3 py-2 rounded-md text-sm text-gray-700">Un peu d'histoire</a>
+                        <a href="mbti.html#mbti-types" class="block px-3 py-2 rounded-md text-sm text-gray-700">Les 16 types</a>
+                        <a href="mbti.html#mbti-faq" class="block px-3 py-2 rounded-md text-sm text-gray-700">FAQ MBTI</a>
+                    </div>
+                </div>
+                <div>
+                    <button id="mobile-ennea-button" class="w-full flex items-center justify-between px-3 py-2 rounded-md text-base font-medium text-gray-500" aria-expanded="false">
+                        Ennéagramme
+                        <svg id="mobile-ennea-caret" class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
+                    </button>
+                    <div id="mobile-ennea-menu" class="hidden pl-4 space-y-1">
+                        <a href="enneagramme.html#ennea-hero" class="block px-3 py-2 rounded-md text-sm text-gray-700">Comprendre l’Ennéagramme</a>
+                        <a href="enneagramme.html#ennea-history" class="block px-3 py-2 rounded-md text-sm text-gray-700">Un peu d'histoire</a>
+                        <a href="enneagramme.html#ennea-types" class="block px-3 py-2 rounded-md text-sm text-gray-700">Les 9 types</a>
+                        <a href="enneagramme.html#ennea-faq" class="block px-3 py-2 rounded-md text-sm text-gray-700">FAQ Ennéagramme</a>
+                    </div>
+                </div>
+                <a href="index.html#home-ia" class="text-gray-500 hover:text-gray-700 block px-3 py-2 rounded-md text-base font-medium">IA spécialisée</a>
                 <a href="blog.html" class="text-gray-500 hover:text-gray-700 block px-3 py-2 rounded-md text-base font-medium">Blog</a>
+                <a href="index.html#home-faq" class="text-gray-500 hover:text-gray-700 block px-3 py-2 rounded-md text-base font-medium">FAQ</a>
                 <button id="profile-btn-mobile" onclick="openProfileModal()" class="w-full mt-2 inline-flex items-center justify-center px-4 py-2 border border-transparent text-base font-medium rounded-md shadow-sm text-white bg-black hover:bg-gray-800">
                     Mon profil
                 </button>
@@ -4798,13 +4846,15 @@ async function trackEvent(eventName, meta = {}) {
     else if (e.target.className) {
       selector = e.target.tagName.toLowerCase() + '.' + e.target.className.toString().trim().replace(/\s+/g, '.');
     } else selector = e.target.tagName.toLowerCase();
-    trackEvent('click', { element: selector });
+  trackEvent('click', { element: selector });
   });
 })();
 </script>
 
+<script src="nav.js"></script>
 
-  
+
+
 </body>
 </html>
 

--- a/public/enneagramme.html
+++ b/public/enneagramme.html
@@ -407,20 +407,44 @@
                 <div id="home-menu" class="invisible opacity-0 group-hover:visible group-hover:opacity-100 transition absolute left-0 mt-2 w-64 rounded-xl shadow-lg bg-white ring-1 ring-black/5 z-50">
                     <ul class="py-2 text-sm">
                         <li><a href="index.html#home-hero" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Présentation</a></li>
-                        <li><a href="index.html#home-mbti" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">MBTI</a></li>
-                        <li><a href="index.html#home-enneagramme" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Ennéagramme</a></li>
-                        <li><a href="index.html#home-blog" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Blog</a></li>
-                        <li><a href="index.html#home-ia" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">IA spécialisée</a></li>
+                        <li><a href="index.html#home-mbti" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Section MBTI</a></li>
+                        <li><a href="index.html#home-enneagramme" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Section Ennéagramme</a></li>
                         <li><a href="index.html#home-faq" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">FAQ</a></li>
                     </ul>
                 </div>
             </div>
-            <a href="mbti.html" class="text-gray-500 hover:text-gray-700 inline-flex items-center px-1 pt-1 text-sm font-medium">MBTI</a>
-            <a href="enneagramme.html" class="text-gray-500 hover:text-gray-700 inline-flex items-center px-1 pt-1 text-sm font-medium">Ennéagramme</a>
+            <div id="mbti-menu-container" class="relative group">
+                <button id="mbti-menu-button" class="inline-flex items-center gap-2 text-gray-500 hover:text-gray-700 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
+                    MBTI
+                    <svg class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
+                </button>
+                <div id="mbti-menu" class="invisible opacity-0 group-hover:visible group-hover:opacity-100 transition absolute left-0 mt-2 w-64 rounded-xl shadow-lg bg-white ring-1 ring-black/5 z-50">
+                    <ul class="py-2 text-sm">
+                        <li><a href="mbti.html#mbti-hero" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Comprendre le MBTI</a></li>
+                        <li><a href="mbti.html#mbti-history" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Un peu d'histoire</a></li>
+                        <li><a href="mbti.html#mbti-types" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Les 16 types</a></li>
+                        <li><a href="mbti.html#mbti-faq" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">FAQ MBTI</a></li>
+                    </ul>
+                </div>
+            </div>
+            <div id="ennea-menu-container" class="relative group">
+                <button id="ennea-menu-button" class="inline-flex items-center gap-2 text-gray-500 hover:text-gray-700 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
+                    Ennéagramme
+                    <svg class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
+                </button>
+                <div id="ennea-menu" class="invisible opacity-0 group-hover:visible group-hover:opacity-100 transition absolute left-0 mt-2 w-64 rounded-xl shadow-lg bg-white ring-1 ring-black/5 z-50">
+                    <ul class="py-2 text-sm">
+                        <li><a href="enneagramme.html#ennea-hero" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Comprendre l’Ennéagramme</a></li>
+                        <li><a href="enneagramme.html#ennea-history" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Un peu d'histoire</a></li>
+                        <li><a href="enneagramme.html#ennea-types" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Les 9 types</a></li>
+                        <li><a href="enneagramme.html#ennea-faq" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">FAQ Ennéagramme</a></li>
+                    </ul>
+                </div>
+            </div>
+            <a href="index.html#home-ia" class="text-gray-500 hover:text-gray-700 inline-flex items-center px-1 pt-1 text-sm font-medium">IA spécialisée</a>
             <a href="blog.html" class="text-gray-500 hover:text-gray-700 inline-flex items-center px-1 pt-1 text-sm font-medium">Blog</a>
-            <button id="profile-btn-desktop" onclick="openProfileModal()" class="ml-4 inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-black hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black">
-                Mon profil
-            </button>
+            <a href="index.html#home-faq" class="text-gray-500 hover:text-gray-700 inline-flex items-center px-1 pt-1 text-sm font-medium">FAQ</a>
+            <button id="profile-btn-desktop" onclick="openProfileModal" class="ml-4 inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-black hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black">Mon profil</button>
         </nav>
         <div class="-mr-2 flex items-center md:hidden">
             <button type="button" id="mobile-menu-button" class="inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500" aria-controls="mobile-menu" aria-expanded="false">
@@ -438,16 +462,38 @@
                     </button>
                     <div id="mobile-home-menu" class="hidden pl-4 space-y-1">
                         <a href="index.html#home-hero" class="block px-3 py-2 rounded-md text-sm text-gray-700">Présentation</a>
-                        <a href="index.html#home-mbti" class="block px-3 py-2 rounded-md text-sm text-gray-700">MBTI</a>
-                        <a href="index.html#home-enneagramme" class="block px-3 py-2 rounded-md text-sm text-gray-700">Ennéagramme</a>
-                        <a href="index.html#home-blog" class="block px-3 py-2 rounded-md text-sm text-gray-700">Blog</a>
-                        <a href="index.html#home-ia" class="block px-3 py-2 rounded-md text-sm text-gray-700">IA spécialisée</a>
+                        <a href="index.html#home-mbti" class="block px-3 py-2 rounded-md text-sm text-gray-700">Section MBTI</a>
+                        <a href="index.html#home-enneagramme" class="block px-3 py-2 rounded-md text-sm text-gray-700">Section Ennéagramme</a>
                         <a href="index.html#home-faq" class="block px-3 py-2 rounded-md text-sm text-gray-700">FAQ</a>
                     </div>
                 </div>
-                <a href="mbti.html" class="text-gray-500 hover:text-gray-700 block px-3 py-2 rounded-md text-base font-medium">MBTI</a>
-                <a href="enneagramme.html" class="text-gray-500 hover:text-gray-700 block px-3 py-2 rounded-md text-base font-medium">Ennéagramme</a>
+                <div>
+                    <button id="mobile-mbti-button" class="w-full flex items-center justify-between px-3 py-2 rounded-md text-base font-medium text-gray-500" aria-expanded="false">
+                        MBTI
+                        <svg id="mobile-mbti-caret" class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
+                    </button>
+                    <div id="mobile-mbti-menu" class="hidden pl-4 space-y-1">
+                        <a href="mbti.html#mbti-hero" class="block px-3 py-2 rounded-md text-sm text-gray-700">Comprendre le MBTI</a>
+                        <a href="mbti.html#mbti-history" class="block px-3 py-2 rounded-md text-sm text-gray-700">Un peu d'histoire</a>
+                        <a href="mbti.html#mbti-types" class="block px-3 py-2 rounded-md text-sm text-gray-700">Les 16 types</a>
+                        <a href="mbti.html#mbti-faq" class="block px-3 py-2 rounded-md text-sm text-gray-700">FAQ MBTI</a>
+                    </div>
+                </div>
+                <div>
+                    <button id="mobile-ennea-button" class="w-full flex items-center justify-between px-3 py-2 rounded-md text-base font-medium text-gray-500" aria-expanded="false">
+                        Ennéagramme
+                        <svg id="mobile-ennea-caret" class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
+                    </button>
+                    <div id="mobile-ennea-menu" class="hidden pl-4 space-y-1">
+                        <a href="enneagramme.html#ennea-hero" class="block px-3 py-2 rounded-md text-sm text-gray-700">Comprendre l’Ennéagramme</a>
+                        <a href="enneagramme.html#ennea-history" class="block px-3 py-2 rounded-md text-sm text-gray-700">Un peu d'histoire</a>
+                        <a href="enneagramme.html#ennea-types" class="block px-3 py-2 rounded-md text-sm text-gray-700">Les 9 types</a>
+                        <a href="enneagramme.html#ennea-faq" class="block px-3 py-2 rounded-md text-sm text-gray-700">FAQ Ennéagramme</a>
+                    </div>
+                </div>
+                <a href="index.html#home-ia" class="text-gray-500 hover:text-gray-700 block px-3 py-2 rounded-md text-base font-medium">IA spécialisée</a>
                 <a href="blog.html" class="text-gray-500 hover:text-gray-700 block px-3 py-2 rounded-md text-base font-medium">Blog</a>
+                <a href="index.html#home-faq" class="text-gray-500 hover:text-gray-700 block px-3 py-2 rounded-md text-base font-medium">FAQ</a>
                 <button id="profile-btn-mobile" onclick="openProfileModal()" class="w-full mt-2 inline-flex items-center justify-center px-4 py-2 border border-transparent text-base font-medium rounded-md shadow-sm text-white bg-black hover:bg-gray-800">
                     Mon profil
                 </button>
@@ -456,7 +502,7 @@
     </header>
 
     <main>
-<section id="hero" class="px-4 sm:px-6 lg:px-8 relative overflow-hidden pc-hero mt-8 sm:mt-12">
+<section id="ennea-hero" class="px-4 sm:px-6 lg:px-8 relative overflow-hidden pc-hero mt-8 sm:mt-12">
   <canvas id="pc-constellation" aria-hidden="true"></canvas>
   <div class="absolute inset-0 opacity-[0.02]">
     <div class="absolute inset-0" style="background-image: radial-gradient(circle at 1px 1px, rgb(15 23 42) 1px, transparent 0); background-size: 40px 40px;"></div>
@@ -471,7 +517,7 @@
   </div>
 </section>
 
-<section class="py-16 px-4 sm:px-6 lg:px-8 bg-gray-50">
+<section id="ennea-history" class="py-16 px-4 sm:px-6 lg:px-8 bg-gray-50">
   <div class="max-w-3xl mx-auto">
     <div class="text-center">
       <h2 class="text-3xl font-extrabold text-gray-900 sm:text-4xl">Un peu d'histoire</h2>
@@ -515,7 +561,7 @@
 </section>
 
 
-    <div id="enneagram" data-aos="fade-left" class="section section-fonce py-16 px-4 sm:px-6 lg:px-8">
+    <div id="ennea-types" data-aos="fade-left" class="section section-fonce py-16 px-4 sm:px-6 lg:px-8">
         <div class="max-w-7xl mx-auto">
             <div class="text-center">
                 <h2 class="text-3xl font-extrabold text-gray-900 sm:text-4xl">
@@ -811,7 +857,7 @@
 
 
     </main>
-        <div id="faq" data-aos="fade-up" class="section section-clair py-16 px-4 sm:px-6 lg:px-8">
+        <div id="ennea-faq" data-aos="fade-up" class="section section-clair py-16 px-4 sm:px-6 lg:px-8">
         <div class="max-w-3xl mx-auto">
             <div class="text-center">
                 <h2 class="text-3xl font-extrabold text-gray-900 sm:text-4xl">
@@ -5233,13 +5279,15 @@ async function trackEvent(eventName, meta = {}) {
     else if (e.target.className) {
       selector = e.target.tagName.toLowerCase() + '.' + e.target.className.toString().trim().replace(/\s+/g, '.');
     } else selector = e.target.tagName.toLowerCase();
-    trackEvent('click', { element: selector });
+  trackEvent('click', { element: selector });
   });
 })();
 </script>
 
+<script src="nav.js"></script>
 
-  
+
+
 </body>
 </html>
 

--- a/public/index.html
+++ b/public/index.html
@@ -407,17 +407,43 @@
                 <div id="home-menu" class="invisible opacity-0 group-hover:visible group-hover:opacity-100 transition absolute left-0 mt-2 w-64 rounded-xl shadow-lg bg-white ring-1 ring-black/5 z-50">
                     <ul class="py-2 text-sm">
                         <li><a href="index.html#home-hero" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Présentation</a></li>
-                        <li><a href="index.html#home-mbti" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">MBTI</a></li>
-                        <li><a href="index.html#home-enneagramme" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Ennéagramme</a></li>
-                        <li><a href="index.html#home-blog" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Blog</a></li>
-                        <li><a href="index.html#home-ia" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">IA spécialisée</a></li>
+                        <li><a href="index.html#home-mbti" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Section MBTI</a></li>
+                        <li><a href="index.html#home-enneagramme" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Section Ennéagramme</a></li>
                         <li><a href="index.html#home-faq" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">FAQ</a></li>
                     </ul>
                 </div>
             </div>
-            <a href="mbti.html" class="text-gray-500 hover:text-gray-700 inline-flex items-center px-1 pt-1 text-sm font-medium">MBTI</a>
-            <a href="enneagramme.html" class="text-gray-500 hover:text-gray-700 inline-flex items-center px-1 pt-1 text-sm font-medium">Ennéagramme</a>
+            <div id="mbti-menu-container" class="relative group">
+                <button id="mbti-menu-button" class="inline-flex items-center gap-2 text-gray-500 hover:text-gray-700 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
+                    MBTI
+                    <svg class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
+                </button>
+                <div id="mbti-menu" class="invisible opacity-0 group-hover:visible group-hover:opacity-100 transition absolute left-0 mt-2 w-64 rounded-xl shadow-lg bg-white ring-1 ring-black/5 z-50">
+                    <ul class="py-2 text-sm">
+                        <li><a href="mbti.html#mbti-hero" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Comprendre le MBTI</a></li>
+                        <li><a href="mbti.html#mbti-history" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Un peu d'histoire</a></li>
+                        <li><a href="mbti.html#mbti-types" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Les 16 types</a></li>
+                        <li><a href="mbti.html#mbti-faq" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">FAQ MBTI</a></li>
+                    </ul>
+                </div>
+            </div>
+            <div id="ennea-menu-container" class="relative group">
+                <button id="ennea-menu-button" class="inline-flex items-center gap-2 text-gray-500 hover:text-gray-700 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
+                    Ennéagramme
+                    <svg class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
+                </button>
+                <div id="ennea-menu" class="invisible opacity-0 group-hover:visible group-hover:opacity-100 transition absolute left-0 mt-2 w-64 rounded-xl shadow-lg bg-white ring-1 ring-black/5 z-50">
+                    <ul class="py-2 text-sm">
+                        <li><a href="enneagramme.html#ennea-hero" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Comprendre l’Ennéagramme</a></li>
+                        <li><a href="enneagramme.html#ennea-history" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Un peu d'histoire</a></li>
+                        <li><a href="enneagramme.html#ennea-types" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Les 9 types</a></li>
+                        <li><a href="enneagramme.html#ennea-faq" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">FAQ Ennéagramme</a></li>
+                    </ul>
+                </div>
+            </div>
+            <a href="index.html#home-ia" class="text-gray-500 hover:text-gray-700 inline-flex items-center px-1 pt-1 text-sm font-medium">IA spécialisée</a>
             <a href="blog.html" class="text-gray-500 hover:text-gray-700 inline-flex items-center px-1 pt-1 text-sm font-medium">Blog</a>
+            <a href="index.html#home-faq" class="text-gray-500 hover:text-gray-700 inline-flex items-center px-1 pt-1 text-sm font-medium">FAQ</a>
             <button id="profile-btn-desktop" onclick="openProfileModal()" class="ml-4 inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-black hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black">
                 Mon profil
             </button>
@@ -438,16 +464,38 @@
                     </button>
                     <div id="mobile-home-menu" class="hidden pl-4 space-y-1">
                         <a href="index.html#home-hero" class="block px-3 py-2 rounded-md text-sm text-gray-700">Présentation</a>
-                        <a href="index.html#home-mbti" class="block px-3 py-2 rounded-md text-sm text-gray-700">MBTI</a>
-                        <a href="index.html#home-enneagramme" class="block px-3 py-2 rounded-md text-sm text-gray-700">Ennéagramme</a>
-                        <a href="index.html#home-blog" class="block px-3 py-2 rounded-md text-sm text-gray-700">Blog</a>
-                        <a href="index.html#home-ia" class="block px-3 py-2 rounded-md text-sm text-gray-700">IA spécialisée</a>
+                        <a href="index.html#home-mbti" class="block px-3 py-2 rounded-md text-sm text-gray-700">Section MBTI</a>
+                        <a href="index.html#home-enneagramme" class="block px-3 py-2 rounded-md text-sm text-gray-700">Section Ennéagramme</a>
                         <a href="index.html#home-faq" class="block px-3 py-2 rounded-md text-sm text-gray-700">FAQ</a>
                     </div>
                 </div>
-                <a href="mbti.html" class="text-gray-500 hover:text-gray-700 block px-3 py-2 rounded-md text-base font-medium">MBTI</a>
-                <a href="enneagramme.html" class="text-gray-500 hover:text-gray-700 block px-3 py-2 rounded-md text-base font-medium">Ennéagramme</a>
+                <div>
+                    <button id="mobile-mbti-button" class="w-full flex items-center justify-between px-3 py-2 rounded-md text-base font-medium text-gray-500" aria-expanded="false">
+                        MBTI
+                        <svg id="mobile-mbti-caret" class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
+                    </button>
+                    <div id="mobile-mbti-menu" class="hidden pl-4 space-y-1">
+                        <a href="mbti.html#mbti-hero" class="block px-3 py-2 rounded-md text-sm text-gray-700">Comprendre le MBTI</a>
+                        <a href="mbti.html#mbti-history" class="block px-3 py-2 rounded-md text-sm text-gray-700">Un peu d'histoire</a>
+                        <a href="mbti.html#mbti-types" class="block px-3 py-2 rounded-md text-sm text-gray-700">Les 16 types</a>
+                        <a href="mbti.html#mbti-faq" class="block px-3 py-2 rounded-md text-sm text-gray-700">FAQ MBTI</a>
+                    </div>
+                </div>
+                <div>
+                    <button id="mobile-ennea-button" class="w-full flex items-center justify-between px-3 py-2 rounded-md text-base font-medium text-gray-500" aria-expanded="false">
+                        Ennéagramme
+                        <svg id="mobile-ennea-caret" class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
+                    </button>
+                    <div id="mobile-ennea-menu" class="hidden pl-4 space-y-1">
+                        <a href="enneagramme.html#ennea-hero" class="block px-3 py-2 rounded-md text-sm text-gray-700">Comprendre l’Ennéagramme</a>
+                        <a href="enneagramme.html#ennea-history" class="block px-3 py-2 rounded-md text-sm text-gray-700">Un peu d'histoire</a>
+                        <a href="enneagramme.html#ennea-types" class="block px-3 py-2 rounded-md text-sm text-gray-700">Les 9 types</a>
+                        <a href="enneagramme.html#ennea-faq" class="block px-3 py-2 rounded-md text-sm text-gray-700">FAQ Ennéagramme</a>
+                    </div>
+                </div>
+                <a href="index.html#home-ia" class="text-gray-500 hover:text-gray-700 block px-3 py-2 rounded-md text-base font-medium">IA spécialisée</a>
                 <a href="blog.html" class="text-gray-500 hover:text-gray-700 block px-3 py-2 rounded-md text-base font-medium">Blog</a>
+                <a href="index.html#home-faq" class="text-gray-500 hover:text-gray-700 block px-3 py-2 rounded-md text-base font-medium">FAQ</a>
                 <button id="profile-btn-mobile" onclick="openProfileModal()" class="w-full mt-2 inline-flex items-center justify-center px-4 py-2 border border-transparent text-base font-medium rounded-md shadow-sm text-white bg-black hover:bg-gray-800">
                     Mon profil
                 </button>
@@ -5267,13 +5315,15 @@ async function trackEvent(eventName, meta = {}) {
     else if (e.target.className) {
       selector = e.target.tagName.toLowerCase() + '.' + e.target.className.toString().trim().replace(/\s+/g, '.');
     } else selector = e.target.tagName.toLowerCase();
-    trackEvent('click', { element: selector });
+  trackEvent('click', { element: selector });
   });
 })();
 </script>
 
+<script src="nav.js"></script>
 
-  
+
+
 </body>
 </html>
 

--- a/public/mbti.html
+++ b/public/mbti.html
@@ -407,17 +407,43 @@
                 <div id="home-menu" class="invisible opacity-0 group-hover:visible group-hover:opacity-100 transition absolute left-0 mt-2 w-64 rounded-xl shadow-lg bg-white ring-1 ring-black/5 z-50">
                     <ul class="py-2 text-sm">
                         <li><a href="index.html#home-hero" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Présentation</a></li>
-                        <li><a href="index.html#home-mbti" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">MBTI</a></li>
-                        <li><a href="index.html#home-enneagramme" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Ennéagramme</a></li>
-                        <li><a href="index.html#home-blog" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Blog</a></li>
-                        <li><a href="index.html#home-ia" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">IA spécialisée</a></li>
+                        <li><a href="index.html#home-mbti" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Section MBTI</a></li>
+                        <li><a href="index.html#home-enneagramme" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Section Ennéagramme</a></li>
                         <li><a href="index.html#home-faq" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">FAQ</a></li>
                     </ul>
                 </div>
             </div>
-            <a href="mbti.html" class="text-gray-500 hover:text-gray-700 inline-flex items-center px-1 pt-1 text-sm font-medium">MBTI</a>
-            <a href="enneagramme.html" class="text-gray-500 hover:text-gray-700 inline-flex items-center px-1 pt-1 text-sm font-medium">Ennéagramme</a>
+            <div id="mbti-menu-container" class="relative group">
+                <button id="mbti-menu-button" class="inline-flex items-center gap-2 text-gray-500 hover:text-gray-700 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
+                    MBTI
+                    <svg class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
+                </button>
+                <div id="mbti-menu" class="invisible opacity-0 group-hover:visible group-hover:opacity-100 transition absolute left-0 mt-2 w-64 rounded-xl shadow-lg bg-white ring-1 ring-black/5 z-50">
+                    <ul class="py-2 text-sm">
+                        <li><a href="mbti.html#mbti-hero" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Comprendre le MBTI</a></li>
+                        <li><a href="mbti.html#mbti-history" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Un peu d'histoire</a></li>
+                        <li><a href="mbti.html#mbti-types" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Les 16 types</a></li>
+                        <li><a href="mbti.html#mbti-faq" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">FAQ MBTI</a></li>
+                    </ul>
+                </div>
+            </div>
+            <div id="ennea-menu-container" class="relative group">
+                <button id="ennea-menu-button" class="inline-flex items-center gap-2 text-gray-500 hover:text-gray-700 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
+                    Ennéagramme
+                    <svg class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
+                </button>
+                <div id="ennea-menu" class="invisible opacity-0 group-hover:visible group-hover:opacity-100 transition absolute left-0 mt-2 w-64 rounded-xl shadow-lg bg-white ring-1 ring-black/5 z-50">
+                    <ul class="py-2 text-sm">
+                        <li><a href="enneagramme.html#ennea-hero" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Comprendre l’Ennéagramme</a></li>
+                        <li><a href="enneagramme.html#ennea-history" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Un peu d'histoire</a></li>
+                        <li><a href="enneagramme.html#ennea-types" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Les 9 types</a></li>
+                        <li><a href="enneagramme.html#ennea-faq" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">FAQ Ennéagramme</a></li>
+                    </ul>
+                </div>
+            </div>
+            <a href="index.html#home-ia" class="text-gray-500 hover:text-gray-700 inline-flex items-center px-1 pt-1 text-sm font-medium">IA spécialisée</a>
             <a href="blog.html" class="text-gray-500 hover:text-gray-700 inline-flex items-center px-1 pt-1 text-sm font-medium">Blog</a>
+            <a href="index.html#home-faq" class="text-gray-500 hover:text-gray-700 inline-flex items-center px-1 pt-1 text-sm font-medium">FAQ</a>
             <button id="profile-btn-desktop" onclick="openProfileModal()" class="ml-4 inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-black hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black">
                 Mon profil
             </button>
@@ -438,16 +464,38 @@
                     </button>
                     <div id="mobile-home-menu" class="hidden pl-4 space-y-1">
                         <a href="index.html#home-hero" class="block px-3 py-2 rounded-md text-sm text-gray-700">Présentation</a>
-                        <a href="index.html#home-mbti" class="block px-3 py-2 rounded-md text-sm text-gray-700">MBTI</a>
-                        <a href="index.html#home-enneagramme" class="block px-3 py-2 rounded-md text-sm text-gray-700">Ennéagramme</a>
-                        <a href="index.html#home-blog" class="block px-3 py-2 rounded-md text-sm text-gray-700">Blog</a>
-                        <a href="index.html#home-ia" class="block px-3 py-2 rounded-md text-sm text-gray-700">IA spécialisée</a>
+                        <a href="index.html#home-mbti" class="block px-3 py-2 rounded-md text-sm text-gray-700">Section MBTI</a>
+                        <a href="index.html#home-enneagramme" class="block px-3 py-2 rounded-md text-sm text-gray-700">Section Ennéagramme</a>
                         <a href="index.html#home-faq" class="block px-3 py-2 rounded-md text-sm text-gray-700">FAQ</a>
                     </div>
                 </div>
-                <a href="mbti.html" class="text-gray-500 hover:text-gray-700 block px-3 py-2 rounded-md text-base font-medium">MBTI</a>
-                <a href="enneagramme.html" class="text-gray-500 hover:text-gray-700 block px-3 py-2 rounded-md text-base font-medium">Ennéagramme</a>
+                <div>
+                    <button id="mobile-mbti-button" class="w-full flex items-center justify-between px-3 py-2 rounded-md text-base font-medium text-gray-500" aria-expanded="false">
+                        MBTI
+                        <svg id="mobile-mbti-caret" class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
+                    </button>
+                    <div id="mobile-mbti-menu" class="hidden pl-4 space-y-1">
+                        <a href="mbti.html#mbti-hero" class="block px-3 py-2 rounded-md text-sm text-gray-700">Comprendre le MBTI</a>
+                        <a href="mbti.html#mbti-history" class="block px-3 py-2 rounded-md text-sm text-gray-700">Un peu d'histoire</a>
+                        <a href="mbti.html#mbti-types" class="block px-3 py-2 rounded-md text-sm text-gray-700">Les 16 types</a>
+                        <a href="mbti.html#mbti-faq" class="block px-3 py-2 rounded-md text-sm text-gray-700">FAQ MBTI</a>
+                    </div>
+                </div>
+                <div>
+                    <button id="mobile-ennea-button" class="w-full flex items-center justify-between px-3 py-2 rounded-md text-base font-medium text-gray-500" aria-expanded="false">
+                        Ennéagramme
+                        <svg id="mobile-ennea-caret" class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
+                    </button>
+                    <div id="mobile-ennea-menu" class="hidden pl-4 space-y-1">
+                        <a href="enneagramme.html#ennea-hero" class="block px-3 py-2 rounded-md text-sm text-gray-700">Comprendre l’Ennéagramme</a>
+                        <a href="enneagramme.html#ennea-history" class="block px-3 py-2 rounded-md text-sm text-gray-700">Un peu d'histoire</a>
+                        <a href="enneagramme.html#ennea-types" class="block px-3 py-2 rounded-md text-sm text-gray-700">Les 9 types</a>
+                        <a href="enneagramme.html#ennea-faq" class="block px-3 py-2 rounded-md text-sm text-gray-700">FAQ Ennéagramme</a>
+                    </div>
+                </div>
+                <a href="index.html#home-ia" class="text-gray-500 hover:text-gray-700 block px-3 py-2 rounded-md text-base font-medium">IA spécialisée</a>
                 <a href="blog.html" class="text-gray-500 hover:text-gray-700 block px-3 py-2 rounded-md text-base font-medium">Blog</a>
+                <a href="index.html#home-faq" class="text-gray-500 hover:text-gray-700 block px-3 py-2 rounded-md text-base font-medium">FAQ</a>
                 <button id="profile-btn-mobile" onclick="openProfileModal()" class="w-full mt-2 inline-flex items-center justify-center px-4 py-2 border border-transparent text-base font-medium rounded-md shadow-sm text-white bg-black hover:bg-gray-800">
                     Mon profil
                 </button>
@@ -456,7 +504,7 @@
     </header>
 
     <main>
-<section id="hero" class="px-4 sm:px-6 lg:px-8 relative overflow-hidden pc-hero mt-8 sm:mt-12">
+<section id="mbti-hero" class="px-4 sm:px-6 lg:px-8 relative overflow-hidden pc-hero mt-8 sm:mt-12">
   <canvas id="pc-constellation" aria-hidden="true"></canvas>
   <div class="absolute inset-0 opacity-[0.02]">
     <div class="absolute inset-0" style="background-image: radial-gradient(circle at 1px 1px, rgb(15 23 42) 1px, transparent 0); background-size: 40px 40px;"></div>
@@ -471,7 +519,7 @@
   </div>
 </section>
 
-<section class="py-16 px-4 sm:px-6 lg:px-8 bg-gray-50">
+<section id="mbti-history" class="py-16 px-4 sm:px-6 lg:px-8 bg-gray-50">
   <div class="max-w-3xl mx-auto">
     <div class="text-center">
       <h2 class="text-3xl font-extrabold text-gray-900 sm:text-4xl">Un peu d'histoire</h2>
@@ -525,7 +573,7 @@
 
 
 
-    <div id="mbti" data-aos="fade-right" class="section section-clair py-16 px-4 sm:px-6 lg:px-8">
+    <div id="mbti-types" data-aos="fade-right" class="section section-clair py-16 px-4 sm:px-6 lg:px-8">
         <div class="max-w-7xl mx-auto">
             <div class="text-center">
                 <h2 class="text-3xl font-extrabold text-gray-900 sm:text-4xl">
@@ -906,7 +954,7 @@
 
 
     </main>
-        <div id="faq" data-aos="fade-up" class="section section-clair py-16 px-4 sm:px-6 lg:px-8">
+        <div id="mbti-faq" data-aos="fade-up" class="section section-clair py-16 px-4 sm:px-6 lg:px-8">
         <div class="max-w-3xl mx-auto">
             <div class="text-center">
                 <h2 class="text-3xl font-extrabold text-gray-900 sm:text-4xl">
@@ -5328,13 +5376,15 @@ async function trackEvent(eventName, meta = {}) {
     else if (e.target.className) {
       selector = e.target.tagName.toLowerCase() + '.' + e.target.className.toString().trim().replace(/\s+/g, '.');
     } else selector = e.target.tagName.toLowerCase();
-    trackEvent('click', { element: selector });
+  trackEvent('click', { element: selector });
   });
 })();
 </script>
 
+<script src="nav.js"></script>
 
-  
+
+
 </body>
 </html>
 

--- a/public/nav.js
+++ b/public/nav.js
@@ -1,0 +1,73 @@
+(function(){
+  document.addEventListener('DOMContentLoaded', function(){
+    const desktopConfigs=[
+      {c:'home-menu-container',b:'home-menu-button',m:'home-menu'},
+      {c:'mbti-menu-container',b:'mbti-menu-button',m:'mbti-menu'},
+      {c:'ennea-menu-container',b:'ennea-menu-button',m:'ennea-menu'}
+    ];
+    const desktopMenus=desktopConfigs.map(cfg=>({
+      container:document.getElementById(cfg.c),
+      button:document.getElementById(cfg.b),
+      menu:document.getElementById(cfg.m)
+    })).filter(obj=>obj.container&&obj.button&&obj.menu);
+    desktopMenus.forEach(current=>{
+      const openMenu=()=>{
+        desktopMenus.forEach(other=>{
+          if(other!==current){
+            other.menu.classList.add('invisible','opacity-0');
+            other.button.setAttribute('aria-expanded','false');
+          }
+        });
+        current.menu.classList.remove('invisible','opacity-0');
+        current.button.setAttribute('aria-expanded','true');
+      };
+      const closeMenu=()=>{
+        current.menu.classList.add('invisible','opacity-0');
+        current.button.setAttribute('aria-expanded','false');
+      };
+      current.container.addEventListener('mouseenter',openMenu);
+      current.container.addEventListener('mouseleave',closeMenu);
+      current.button.addEventListener('focus',openMenu);
+      current.button.addEventListener('blur',e=>{if(!current.menu.contains(e.relatedTarget)) closeMenu();});
+      document.addEventListener('click',e=>{if(!current.container.contains(e.target)) closeMenu();});
+      document.addEventListener('keydown',e=>{if(e.key==='Escape') closeMenu();});
+    });
+
+    const mobileConfigs=[
+      {b:'mobile-home-button',m:'mobile-home-menu',c:'mobile-home-caret'},
+      {b:'mobile-mbti-button',m:'mobile-mbti-menu',c:'mobile-mbti-caret'},
+      {b:'mobile-ennea-button',m:'mobile-ennea-menu',c:'mobile-ennea-caret'}
+    ];
+    const mobileMenus=mobileConfigs.map(cfg=>({
+      button:document.getElementById(cfg.b),
+      menu:document.getElementById(cfg.m),
+      caret:document.getElementById(cfg.c)
+    })).filter(obj=>obj.button&&obj.menu&&obj.caret);
+
+    mobileMenus.forEach(current=>{
+      current.button.addEventListener('click',()=>{
+        const expanded=current.button.getAttribute('aria-expanded')==='true';
+        mobileMenus.forEach(other=>{
+          other.menu.classList.add('hidden');
+          other.button.setAttribute('aria-expanded','false');
+          other.caret.classList.remove('rotate-180');
+        });
+        if(!expanded){
+          current.menu.classList.remove('hidden');
+          current.button.setAttribute('aria-expanded','true');
+          current.caret.classList.add('rotate-180');
+        }
+      });
+    });
+
+    document.addEventListener('click',e=>{
+      mobileMenus.forEach(m=>{
+        if(!m.button.contains(e.target) && !m.menu.contains(e.target)){
+          m.menu.classList.add('hidden');
+          m.button.setAttribute('aria-expanded','false');
+          m.caret.classList.remove('rotate-180');
+        }
+      });
+    });
+  });
+})();


### PR DESCRIPTION
## Summary
- Reworked the desktop and mobile navigation to include dropdowns for Accueil, MBTI and Ennéagramme while keeping IA spécialisée, Blog and FAQ as direct links.
- Introduced a dedicated `nav.js` script handling hover/focus dropdowns on desktop and tap-to-toggle submenus on mobile with proper ARIA attributes.
- Added explicit section anchors on MBTI and Ennéagramme pages to enable submenu links to jump to the correct content.

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689ca0460e508321bd5f0ded0859a0b5