### PR TITLE
fix: repair question dataset syntax

### DIFF
--- a/public/questions-v2.js
+++ b/public/questions-v2.js
@@ -263,7 +263,7 @@ const EXTERNAL_QUESTIONS = [
       },
       {
         "text": "Il cherche à optimiser, à tout structurer, parfois au détriment de l’humain.",
-        "functions": { "Te": 3, "Si":  2, "Ni": 1" },
+        "functions": { "Te": 3, "Si":  2, "Ni": 1 },
         "enneagram": { "1": 1, "2": 2 }
       },
       {
@@ -372,7 +372,7 @@ const EXTERNAL_QUESTIONS = [
       },
       {
         "text": "Il agit selon une vision intérieure qu’il est parfois le seul à comprendre.",
-        "functions": { "Ni": 3, "Ti": 2, "Fi", 2 },
+        "functions": { "Ni": 3, "Ti": 2, "Fi": 2 },
         "enneagram": { "5": 1, "9": 2 }
       }
     ]


### PR DESCRIPTION
## Summary
- fix malformed function weighting entries in `questions-v2.js` causing syntax error

## Testing
- `node -c public/questions-v2.js`
- `node -e "const qs=require('./public/questions-v2.js'); console.log(qs.AUTO_QUESTIONS.length, qs.EXTERNAL_QUESTIONS.length)"`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689fed98f94c8321a276fc7f2aecb208