### PR TITLE
Fix questionnaire module export

### DIFF
--- a/public/questions-v2.js
+++ b/public/questions-v2.js
@@ -641,8 +641,4 @@ const EXTERNAL_QUESTIONS = [
 
 if (typeof module !== 'undefined') {
   module.exports = { AUTO_QUESTIONS, EXTERNAL_QUESTIONS };
-];
-
-if (typeof module !== 'undefined') {
-  module.exports = EXTERNAL_QUESTIONS;
 }


### PR DESCRIPTION
## Summary
- remove stray characters and duplicate export from questions-v2.js
- ensure both auto and external questionnaires load correctly

## Testing
- `node -e "require('./public/questions-v2.js'); console.log('loaded');"`
- `npm test` *(fails: Missing script "test"*

------
https://chatgpt.com/codex/tasks/task_e_689fcf93ae6c8321ab3ceb86e7166d67