### PR TITLE
Rendre les onglets principaux du menu cliquables

### DIFF
--- a/public/blog-enneagramme-instincts.html
+++ b/public/blog-enneagramme-instincts.html
@@ -400,10 +400,10 @@
         </div>
         <nav class="desktop-nav hidden md:ml-6 md:flex md:items-center md:space-x-8">
             <div id="home-menu-container" class="relative group">
-                <button id="home-menu-button" class="inline-flex items-center gap-2 text-gray-900 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
+                <a id="home-menu-button" href="index.html" class="inline-flex items-center gap-2 text-gray-900 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
                     Accueil
                     <svg class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                </button>
+                </a>
                 <div id="home-menu" class="invisible opacity-0 group-hover:visible group-hover:opacity-100 transition absolute left-0 mt-2 w-64 rounded-xl shadow-lg bg-white ring-1 ring-black/5 z-50">
                     <ul class="py-2 text-sm">
                         <li><a href="index.html#home-hero" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Présentation</a></li>
@@ -414,10 +414,10 @@
                 </div>
             </div>
             <div id="mbti-menu-container" class="relative group">
-                <button id="mbti-menu-button" class="inline-flex items-center gap-2 text-gray-500 hover:text-gray-700 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
+                <a id="mbti-menu-button" href="mbti.html" class="inline-flex items-center gap-2 text-gray-500 hover:text-gray-700 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
                     MBTI
                     <svg class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                </button>
+                </a>
                 <div id="mbti-menu" class="invisible opacity-0 group-hover:visible group-hover:opacity-100 transition absolute left-0 mt-2 w-64 rounded-xl shadow-lg bg-white ring-1 ring-black/5 z-50">
                     <ul class="py-2 text-sm">
                         <li><a href="mbti.html#mbti-hero" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Comprendre le MBTI</a></li>
@@ -428,10 +428,10 @@
                 </div>
             </div>
             <div id="ennea-menu-container" class="relative group">
-                <button id="ennea-menu-button" class="inline-flex items-center gap-2 text-gray-500 hover:text-gray-700 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
+                <a id="ennea-menu-button" href="enneagramme.html" class="inline-flex items-center gap-2 text-gray-500 hover:text-gray-700 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
                     Ennéagramme
                     <svg class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                </button>
+                </a>
                 <div id="ennea-menu" class="invisible opacity-0 group-hover:visible group-hover:opacity-100 transition absolute left-0 mt-2 w-64 rounded-xl shadow-lg bg-white ring-1 ring-black/5 z-50">
                     <ul class="py-2 text-sm">
                         <li><a href="enneagramme.html#ennea-hero" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Comprendre l’Ennéagramme</a></li>
@@ -458,10 +458,10 @@
         <div class="mobile-menu md:hidden" id="mobile-menu">
             <div class="px-2 pt-2 pb-3 space-y-1 sm:px-3 bg-white border-t border-gray-200">
                 <div>
-                    <button id="mobile-home-button" class="w-full flex items-center justify-between px-3 py-2 rounded-md text-base font-medium text-gray-900" aria-expanded="false">
+                    <a id="mobile-home-button" href="index.html" class="w-full flex items-center justify-between px-3 py-2 rounded-md text-base font-medium text-gray-900" aria-expanded="false">
                         Accueil
                         <svg id="mobile-home-caret" class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                    </button>
+                    </a>
                     <div id="mobile-home-menu" class="hidden pl-4 space-y-1">
                         <a href="index.html#home-hero" class="block px-3 py-2 rounded-md text-sm text-gray-700">Présentation</a>
                         <a href="index.html#home-mbti" class="block px-3 py-2 rounded-md text-sm text-gray-700">Section MBTI</a>
@@ -470,10 +470,10 @@
                     </div>
                 </div>
                 <div>
-                    <button id="mobile-mbti-button" class="w-full flex items-center justify-between px-3 py-2 rounded-md text-base font-medium text-gray-500" aria-expanded="false">
+                    <a id="mobile-mbti-button" href="mbti.html" class="w-full flex items-center justify-between px-3 py-2 rounded-md text-base font-medium text-gray-500" aria-expanded="false">
                         MBTI
                         <svg id="mobile-mbti-caret" class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                    </button>
