### PR TITLE
Add homepage constellation canvas background to MBTI/Enneagram/Blog banners (exact copy from index.html).

### DIFF
--- a/public/blog.html
+++ b/public/blog.html
@@ -504,7 +504,7 @@
     </header>
 
     <main>
-        <section id="hero" class="px-4 sm:px-6 lg:px-8 relative overflow-hidden pc-hero mt-8 sm:mt-12">
+        <section id="hero" class="px-4 sm:px-6 lg:px-8 relative overflow-hidden pc-hero mt-8 sm:mt-12" data-hero>
             <canvas id="pc-constellation" aria-hidden="true"></canvas>
             <div class="absolute inset-0 opacity-[0.02]">
                 <div class="absolute inset-0" style="background-image: radial-gradient(circle at 1px 1px, rgb(15 23 42) 1px, transparent 0); background-size: 40px 40px;"></div>

--- a/public/enneagramme.html
+++ b/public/enneagramme.html
@@ -502,7 +502,7 @@
     </header>
 
     <main>
-<section id="ennea-hero" class="px-4 sm:px-6 lg:px-8 relative overflow-hidden pc-hero mt-8 sm:mt-12">
+<section id="ennea-hero" class="px-4 sm:px-6 lg:px-8 relative overflow-hidden pc-hero mt-8 sm:mt-12" data-hero>
   <canvas id="pc-constellation" aria-hidden="true"></canvas>
   <div class="absolute inset-0 opacity-[0.02]">
     <div class="absolute inset-0" style="background-image: radial-gradient(circle at 1px 1px, rgb(15 23 42) 1px, transparent 0); background-size: 40px 40px;"></div>

--- a/public/mbti.html
+++ b/public/mbti.html
@@ -504,7 +504,7 @@
     </header>
 
     <main>
-<section id="mbti-hero" class="px-4 sm:px-6 lg:px-8 relative overflow-hidden pc-hero mt-8 sm:mt-12">
+<section id="mbti-hero" class="px-4 sm:px-6 lg:px-8 relative overflow-hidden pc-hero mt-8 sm:mt-12" data-hero>
   <canvas id="pc-constellation" aria-hidden="true"></canvas>
   <div class="absolute inset-0 opacity-[0.02]">
     <div class="absolute inset-0" style="background-image: radial-gradient(circle at 1px 1px, rgb(15 23 42) 1px, transparent 0); background-size: 40px 40px;"></div>


### PR DESCRIPTION
## Summary
- enable constellation canvas initialization by marking MBTI, Enneagram, and Blog hero sections with `data-hero`

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689cac8c5e048321b94cd63c071bfcb6