### PR TITLE
Refactor scoring to cognitive functions

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1823,124 +1823,87 @@ const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBh
         }
 
        function computeWeightedResults(evaluations) {
-    const baseWeights = {
-        family: 30,
-        partner: 25,
-        friend: 25,
-        colleague: 15
-    };
-
-    const combinedMbti = { E: 0, I: 0, S: 0, N: 0, T: 0, F: 0, J: 0, P: 0 };
-    const combinedEnneagram = { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0, 6: 0, 7: 0, 8: 0, 9: 0 };
-
-    const availableRelations = {};
-    let totalBaseWeight = 0;
-
-    evaluations.forEach(ev => {
-        if (baseWeights[ev.relation]) {
-            if (!availableRelations[ev.relation]) {
-                availableRelations[ev.relation] = [];
-                totalBaseWeight += baseWeights[ev.relation];
-            }
-            availableRelations[ev.relation].push(ev);
-        }
-    });
-
-    if (totalBaseWeight === 0) {
+    const functions = ['Fi','Fe','Ti','Te','Ni','Ne','Si','Se'];
+    const types = ['1','2','3','4','5','6','7','8','9'];
+    if (!Array.isArray(evaluations) || evaluations.length === 0) {
         return {
             mbtiType: null,
             enneagramType: null,
-            mbtiCertainty: 0,
-            enneagramCertainty: 0,
-            overallCertainty: 0,
-            combinedMbti,
-            combinedEnneagram
+            enneagramWing: null,
+            mbtiPercentages: {},
+            mbtiStack: [],
+            mbtiConvergence: 0,
+            enneagramConvergence: 0,
+            overallCertainty: 0
         };
     }
 
-    const normalizedWeights = {};
-    Object.keys(availableRelations).forEach(relation => {
-        normalizedWeights[relation] = (baseWeights[relation] / totalBaseWeight) * 100;
-    });
-
-    Object.keys(availableRelations).forEach(relation => {
-        const weight = normalizedWeights[relation];
-        const relEvaluations = availableRelations[relation];
-        const avgMbti = { E: 0, I: 0, S: 0, N: 0, T: 0, F: 0, J: 0, P: 0 };
-        const avgEnneagram = { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0, 6: 0, 7: 0, 8: 0, 9: 0 };
-
-        relEvaluations.forEach(ev => {
-            Object.keys(ev.mbti_scores).forEach(trait => {
-                avgMbti[trait] += ev.mbti_scores[trait];
-            });
-            Object.keys(ev.enneagram_scores).forEach(type => {
-                avgEnneagram[type] += ev.enneagram_scores[type];
-            });
+    const avg = (keys, field) => {
+        const totals = Object.fromEntries(keys.map(k => [k, 0]));
+        evaluations.forEach(ev => {
+            const scores = ev[field] || {};
+            keys.forEach(k => { totals[k] += Number(scores[k] || 0); });
         });
+        const count = evaluations.length;
+        return Object.fromEntries(keys.map(k => [k, totals[k] / count]));
+    };
 
-        Object.keys(avgMbti).forEach(trait => {
-            avgMbti[trait] = avgMbti[trait] / relEvaluations.length;
-            combinedMbti[trait] += avgMbti[trait] * (weight / 100);
-        });
-        Object.keys(avgEnneagram).forEach(type => {
-            avgEnneagram[type] = avgEnneagram[type] / relEvaluations.length;
-            combinedEnneagram[type] += avgEnneagram[type] * (weight / 100);
-        });
-    });
+    const avgFunc = avg(functions, 'function_scores');
+    const avgEnnea = avg(types, 'enneagram_scores');
 
+    const E = avgFunc.Fe + avgFunc.Te + avgFunc.Se + avgFunc.Ne;
+    const I = avgFunc.Fi + avgFunc.Ti + avgFunc.Si + avgFunc.Ni;
+    const S = avgFunc.Si + avgFunc.Se;
+    const N = avgFunc.Ni + avgFunc.Ne;
+    const T = avgFunc.Ti + avgFunc.Te;
+    const F = avgFunc.Fi + avgFunc.Fe;
+    const J = avgFunc.Te + avgFunc.Fe;
+    const P = avgFunc.Se + avgFunc.Ne;
     const mbtiType =
-        (combinedMbti.E > combinedMbti.I ? 'E' : 'I') +
-        (combinedMbti.S > combinedMbti.N ? 'S' : 'N') +
-        (combinedMbti.T > combinedMbti.F ? 'T' : 'F') +
-        (combinedMbti.J > combinedMbti.P ? 'J' : 'P');
+        (E >= I ? 'E' : 'I') +
+        (S >= N ? 'S' : 'N') +
+        (T >= F ? 'T' : 'F') +
+        (J >= P ? 'J' : 'P');
 
-    let topEnnea = '1';
-    Object.keys(combinedEnneagram).forEach(type => {
-        if (combinedEnneagram[type] > combinedEnneagram[topEnnea]) {
-            topEnnea = type;
-        }
-    });
+    const mbtiStack = Object.entries(avgFunc)
+        .sort((a,b)=>b[1]-a[1])
+        .slice(0,4)
+        .map(([f])=>f);
+    const totalFunc = Object.values(avgFunc).reduce((a,b)=>a+b,0);
+    const mbtiPercentages = Object.fromEntries(functions.map(f=>[f, totalFunc?Math.round(avgFunc[f]/totalFunc*100):0]));
 
-    const mbtiTypes = [];
-    const enneagramTypes = [];
+    let enneagramType = null; let max = -Infinity;
+    Object.entries(avgEnnea).forEach(([t,v])=>{ if(v>max){max=v; enneagramType=t;} });
+    const left = enneagramType==='1'?'9':String(Number(enneagramType)-1);
+    const right = enneagramType==='9'?'1':String(Number(enneagramType)+1);
+    const enneagramWing = avgEnnea[left] >= avgEnnea[right] ? left : right;
 
-    evaluations.forEach(ev => {
-        const evMbtiType =
-            (ev.mbti_scores.E > ev.mbti_scores.I ? 'E' : 'I') +
-            (ev.mbti_scores.S > ev.mbti_scores.N ? 'S' : 'N') +
-            (ev.mbti_scores.T > ev.mbti_scores.F ? 'T' : 'F') +
-            (ev.mbti_scores.J > ev.mbti_scores.P ? 'J' : 'P');
-        const evEnneaType = Object.keys(ev.enneagram_scores).reduce((a, b) =>
-            ev.enneagram_scores[a] > ev.enneagram_scores[b] ? a : b
-        );
-        mbtiTypes.push(evMbtiType);
-        enneagramTypes.push(evEnneaType);
-    });
-
-    const mbtiFreq = {};
-    mbtiTypes.forEach(type => {
-        mbtiFreq[type] = (mbtiFreq[type] || 0) + 1;
-    });
-    const mbtiMaxFreq = Math.max(...Object.values(mbtiFreq));
-    const mbtiCertainty = Math.round((mbtiMaxFreq / mbtiTypes.length) * 100);
-
-    const enneaFreq = {};
-    enneagramTypes.forEach(type => {
-        enneaFreq[type] = (enneaFreq[type] || 0) + 1;
-    });
-    const enneaMaxFreq = Math.max(...Object.values(enneaFreq));
-    const enneagramCertainty = Math.round((enneaMaxFreq / enneagramTypes.length) * 100);
-
-    const overallCertainty = Math.round((mbtiCertainty + enneagramCertainty) / 2);
+    const convergence = (keys, field) => {
+        if (evaluations.length<=1) return 100;
+        const means = avg(keys, field);
+        let dev = 0;
+        evaluations.forEach(ev=>{
+            const scores=ev[field]||{};
+            keys.forEach(k=>{dev += Math.abs(Number(scores[k]||0)-means[k]);});
+        });
+        const maxDev = evaluations.length * keys.length * 3;
+        return Math.round((1 - Math.min(dev/maxDev,1)) * 100);
+    };
+    const mbtiConvergence = convergence(functions, 'function_scores');
+    const enneagramConvergence = convergence(types, 'enneagram_scores');
+    const overallCertainty = Math.round((mbtiConvergence + enneagramConvergence)/2);
 
     return {
         mbtiType,
-        enneagramType: topEnnea,
-        mbtiCertainty,
-        enneagramCertainty,
+        enneagramType,
+        enneagramWing,
+        mbtiPercentages,
+        mbtiStack,
+        mbtiConvergence,
+        enneagramConvergence,
         overallCertainty,
-        combinedMbti,
-        combinedEnneagram
+        functionAverages: avgFunc,
+        enneagramAverages: avgEnnea
     };
 }
 
@@ -1976,8 +1939,8 @@ async function calculateFinalProfile(code) {
                 mbti_type: weighted.mbtiType,
                 enneagram_type: weighted.enneagramType,
                 certainty_score: overallCertainty,
-                mbti_scores: weighted.combinedMbti,
-                enneagram_scores: weighted.combinedEnneagram
+                mbti_scores: weighted.functionAverages,
+                enneagram_scores: weighted.enneagramAverages
             })
             .eq('code', code);
 
@@ -1987,13 +1950,13 @@ async function calculateFinalProfile(code) {
                 code,
                 mbti_type: weighted.mbtiType,
                 enneagram_type: weighted.enneagramType,
-                mbti_scores: weighted.combinedMbti,
-                enneagram_scores: weighted.combinedEnneagram,
+                mbti_scores: weighted.functionAverages,
+                enneagram_scores: weighted.enneagramAverages,
                 certainty_score: overallCertainty
             },
             evaluations,
-            mbtiCertainty: weighted.mbtiCertainty,
-            enneagramCertainty: weighted.enneagramCertainty,
+            mbtiCertainty: weighted.mbtiConvergence,
+            enneagramCertainty: weighted.enneagramConvergence,
             overallCertainty
         };
     } catch (err) {

--- a/public/questions-v2.js
+++ b/public/questions-v2.js
@@ -1,0 +1,337 @@
+// Nouveau questionnaire basé sur les fonctions cognitives et l'ennéagramme
+
+const AUTO_QUESTIONS = [
+  {
+    id: 1,
+    question: "Quand vous devez trancher un choix personnel, vous privilégiez…",
+    options: [
+      { text: "ce qui résonne avec vos valeurs intérieures", functions: { Fi: 3 }, enneagram: { 4: 2, 9: 1 } },
+      { text: "l'impact que cela aura sur l'harmonie autour de vous", functions: { Fe: 3 }, enneagram: { 2: 2, 6: 1 } },
+      { text: "la solution la plus efficace et mesurable", functions: { Te: 3 }, enneagram: { 1: 2, 3: 1 } }
+    ]
+  },
+  {
+    id: 2,
+    question: "Pour comprendre un nouveau concept, vous préférez…",
+    options: [
+      { text: "explorer librement toutes les pistes possibles", functions: { Ne: 3 }, enneagram: { 7: 2, 5: 1 } },
+      { text: "relier l'idée à vos expériences passées", functions: { Si: 3 }, enneagram: { 6: 2, 1: 1 } },
+      { text: "expérimenter concrètement sur le terrain", functions: { Se: 3 }, enneagram: { 8: 2, 3: 1 } }
+    ]
+  },
+  {
+    id: 3,
+    question: "Face à un imprévu dans votre journée, vous…",
+    options: [
+      { text: "improvisez avec enthousiasme", functions: { Se: 2, Ne: 1 }, enneagram: { 7: 2 } },
+      { text: "cherchez à rétablir votre plan initial", functions: { Si: 2, Te: 1 }, enneagram: { 1: 2 } },
+      { text: "prenez du recul pour comprendre le sens caché", functions: { Ni: 3 }, enneagram: { 4: 1, 5: 1 } }
+    ]
+  },
+  {
+    id: 4,
+    question: "Dans une discussion animée, vous êtes celui qui…",
+    options: [
+      { text: "ramène des faits et de la logique", functions: { Ti: 3 }, enneagram: { 5: 2 } },
+      { text: "observe silencieusement en analysant le non‑dit", functions: { Ni: 2, Fi: 1 }, enneagram: { 4: 2 } },
+      { text: "anime le groupe et met chacun à l'aise", functions: { Fe: 3 }, enneagram: { 2: 2 } }
+    ]
+  },
+  {
+    id: 5,
+    question: "Votre espace de travail idéal est…",
+    options: [
+      { text: "structuré et optimisé pour la productivité", functions: { Te: 3, Si: 1 }, enneagram: { 1: 2, 3: 1 } },
+      { text: "rempli d'objets inspirants et uniques", functions: { Fi: 2, Ne: 1 }, enneagram: { 4: 2 } },
+      { text: "minimaliste pour rester en alerte", functions: { Se: 2, Ti: 1 }, enneagram: { 8: 2 } }
+    ]
+  },
+  {
+    id: 6,
+    question: "Lorsque vous aidez quelqu'un, vous…",
+    options: [
+      { text: "partagez des conseils pratiques immédiatement applicables", functions: { Te: 2, Se: 1 }, enneagram: { 3: 1, 8: 1 } },
+      { text: "écoutez avec empathie pour comprendre ses émotions", functions: { Fe: 2, Fi: 1 }, enneagram: { 2: 3 } },
+      { text: "analysez sa situation pour trouver la cause profonde", functions: { Ti: 2, Ni: 1 }, enneagram: { 5: 2 } }
+    ]
+  },
+  {
+    id: 7,
+    question: "Quand vous planifiez l'avenir, vous voyez surtout…",
+    options: [
+      { text: "des possibilités variées et changeantes", functions: { Ne: 3 }, enneagram: { 7: 3 } },
+      { text: "une vision claire et ciblée", functions: { Ni: 3 }, enneagram: { 1: 1, 3: 1 } },
+      { text: "les étapes concrètes à réaliser", functions: { Si: 2, Te: 1 }, enneagram: { 6: 2 } }
+    ]
+  },
+  {
+    id: 8,
+    question: "Devant un conflit relationnel, vous avez tendance à…",
+    options: [
+      { text: "rechercher une solution gagnant‑gagnant", functions: { Fe: 3 }, enneagram: { 9: 2 } },
+      { text: "exprimer directement ce qui ne va pas", functions: { Te: 2, Se: 1 }, enneagram: { 8: 2 } },
+      { text: "vous retirer pour réfléchir", functions: { Fi: 2, Ni: 1 }, enneagram: { 5: 2 } }
+    ]
+  },
+  {
+    id: 9,
+    question: "Votre motivation première est de…",
+    options: [
+      { text: "vivre en accord avec votre identité", functions: { Fi: 3 }, enneagram: { 4: 3 } },
+      { text: "atteindre un objectif mesurable", functions: { Te: 3 }, enneagram: { 3: 3 } },
+      { text: "rester en paix et éviter le stress", functions: { Si: 2, Ne: 1 }, enneagram: { 9: 3 } }
+    ]
+  },
+  {
+    id: 10,
+    question: "Quand vous explorez un nouveau lieu, vous…",
+    options: [
+      { text: "vous laissez guider par vos cinq sens", functions: { Se: 3 }, enneagram: { 7: 2 } },
+      { text: "recherchez l'histoire cachée du lieu", functions: { Ni: 2, Ti: 1 }, enneagram: { 5: 2 } },
+      { text: "comparez ce que vous voyez à des souvenirs", functions: { Si: 3 }, enneagram: { 6: 2 } }
+    ]
+  },
+  {
+    id: 11,
+    question: "Lorsque vous travaillez en équipe, vous êtes celui qui…",
+    options: [
+      { text: "coordonne et répartit les tâches", functions: { Te: 3 }, enneagram: { 1: 1, 8: 1 } },
+      { text: "assure que tout le monde se sente entendu", functions: { Fe: 3 }, enneagram: { 2: 2 } },
+      { text: "propose des idées originales", functions: { Ne: 3 }, enneagram: { 7: 2 } }
+    ]
+  },
+  {
+    id: 12,
+    question: "Votre rapport au temps est plutôt…",
+    options: [
+      { text: "orienté vers l'instant présent", functions: { Se: 2, Fi: 1 }, enneagram: { 7: 1, 8: 1 } },
+      { text: "tourné vers des schémas récurrents", functions: { Si: 3 }, enneagram: { 6: 2 } },
+      { text: "projeté vers ce qui va arriver", functions: { Ni: 3 }, enneagram: { 5: 1 } }
+    ]
+  },
+  {
+    id: 13,
+    question: "Face à une règle qui vous semble absurde, vous…",
+    options: [
+      { text: "la contournez si elle entrave votre liberté", functions: { Fi: 2, Ne: 1 }, enneagram: { 4: 1, 7: 1 } },
+      { text: "cherchez à la modifier officiellement", functions: { Te: 2, Fe: 1 }, enneagram: { 1: 2, 8: 1 } },
+      { text: "l'appliquez malgré tout pour garder l'ordre", functions: { Si: 2, Ti: 1 }, enneagram: { 6: 2 } }
+    ]
+  },
+  {
+    id: 14,
+    question: "Quand vous êtes plongé dans vos pensées, c'est souvent pour…",
+    options: [
+      { text: "explorer des symboles et significations", functions: { Ni: 3 }, enneagram: { 4: 1, 5: 1 } },
+      { text: "réviser des souvenirs en détail", functions: { Si: 3 }, enneagram: { 6: 1, 9: 1 } },
+      { text: "imaginer des scénarios futurs", functions: { Ne: 3 }, enneagram: { 7: 2 } }
+    ]
+  },
+  {
+    id: 15,
+    question: "Pour résoudre un problème technique, vous…",
+    options: [
+      { text: "décomposez logiquement chaque étape", functions: { Ti: 3 }, enneagram: { 5: 3 } },
+      { text: "cherchez un tutoriel ou l'avis d'un expert", functions: { Te: 2, Si: 1 }, enneagram: { 6: 2 } },
+      { text: "expérimentez différentes possibilités", functions: { Ne: 2, Se: 1 }, enneagram: { 7: 2 } }
+    ]
+  },
+  {
+    id: 16,
+    question: "Votre définition d'une vie réussie se rapproche de…",
+    options: [
+      { text: "rester fidèle à soi et à ses proches", functions: { Fi: 2, Fe: 1 }, enneagram: { 2: 1, 4: 2 } },
+      { text: "laisser une trace concrète et utile", functions: { Te: 2, Ni: 1 }, enneagram: { 3: 2, 1: 1 } },
+      { text: "profiter du voyage sans pression", functions: { Si: 1, Ne: 1, Se: 1 }, enneagram: { 9: 2 } }
+    ]
+  }
+];
+
+// Version externe - 20 questions
+const EXTERNAL_QUESTIONS = [
+  {
+    id: 1,
+    question: "Cette personne prend ses décisions surtout en fonction…",
+    options: [
+      { text: "de ses valeurs personnelles", functions: { Fi: 3 }, enneagram: { 4: 2, 9: 1 } },
+      { text: "de l'impact sur les autres", functions: { Fe: 3 }, enneagram: { 2: 2, 6: 1 } },
+      { text: "de l'efficacité mesurable", functions: { Te: 3 }, enneagram: { 3: 2, 1: 1 } }
+    ]
+  },
+  {
+    id: 2,
+    question: "Pour apprendre, cette personne préfère…",
+    options: [
+      { text: "tester immédiatement", functions: { Se: 3 }, enneagram: { 7: 2, 8: 1 } },
+      { text: "relier à son vécu", functions: { Si: 3 }, enneagram: { 6: 2 } },
+      { text: "explorer des idées abstraites", functions: { Ne: 2, Ni: 1 }, enneagram: { 5: 2 } }
+    ]
+  },
+  {
+    id: 3,
+    question: "Lorsqu'elle est sous pression, cette personne…",
+    options: [
+      { text: "cherche à garder le contrôle et l'ordre", functions: { Te: 2, Si: 1 }, enneagram: { 1: 2, 8: 1 } },
+      { text: "se replie pour réfléchir", functions: { Fi: 2, Ni: 1 }, enneagram: { 5: 2 } },
+      { text: "dédramatise et passe à autre chose", functions: { Ne: 2, Se: 1 }, enneagram: { 7: 2 } }
+    ]
+  },
+  {
+    id: 4,
+    question: "Dans un groupe, cette personne est souvent celle qui…",
+    options: [
+      { text: "met l'ambiance et encourage", functions: { Fe: 2, Se: 1 }, enneagram: { 2: 2, 7: 1 } },
+      { text: "analyse en silence", functions: { Ni: 2, Ti: 1 }, enneagram: { 5: 2 } },
+      { text: "structure l'action", functions: { Te: 3 }, enneagram: { 3: 2, 8: 1 } }
+    ]
+  },
+  {
+    id: 5,
+    question: "Son environnement de travail est plutôt…",
+    options: [
+      { text: "soigné et fonctionnel", functions: { Si: 2, Te: 1 }, enneagram: { 1: 2 } },
+      { text: "créatif et personnalisé", functions: { Fi: 2, Ne: 1 }, enneagram: { 4: 2 } },
+      { text: "variable selon son humeur", functions: { Se: 2 }, enneagram: { 7: 1, 9: 1 } }
+    ]
+  },
+  {
+    id: 6,
+    question: "Avec les autres, cette personne montre surtout…",
+    options: [
+      { text: "de l'empathie et du soutien", functions: { Fe: 3 }, enneagram: { 2: 3 } },
+      { text: "des conseils pratiques", functions: { Te: 2, Se: 1 }, enneagram: { 3: 1, 8: 1 } },
+      { text: "une écoute discrète", functions: { Fi: 2, Si: 1 }, enneagram: { 9: 2 } }
+    ]
+  },
+  {
+    id: 7,
+    question: "Quand un plan change, cette personne…",
+    options: [
+      { text: "s'adapte rapidement", functions: { Ne: 2, Se: 1 }, enneagram: { 7: 2 } },
+      { text: "cherche à revenir au plan initial", functions: { Si: 2, Te: 1 }, enneagram: { 6: 2 } },
+      { text: "questionne le sens du changement", functions: { Ni: 2, Fi: 1 }, enneagram: { 4: 1, 5: 1 } }
+    ]
+  },
+  {
+    id: 8,
+    question: "Lors d'un désaccord, cette personne…",
+    options: [
+      { text: "négocie pour que chacun y trouve son compte", functions: { Fe: 3 }, enneagram: { 9: 2 } },
+      { text: "maintient fermement sa position", functions: { Te: 2, Ti: 1 }, enneagram: { 8: 2, 1: 1 } },
+      { text: "se retire pour éviter l'escalade", functions: { Fi: 2, Si: 1 }, enneagram: { 6: 1, 5: 1 } }
+    ]
+  },
+  {
+    id: 9,
+    question: "Cette personne paraît motivée avant tout par…",
+    options: [
+      { text: "la réussite mesurable", functions: { Te: 3 }, enneagram: { 3: 3 } },
+      { text: "l'harmonie relationnelle", functions: { Fe: 3 }, enneagram: { 2: 2, 9: 1 } },
+      { text: "la recherche de sens intérieur", functions: { Fi: 3 }, enneagram: { 4: 2 } }
+    ]
+  },
+  {
+    id: 10,
+    question: "Devant une situation nouvelle, cette personne…",
+    options: [
+      { text: "observe avant d'agir", functions: { Ni: 2, Si: 1 }, enneagram: { 5: 2 } },
+      { text: "se lance spontanément", functions: { Se: 3 }, enneagram: { 7: 2 } },
+      { text: "cherche des références pour se rassurer", functions: { Si: 2, Fe: 1 }, enneagram: { 6: 2 } }
+    ]
+  },
+  {
+    id: 11,
+    question: "Son style de communication est…",
+    options: [
+      { text: "direct et objectif", functions: { Te: 2, Ti: 1 }, enneagram: { 1: 1, 8: 1 } },
+      { text: "imaginatif et digressif", functions: { Ne: 3 }, enneagram: { 7: 2 } },
+      { text: "chaleureux et personnel", functions: { Fe: 3 }, enneagram: { 2: 3 } }
+    ]
+  },
+  {
+    id: 12,
+    question: "Quand elle parle de l'avenir, cette personne…",
+    options: [
+      { text: "décrit un but précis", functions: { Ni: 3 }, enneagram: { 3: 1, 1: 1 } },
+      { text: "imagine plusieurs scénarios possibles", functions: { Ne: 3 }, enneagram: { 7: 2 } },
+      { text: "reste plutôt centrée sur le présent", functions: { Se: 2, Fi: 1 }, enneagram: { 9: 2 } }
+    ]
+  },
+  {
+    id: 13,
+    question: "Dans son temps libre, cette personne aime surtout…",
+    options: [
+      { text: "organiser des activités utiles", functions: { Te: 2, Si: 1 }, enneagram: { 1: 1, 3: 1 } },
+      { text: "créer et s'exprimer", functions: { Fi: 2, Ne: 1 }, enneagram: { 4: 2 } },
+      { text: "se détendre sans plan", functions: { Se: 2, Ne: 1 }, enneagram: { 9: 2, 7: 1 } }
+    ]
+  },
+  {
+    id: 14,
+    question: "Face à l'incertitude, cette personne…",
+    options: [
+      { text: "cherche à rassembler des données", functions: { Ti: 2, Te: 1 }, enneagram: { 5: 2, 6: 1 } },
+      { text: "fait confiance à son intuition", functions: { Ni: 2, Fi: 1 }, enneagram: { 4: 1, 8: 1 } },
+      { text: "avance sans trop se poser de questions", functions: { Se: 2, Ne: 1 }, enneagram: { 7: 2 } }
+    ]
+  },
+  {
+    id: 15,
+    question: "Cette personne semble surtout rechercher…",
+    options: [
+      { text: "la sécurité et la stabilité", functions: { Si: 3 }, enneagram: { 6: 3 } },
+      { text: "l'indépendance", functions: { Fi: 2, Ti: 1 }, enneagram: { 5: 2, 4: 1 } },
+      { text: "l'intensité et le défi", functions: { Se: 2, Te: 1 }, enneagram: { 8: 2 } }
+    ]
+  },
+  {
+    id: 16,
+    question: "Dans ses relations, cette personne est vue comme…",
+    options: [
+      { text: "protectrice et attentive", functions: { Fe: 3 }, enneagram: { 2: 2 } },
+      { text: "réservée mais fiable", functions: { Si: 2, Fi: 1 }, enneagram: { 6: 1, 9: 1 } },
+      { text: "franche et parfois brusque", functions: { Te: 2, Se: 1 }, enneagram: { 8: 2 } }
+    ]
+  },
+  {
+    id: 17,
+    question: "Quand il faut choisir rapidement, cette personne…",
+    options: [
+      { text: "va droit au but", functions: { Te: 2, Se: 1 }, enneagram: { 3: 2 } },
+      { text: "prend un moment pour réfléchir", functions: { Ti: 2, Si: 1 }, enneagram: { 5: 2 } },
+      { text: "demande l'avis du groupe", functions: { Fe: 2, Ne: 1 }, enneagram: { 6: 2 } }
+    ]
+  },
+  {
+    id: 18,
+    question: "Cette personne semble se ressourcer surtout…",
+    options: [
+      { text: "seule dans son monde intérieur", functions: { Ni: 2, Fi: 1 }, enneagram: { 4: 1, 5: 1 } },
+      { text: "au contact d'un large cercle social", functions: { Fe: 2, Se: 1 }, enneagram: { 7: 2, 2: 1 } },
+      { text: "avec quelques proches de confiance", functions: { Si: 2, Fi: 1 }, enneagram: { 6: 2 } }
+    ]
+  },
+  {
+    id: 19,
+    question: "Son approche des règles est plutôt…",
+    options: [
+      { text: "les respecter scrupuleusement", functions: { Si: 2, Te: 1 }, enneagram: { 1: 2 } },
+      { text: "les contourner si elles semblent injustes", functions: { Fi: 2, Ne: 1 }, enneagram: { 4: 1, 7: 1 } },
+      { text: "les questionner pour les améliorer", functions: { Ti: 2, Fe: 1 }, enneagram: { 6: 1, 5: 1 } }
+    ]
+  },
+  {
+    id: 20,
+    question: "Globalement, cette personne dégage surtout…",
+    options: [
+      { text: "une énergie calme et conciliante", functions: { Si: 2, Fe: 1 }, enneagram: { 9: 3 } },
+      { text: "une présence intense et directive", functions: { Te: 2, Se: 1 }, enneagram: { 8: 3 } },
+      { text: "une curiosité vive et enthousiaste", functions: { Ne: 3 }, enneagram: { 7: 3 } }
+    ]
+  }
+];
+
+if (typeof module !== 'undefined') {
+  module.exports = { AUTO_QUESTIONS, EXTERNAL_QUESTIONS };
+}
+


### PR DESCRIPTION
## Summary
- replace relation-based weighting with cognitive function averaging and convergence scoring
- add revised cognitive-function/enneagram questionnaires for auto and external evaluations
- store function averages and wing-aware enneagram results when computing final profile

## Testing
- `npm test` *(fails: Missing script "test")*
- `node -e "require('./computeFinalProfileFromExternalEvaluations.js'); console.log('loaded');"`


------
https://chatgpt.com/codex/tasks/task_e_689f4e9fd23883219004853bb724d9de