+                    </a>
                     <div id="mobile-mbti-menu" class="hidden pl-4 space-y-1">
                         <a href="mbti.html#mbti-hero" class="block px-3 py-2 rounded-md text-sm text-gray-700">Comprendre le MBTI</a>
                         <a href="mbti.html#mbti-history" class="block px-3 py-2 rounded-md text-sm text-gray-700">Un peu d'histoire</a>
@@ -482,10 +482,10 @@
                     </div>
                 </div>
                 <div>
-                    <button id="mobile-ennea-button" class="w-full flex items-center justify-between px-3 py-2 rounded-md text-base font-medium text-gray-500" aria-expanded="false">
+                    <a id="mobile-ennea-button" href="enneagramme.html" class="w-full flex items-center justify-between px-3 py-2 rounded-md text-base font-medium text-gray-500" aria-expanded="false">
                         Ennéagramme
                         <svg id="mobile-ennea-caret" class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                    </button>
+                    </a>
                     <div id="mobile-ennea-menu" class="hidden pl-4 space-y-1">
                         <a href="enneagramme.html#ennea-hero" class="block px-3 py-2 rounded-md text-sm text-gray-700">Comprendre l’Ennéagramme</a>
                         <a href="enneagramme.html#ennea-history" class="block px-3 py-2 rounded-md text-sm text-gray-700">Un peu d'histoire</a>

--- a/public/blog-mbti-4-dimensions.html
+++ b/public/blog-mbti-4-dimensions.html
@@ -400,10 +400,10 @@
         </div>
         <nav class="desktop-nav hidden md:ml-6 md:flex md:items-center md:space-x-8">
             <div id="home-menu-container" class="relative group">
-                <button id="home-menu-button" class="inline-flex items-center gap-2 text-gray-900 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
+                <a id="home-menu-button" href="index.html" class="inline-flex items-center gap-2 text-gray-900 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
                     Accueil
                     <svg class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                </button>
+                </a>
                 <div id="home-menu" class="invisible opacity-0 group-hover:visible group-hover:opacity-100 transition absolute left-0 mt-2 w-64 rounded-xl shadow-lg bg-white ring-1 ring-black/5 z-50">
                     <ul class="py-2 text-sm">
                         <li><a href="index.html#home-hero" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Présentation</a></li>
@@ -414,10 +414,10 @@
                 </div>
             </div>
             <div id="mbti-menu-container" class="relative group">
-                <button id="mbti-menu-button" class="inline-flex items-center gap-2 text-gray-500 hover:text-gray-700 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
+                <a id="mbti-menu-button" href="mbti.html" class="inline-flex items-center gap-2 text-gray-500 hover:text-gray-700 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
                     MBTI
                     <svg class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                </button>
+                </a>
                 <div id="mbti-menu" class="invisible opacity-0 group-hover:visible group-hover:opacity-100 transition absolute left-0 mt-2 w-64 rounded-xl shadow-lg bg-white ring-1 ring-black/5 z-50">
                     <ul class="py-2 text-sm">
                         <li><a href="mbti.html#mbti-hero" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Comprendre le MBTI</a></li>
@@ -428,10 +428,10 @@
                 </div>
             </div>
             <div id="ennea-menu-container" class="relative group">
-                <button id="ennea-menu-button" class="inline-flex items-center gap-2 text-gray-500 hover:text-gray-700 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
+                <a id="ennea-menu-button" href="enneagramme.html" class="inline-flex items-center gap-2 text-gray-500 hover:text-gray-700 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
                     Ennéagramme
                     <svg class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                </button>
+                </a>
                 <div id="ennea-menu" class="invisible opacity-0 group-hover:visible group-hover:opacity-100 transition absolute left-0 mt-2 w-64 rounded-xl shadow-lg bg-white ring-1 ring-black/5 z-50">
                     <ul class="py-2 text-sm">
                         <li><a href="enneagramme.html#ennea-hero" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Comprendre l’Ennéagramme</a></li>
@@ -458,10 +458,10 @@
         <div class="mobile-menu md:hidden" id="mobile-menu">
             <div class="px-2 pt-2 pb-3 space-y-1 sm:px-3 bg-white border-t border-gray-200">
                 <div>
