### PR TITLE
fix: keep mobile menu open until second tap

### DIFF
--- a/public/nav.js
+++ b/public/nav.js
@@ -72,7 +72,7 @@
           current.button.setAttribute('aria-expanded','true');
           current.caret.classList.add('rotate-180');
         }
-      });
+      },{capture:true});
     });
 
     document.addEventListener('click',e=>{


### PR DESCRIPTION
## Summary
- ensure "Accueil", "MBTI" and "Ennéagramme" mobile links open their submenu on first tap and navigate on second tap

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689cb4c98570832185ddcfa67dbd21a5