-                    <button id="mobile-home-button" class="w-full flex items-center justify-between px-3 py-2 rounded-md text-base font-medium text-gray-900" aria-expanded="false">
+                    <a id="mobile-home-button" href="index.html" class="w-full flex items-center justify-between px-3 py-2 rounded-md text-base font-medium text-gray-900" aria-expanded="false">
                         Accueil
                         <svg id="mobile-home-caret" class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                    </button>
+                    </a>
                     <div id="mobile-home-menu" class="hidden pl-4 space-y-1">
                         <a href="index.html#home-hero" class="block px-3 py-2 rounded-md text-sm text-gray-700">Présentation</a>
                         <a href="index.html#home-mbti" class="block px-3 py-2 rounded-md text-sm text-gray-700">Section MBTI</a>
@@ -470,10 +470,10 @@
                     </div>
                 </div>
                 <div>
-                    <button id="mobile-mbti-button" class="w-full flex items-center justify-between px-3 py-2 rounded-md text-base font-medium text-gray-500" aria-expanded="false">
+                    <a id="mobile-mbti-button" href="mbti.html" class="w-full flex items-center justify-between px-3 py-2 rounded-md text-base font-medium text-gray-500" aria-expanded="false">
                         MBTI
                         <svg id="mobile-mbti-caret" class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                    </button>
+                    </a>
                     <div id="mobile-mbti-menu" class="hidden pl-4 space-y-1">
                         <a href="mbti.html#mbti-hero" class="block px-3 py-2 rounded-md text-sm text-gray-700">Comprendre le MBTI</a>
                         <a href="mbti.html#mbti-history" class="block px-3 py-2 rounded-md text-sm text-gray-700">Un peu d'histoire</a>
@@ -482,10 +482,10 @@
                     </div>
                 </div>
                 <div>
-                    <button id="mobile-ennea-button" class="w-full flex items-center justify-between px-3 py-2 rounded-md text-base font-medium text-gray-500" aria-expanded="false">
+                    <a id="mobile-ennea-button" href="enneagramme.html" class="w-full flex items-center justify-between px-3 py-2 rounded-md text-base font-medium text-gray-500" aria-expanded="false">
                         Ennéagramme
                         <svg id="mobile-ennea-caret" class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                    </button>
+                    </a>
                     <div id="mobile-ennea-menu" class="hidden pl-4 space-y-1">
                         <a href="enneagramme.html#ennea-hero" class="block px-3 py-2 rounded-md text-sm text-gray-700">Comprendre l’Ennéagramme</a>
                         <a href="enneagramme.html#ennea-history" class="block px-3 py-2 rounded-md text-sm text-gray-700">Un peu d'histoire</a>

--- a/public/blog.html
+++ b/public/blog.html
@@ -400,10 +400,10 @@
         </div>
         <nav class="desktop-nav hidden md:ml-6 md:flex md:items-center md:space-x-8">
             <div id="home-menu-container" class="relative group">
-                <button id="home-menu-button" class="inline-flex items-center gap-2 text-gray-900 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
+                <a id="home-menu-button" href="index.html" class="inline-flex items-center gap-2 text-gray-900 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
                     Accueil
                     <svg class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                </button>
+                </a>
                 <div id="home-menu" class="invisible opacity-0 group-hover:visible group-hover:opacity-100 transition absolute left-0 mt-2 w-64 rounded-xl shadow-lg bg-white ring-1 ring-black/5 z-50">
                     <ul class="py-2 text-sm">
                         <li><a href="index.html#home-hero" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Présentation</a></li>
@@ -414,10 +414,10 @@
                 </div>
             </div>
             <div id="mbti-menu-container" class="relative group">
-                <button id="mbti-menu-button" class="inline-flex items-center gap-2 text-gray-500 hover:text-gray-700 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
+                <a id="mbti-menu-button" href="mbti.html" class="inline-flex items-center gap-2 text-gray-500 hover:text-gray-700 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
                     MBTI
                     <svg class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                </button>
+                </a>
                 <div id="mbti-menu" class="invisible opacity-0 group-hover:visible group-hover:opacity-100 transition absolute left-0 mt-2 w-64 rounded-xl shadow-lg bg-white ring-1 ring-black/5 z-50">
                     <ul class="py-2 text-sm">
                         <li><a href="mbti.html#mbti-hero" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Comprendre le MBTI</a></li>
@@ -428,10 +428,10 @@
                 </div>
             </div>
             <div id="ennea-menu-container" class="relative group">
-                <button id="ennea-menu-button" class="inline-flex items-center gap-2 text-gray-500 hover:text-gray-700 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
+                <a id="ennea-menu-button" href="enneagramme.html" class="inline-flex items-center gap-2 text-gray-500 hover:text-gray-700 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
                     Ennéagramme
                     <svg class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                </button>
+                </a>
                 <div id="ennea-menu" class="invisible opacity-0 group-hover:visible group-hover:opacity-100 transition absolute left-0 mt-2 w-64 rounded-xl shadow-lg bg-white ring-1 ring-black/5 z-50">
                     <ul class="py-2 text-sm">
                         <li><a href="enneagramme.html#ennea-hero" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Comprendre l’Ennéagramme</a></li>
@@ -458,10 +458,10 @@
         <div class="mobile-menu md:hidden" id="mobile-menu">
             <div class="px-2 pt-2 pb-3 space-y-1 sm:px-3 bg-white border-t border-gray-200">
                 <div>
-                    <button id="mobile-home-button" class="w-full flex items-center justify-between px-3 py-2 rounded-md text-base font-medium text-gray-900" aria-expanded="false">
+                    <a id="mobile-home-button" href="index.html" class="w-full flex items-center justify-between px-3 py-2 rounded-md text-base font-medium text-gray-900" aria-expanded="false">
                         Accueil
                         <svg id="mobile-home-caret" class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                    </button>
+                    </a>
                     <div id="mobile-home-menu" class="hidden pl-4 space-y-1">
                         <a href="index.html#home-hero" class="block px-3 py-2 rounded-md text-sm text-gray-700">Présentation</a>
                         <a href="index.html#home-mbti" class="block px-3 py-2 rounded-md text-sm text-gray-700">Section MBTI</a>
@@ -470,10 +470,10 @@
                     </div>
                 </div>
                 <div>
-                    <button id="mobile-mbti-button" class="w-full flex items-center justify-between px-3 py-2 rounded-md text-base font-medium text-gray-500" aria-expanded="false">
+                    <a id="mobile-mbti-button" href="mbti.html" class="w-full flex items-center justify-between px-3 py-2 rounded-md text-base font-medium text-gray-500" aria-expanded="false">
                         MBTI
                         <svg id="mobile-mbti-caret" class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                    </button>
+                    </a>
                     <div id="mobile-mbti-menu" class="hidden pl-4 space-y-1">
                         <a href="mbti.html#mbti-hero" class="block px-3 py-2 rounded-md text-sm text-gray-700">Comprendre le MBTI</a>
                         <a href="mbti.html#mbti-history" class="block px-3 py-2 rounded-md text-sm text-gray-700">Un peu d'histoire</a>
@@ -482,10 +482,10 @@
                     </div>
                 </div>
                 <div>
-                    <button id="mobile-ennea-button" class="w-full flex items-center justify-between px-3 py-2 rounded-md text-base font-medium text-gray-500" aria-expanded="false">
+                    <a id="mobile-ennea-button" href="enneagramme.html" class="w-full flex items-center justify-between px-3 py-2 rounded-md text-base font-medium text-gray-500" aria-expanded="false">
                         Ennéagramme
                         <svg id="mobile-ennea-caret" class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                    </button>
+                    </a>
                     <div id="mobile-ennea-menu" class="hidden pl-4 space-y-1">
                         <a href="enneagramme.html#ennea-hero" class="block px-3 py-2 rounded-md text-sm text-gray-700">Comprendre l’Ennéagramme</a>
                         <a href="enneagramme.html#ennea-history" class="block px-3 py-2 rounded-md text-sm text-gray-700">Un peu d'histoire</a>

--- a/public/enneagramme.html
+++ b/public/enneagramme.html
@@ -400,10 +400,10 @@
         </div>
         <nav class="desktop-nav hidden md:ml-6 md:flex md:items-center md:space-x-8">
             <div id="home-menu-container" class="relative group">
-                <button id="home-menu-button" class="inline-flex items-center gap-2 text-gray-900 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
+                <a id="home-menu-button" href="index.html" class="inline-flex items-center gap-2 text-gray-900 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
                     Accueil
                     <svg class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                </button>
+                </a>
                 <div id="home-menu" class="invisible opacity-0 group-hover:visible group-hover:opacity-100 transition absolute left-0 mt-2 w-64 rounded-xl shadow-lg bg-white ring-1 ring-black/5 z-50">
                     <ul class="py-2 text-sm">
                         <li><a href="index.html#home-hero" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Présentation</a></li>
@@ -414,10 +414,10 @@
                 </div>
             </div>
             <div id="mbti-menu-container" class="relative group">
-                <button id="mbti-menu-button" class="inline-flex items-center gap-2 text-gray-500 hover:text-gray-700 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
+                <a id="mbti-menu-button" href="mbti.html" class="inline-flex items-center gap-2 text-gray-500 hover:text-gray-700 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
                     MBTI
                     <svg class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                </button>
+                </a>
                 <div id="mbti-menu" class="invisible opacity-0 group-hover:visible group-hover:opacity-100 transition absolute left-0 mt-2 w-64 rounded-xl shadow-lg bg-white ring-1 ring-black/5 z-50">
                     <ul class="py-2 text-sm">
                         <li><a href="mbti.html#mbti-hero" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Comprendre le MBTI</a></li>
@@ -428,10 +428,10 @@
                 </div>
             </div>
             <div id="ennea-menu-container" class="relative group">
-                <button id="ennea-menu-button" class="inline-flex items-center gap-2 text-gray-500 hover:text-gray-700 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
+                <a id="ennea-menu-button" href="enneagramme.html" class="inline-flex items-center gap-2 text-gray-500 hover:text-gray-700 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
                     Ennéagramme
                     <svg class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                </button>
+                </a>
                 <div id="ennea-menu" class="invisible opacity-0 group-hover:visible group-hover:opacity-100 transition absolute left-0 mt-2 w-64 rounded-xl shadow-lg bg-white ring-1 ring-black/5 z-50">
                     <ul class="py-2 text-sm">
                         <li><a href="enneagramme.html#ennea-hero" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Comprendre l’Ennéagramme</a></li>
@@ -456,10 +456,10 @@
         <div class="mobile-menu md:hidden" id="mobile-menu">
             <div class="px-2 pt-2 pb-3 space-y-1 sm:px-3 bg-white border-t border-gray-200">
                 <div>
-                    <button id="mobile-home-button" class="w-full flex items-center justify-between px-3 py-2 rounded-md text-base font-medium text-gray-900" aria-expanded="false">
+                    <a id="mobile-home-button" href="index.html" class="w-full flex items-center justify-between px-3 py-2 rounded-md text-base font-medium text-gray-900" aria-expanded="false">
                         Accueil
                         <svg id="mobile-home-caret" class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                    </button>
+                    </a>
                     <div id="mobile-home-menu" class="hidden pl-4 space-y-1">
                         <a href="index.html#home-hero" class="block px-3 py-2 rounded-md text-sm text-gray-700">Présentation</a>
                         <a href="index.html#home-mbti" class="block px-3 py-2 rounded-md text-sm text-gray-700">Section MBTI</a>
@@ -468,10 +468,10 @@
                     </div>
                 </div>
                 <div>
-                    <button id="mobile-mbti-button" class="w-full flex items-center justify-between px-3 py-2 rounded-md text-base font-medium text-gray-500" aria-expanded="false">
+                    <a id="mobile-mbti-button" href="mbti.html" class="w-full flex items-center justify-between px-3 py-2 rounded-md text-base font-medium text-gray-500" aria-expanded="false">
                         MBTI
                         <svg id="mobile-mbti-caret" class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                    </button>
+                    </a>
                     <div id="mobile-mbti-menu" class="hidden pl-4 space-y-1">
                         <a href="mbti.html#mbti-hero" class="block px-3 py-2 rounded-md text-sm text-gray-700">Comprendre le MBTI</a>
                         <a href="mbti.html#mbti-history" class="block px-3 py-2 rounded-md text-sm text-gray-700">Un peu d'histoire</a>
@@ -480,10 +480,10 @@
                     </div>
                 </div>
                 <div>
-                    <button id="mobile-ennea-button" class="w-full flex items-center justify-between px-3 py-2 rounded-md text-base font-medium text-gray-500" aria-expanded="false">
+                    <a id="mobile-ennea-button" href="enneagramme.html" class="w-full flex items-center justify-between px-3 py-2 rounded-md text-base font-medium text-gray-500" aria-expanded="false">
                         Ennéagramme
                         <svg id="mobile-ennea-caret" class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                    </button>
+                    </a>
                     <div id="mobile-ennea-menu" class="hidden pl-4 space-y-1">
                         <a href="enneagramme.html#ennea-hero" class="block px-3 py-2 rounded-md text-sm text-gray-700">Comprendre l’Ennéagramme</a>
                         <a href="enneagramme.html#ennea-history" class="block px-3 py-2 rounded-md text-sm text-gray-700">Un peu d'histoire</a>

--- a/public/index.html
+++ b/public/index.html
@@ -400,10 +400,10 @@
         </div>
         <nav class="desktop-nav hidden md:ml-6 md:flex md:items-center md:space-x-8">
             <div id="home-menu-container" class="relative">
-                <button id="home-menu-button" class="inline-flex items-center gap-2 text-gray-900 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
+                <a id="home-menu-button" href="index.html" class="inline-flex items-center gap-2 text-gray-900 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
                     Accueil
                     <svg class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                </button>
+                </a>
                 <div id="home-menu" class="invisible opacity-0 transition absolute left-0 mt-2 w-64 rounded-xl shadow-lg bg-white ring-1 ring-black/5 z-50">
                     <ul class="py-2 text-sm">
                         <li><a href="index.html#home-how" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Comment ça marche</a></li>
@@ -418,10 +418,10 @@
                 </div>
             </div>
             <div id="mbti-menu-container" class="relative">
-                <button id="mbti-menu-button" class="inline-flex items-center gap-2 text-gray-500 hover:text-gray-700 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
+                <a id="mbti-menu-button" href="mbti.html" class="inline-flex items-center gap-2 text-gray-500 hover:text-gray-700 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
                     MBTI
                     <svg class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                </button>
+                </a>
                 <div id="mbti-menu" class="invisible opacity-0 transition absolute left-0 mt-2 w-64 rounded-xl shadow-lg bg-white ring-1 ring-black/5 z-50">
                     <ul class="py-2 text-sm">
                         <li><a href="mbti.html#mbti-hero" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Comprendre le MBTI</a></li>
@@ -432,10 +432,10 @@
                 </div>
             </div>
             <div id="ennea-menu-container" class="relative">
-                <button id="ennea-menu-button" class="inline-flex items-center gap-2 text-gray-500 hover:text-gray-700 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
+                <a id="ennea-menu-button" href="enneagramme.html" class="inline-flex items-center gap-2 text-gray-500 hover:text-gray-700 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
                     Ennéagramme
                     <svg class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                </button>
+                </a>
                 <div id="ennea-menu" class="invisible opacity-0 transition absolute left-0 mt-2 w-64 rounded-xl shadow-lg bg-white ring-1 ring-black/5 z-50">
                     <ul class="py-2 text-sm">
                         <li><a href="enneagramme.html#ennea-hero" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Comprendre l’Ennéagramme</a></li>
@@ -462,10 +462,10 @@
         <div class="mobile-menu md:hidden" id="mobile-menu">
             <div class="px-2 pt-2 pb-3 space-y-1 sm:px-3 bg-white border-t border-gray-200">
                 <div>
-                    <button id="mobile-home-button" class="w-full flex items-center justify-between px-3 py-2 rounded-md text-base font-medium text-gray-900" aria-expanded="false">
+                    <a id="mobile-home-button" href="index.html" class="w-full flex items-center justify-between px-3 py-2 rounded-md text-base font-medium text-gray-900" aria-expanded="false">
                         Accueil
                         <svg id="mobile-home-caret" class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                    </button>
+                    </a>
                     <div id="mobile-home-menu" class="hidden pl-4 space-y-1">
                         <a href="index.html#home-how" class="block px-3 py-2 rounded-md text-sm text-gray-700">Comment ça marche</a>
                         <a href="index.html#home-mbti" class="block px-3 py-2 rounded-md text-sm text-gray-700">Auto-évaluation</a>
@@ -478,10 +478,10 @@
                     </div>
                 </div>
                 <div>
-                    <button id="mobile-mbti-button" class="w-full flex items-center justify-between px-3 py-2 rounded-md text-base font-medium text-gray-500" aria-expanded="false">
+                    <a id="mobile-mbti-button" href="mbti.html" class="w-full flex items-center justify-between px-3 py-2 rounded-md text-base font-medium text-gray-500" aria-expanded="false">
                         MBTI
                         <svg id="mobile-mbti-caret" class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                    </button>
+                    </a>
                     <div id="mobile-mbti-menu" class="hidden pl-4 space-y-1">
                         <a href="mbti.html#mbti-hero" class="block px-3 py-2 rounded-md text-sm text-gray-700">Comprendre le MBTI</a>
                         <a href="mbti.html#mbti-history" class="block px-3 py-2 rounded-md text-sm text-gray-700">Un peu d'histoire</a>
@@ -490,10 +490,10 @@
                     </div>
                 </div>
                 <div>
-                    <button id="mobile-ennea-button" class="w-full flex items-center justify-between px-3 py-2 rounded-md text-base font-medium text-gray-500" aria-expanded="false">
+                    <a id="mobile-ennea-button" href="enneagramme.html" class="w-full flex items-center justify-between px-3 py-2 rounded-md text-base font-medium text-gray-500" aria-expanded="false">
                         Ennéagramme
                         <svg id="mobile-ennea-caret" class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                    </button>
+                    </a>
                     <div id="mobile-ennea-menu" class="hidden pl-4 space-y-1">
                         <a href="enneagramme.html#ennea-hero" class="block px-3 py-2 rounded-md text-sm text-gray-700">Comprendre l’Ennéagramme</a>
                         <a href="enneagramme.html#ennea-history" class="block px-3 py-2 rounded-md text-sm text-gray-700">Un peu d'histoire</a>

--- a/public/mbti.html
+++ b/public/mbti.html
@@ -400,10 +400,10 @@
         </div>
         <nav class="desktop-nav hidden md:ml-6 md:flex md:items-center md:space-x-8">
             <div id="home-menu-container" class="relative group">
-                <button id="home-menu-button" class="inline-flex items-center gap-2 text-gray-900 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
+                <a id="home-menu-button" href="index.html" class="inline-flex items-center gap-2 text-gray-900 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
                     Accueil
                     <svg class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                </button>
+                </a>
                 <div id="home-menu" class="invisible opacity-0 group-hover:visible group-hover:opacity-100 transition absolute left-0 mt-2 w-64 rounded-xl shadow-lg bg-white ring-1 ring-black/5 z-50">
                     <ul class="py-2 text-sm">
                         <li><a href="index.html#home-hero" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Présentation</a></li>
@@ -414,10 +414,10 @@
                 </div>
             </div>
             <div id="mbti-menu-container" class="relative group">
-                <button id="mbti-menu-button" class="inline-flex items-center gap-2 text-gray-500 hover:text-gray-700 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
+                <a id="mbti-menu-button" href="mbti.html" class="inline-flex items-center gap-2 text-gray-500 hover:text-gray-700 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
                     MBTI
                     <svg class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                </button>
+                </a>
                 <div id="mbti-menu" class="invisible opacity-0 group-hover:visible group-hover:opacity-100 transition absolute left-0 mt-2 w-64 rounded-xl shadow-lg bg-white ring-1 ring-black/5 z-50">
                     <ul class="py-2 text-sm">
                         <li><a href="mbti.html#mbti-hero" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Comprendre le MBTI</a></li>
@@ -428,10 +428,10 @@
                 </div>
             </div>
             <div id="ennea-menu-container" class="relative group">
-                <button id="ennea-menu-button" class="inline-flex items-center gap-2 text-gray-500 hover:text-gray-700 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
+                <a id="ennea-menu-button" href="enneagramme.html" class="inline-flex items-center gap-2 text-gray-500 hover:text-gray-700 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
                     Ennéagramme
                     <svg class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                </button>
+                </a>
                 <div id="ennea-menu" class="invisible opacity-0 group-hover:visible group-hover:opacity-100 transition absolute left-0 mt-2 w-64 rounded-xl shadow-lg bg-white ring-1 ring-black/5 z-50">
                     <ul class="py-2 text-sm">
                         <li><a href="enneagramme.html#ennea-hero" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Comprendre l’Ennéagramme</a></li>
@@ -458,10 +458,10 @@
         <div class="mobile-menu md:hidden" id="mobile-menu">
             <div class="px-2 pt-2 pb-3 space-y-1 sm:px-3 bg-white border-t border-gray-200">
                 <div>
-                    <button id="mobile-home-button" class="w-full flex items-center justify-between px-3 py-2 rounded-md text-base font-medium text-gray-900" aria-expanded="false">
+                    <a id="mobile-home-button" href="index.html" class="w-full flex items-center justify-between px-3 py-2 rounded-md text-base font-medium text-gray-900" aria-expanded="false">
                         Accueil
                         <svg id="mobile-home-caret" class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                    </button>
+                    </a>
                     <div id="mobile-home-menu" class="hidden pl-4 space-y-1">
                         <a href="index.html#home-hero" class="block px-3 py-2 rounded-md text-sm text-gray-700">Présentation</a>
                         <a href="index.html#home-mbti" class="block px-3 py-2 rounded-md text-sm text-gray-700">Section MBTI</a>
@@ -470,10 +470,10 @@
                     </div>
                 </div>
                 <div>
-                    <button id="mobile-mbti-button" class="w-full flex items-center justify-between px-3 py-2 rounded-md text-base font-medium text-gray-500" aria-expanded="false">
+                    <a id="mobile-mbti-button" href="mbti.html" class="w-full flex items-center justify-between px-3 py-2 rounded-md text-base font-medium text-gray-500" aria-expanded="false">
                         MBTI
                         <svg id="mobile-mbti-caret" class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                    </button>
+                    </a>
                     <div id="mobile-mbti-menu" class="hidden pl-4 space-y-1">
                         <a href="mbti.html#mbti-hero" class="block px-3 py-2 rounded-md text-sm text-gray-700">Comprendre le MBTI</a>
                         <a href="mbti.html#mbti-history" class="block px-3 py-2 rounded-md text-sm text-gray-700">Un peu d'histoire</a>
@@ -482,10 +482,10 @@
                     </div>
                 </div>
                 <div>
-                    <button id="mobile-ennea-button" class="w-full flex items-center justify-between px-3 py-2 rounded-md text-base font-medium text-gray-500" aria-expanded="false">
+                    <a id="mobile-ennea-button" href="enneagramme.html" class="w-full flex items-center justify-between px-3 py-2 rounded-md text-base font-medium text-gray-500" aria-expanded="false">
                         Ennéagramme
                         <svg id="mobile-ennea-caret" class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                    </button>
+                    </a>
                     <div id="mobile-ennea-menu" class="hidden pl-4 space-y-1">
                         <a href="enneagramme.html#ennea-hero" class="block px-3 py-2 rounded-md text-sm text-gray-700">Comprendre l’Ennéagramme</a>
                         <a href="enneagramme.html#ennea-history" class="block px-3 py-2 rounded-md text-sm text-gray-700">Un peu d'histoire</a>

--- a/public/nav.js
+++ b/public/nav.js
@@ -53,14 +53,15 @@
     })).filter(obj=>obj.button&&obj.menu&&obj.caret);
 
     mobileMenus.forEach(current=>{
-      current.button.addEventListener('click',()=>{
+      current.button.addEventListener('click',e=>{
         const expanded=current.button.getAttribute('aria-expanded')==='true';
-        mobileMenus.forEach(other=>{
-          other.menu.classList.add('hidden');
-          other.button.setAttribute('aria-expanded','false');
-          other.caret.classList.remove('rotate-180');
-        });
         if(!expanded){
+          e.preventDefault();
+          mobileMenus.forEach(other=>{
+            other.menu.classList.add('hidden');
+            other.button.setAttribute('aria-expanded','false');
+            other.caret.classList.remove('rotate-180');
+          });
           current.menu.classList.remove('hidden');
           current.button.setAttribute('aria-expanded','true');
           current.caret.classList.add('rotate-180');


### PR DESCRIPTION
## Summary
- Permettre d'accéder directement aux pages Accueil, MBTI et Ennéagramme depuis le menu principal
- Sur mobile, un premier tap ouvre le sous-menu et le second lance la navigation

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_689cb017287c8321a47729a03ed3b07a