### PR TITLE
feat: disable results access until evaluations complete

### DIFF
--- a/public/enneagramme.html
+++ b/public/enneagramme.html
@@ -3547,21 +3547,13 @@ function showPrivacyPolicy() {
             
             // Afficher le message selon le statut (3 évaluations requises)
             displayStatusMessage(profile, completedEvaluations, 3);
-            
-            // Afficher/cacher le bouton "Voir mes résultats"
-            const viewResultsBtn = document.getElementById('view-results-btn');
-            if (completedEvaluations >= 1) {
-                viewResultsBtn.style.display = 'block';
-            } else {
-                viewResultsBtn.style.display = 'none';
-            }
         }
 
         function displayStatusMessage(profile, completedEvaluations, totalEvaluations) {
             const statusMessage = document.getElementById('status-message');
             const totalRequired = 3;
             const remaining = totalRequired - completedEvaluations;
-            
+
             if (completedEvaluations >= totalRequired) {
                 statusMessage.className = 'rounded-lg p-4 mb-4 bg-green-50 border border-green-200';
                 statusMessage.innerHTML = `
@@ -3577,10 +3569,10 @@ function showPrivacyPolicy() {
                         </div>
                     </div>
                 `;
+                updateResultsButtonState(0);
             } else {
                 statusMessage.className = 'rounded-lg p-4 mb-4 bg-yellow-50 border border-yellow-200';
                 const personText = remaining === 1 ? 'personne' : 'personnes';
-                const verbText = remaining === 1 ? 'complète' : 'complètent';
                 statusMessage.innerHTML = `
                     <div class="flex">
                         <div class="flex-shrink-0">
@@ -3589,12 +3581,38 @@ function showPrivacyPolicy() {
                         <div class="ml-3">
                             <h3 class="text-sm font-medium text-yellow-800">Évaluations en cours</h3>
                             <div class="mt-2 text-sm text-yellow-700">
-                                <p>Il reste <strong>${remaining} ${personText}</strong> qui ${remaining === 1 ? 'doit' : 'doivent'} ${verbText} l'évaluation pour améliorer votre niveau de certitude.</p>
-                                <p class="mt-1">Partagez votre code unique avec vos proches pour qu'ils puissent vous évaluer.</p>
+                                <p>Il reste <strong>${remaining} ${personText}</strong> qui ${remaining === 1 ? 'doit' : 'doivent'} compléter l’évaluation pour améliorer le niveau de certitude de votre profil et accéder à votre page de résultats détaillés. Cette page présente votre profil MBTI et votre profil Ennéagramme, leur niveau de certitude respectif, des graphiques pour y voir plus clair, une description personnalisée de votre profil par Psycho’Bot, ainsi que les résultats de chaque évaluateur et leur cohérence interne.</p>
+                                <p class="mt-1">Partagez votre code unique avec vos proches pour qu’ils puissent vous évaluer et vous donner accès à cette page.</p>
                             </div>
                         </div>
                     </div>
                 `;
+                updateResultsButtonState(remaining);
+            }
+        }
+
+        function updateResultsButtonState(remaining) {
+            const btn = document.getElementById('seeResultsBtn');
+            if (!btn) return;
+            if (remaining > 0) {
+                if (!btn.dataset.onclick && btn.getAttribute('onclick')) {
+                    btn.dataset.onclick = btn.getAttribute('onclick');
+                }
+                btn.removeAttribute('onclick');
+                btn.setAttribute('disabled', 'disabled');
+                btn.setAttribute('aria-disabled', 'true');
+                btn.classList.add('opacity-60', 'cursor-not-allowed', 'bg-gray-300');
+                btn.classList.remove('bg-black', 'hover:bg-gray-800');
+                btn.setAttribute('title', 'Complétez d’abord 3 évaluations externes pour accéder à vos résultats détaillés.');
+            } else {
+                if (btn.dataset.onclick) {
+                    btn.setAttribute('onclick', btn.dataset.onclick);
+                }
+                btn.removeAttribute('disabled');
+                btn.removeAttribute('aria-disabled');
+                btn.classList.remove('opacity-60', 'cursor-not-allowed', 'bg-gray-300');
+                btn.classList.add('bg-black', 'hover:bg-gray-800');
+                btn.removeAttribute('title');
             }
         }
 
@@ -4296,7 +4314,7 @@ function showPrivacyPolicy() {
                             <i class="fas fa-share mr-2"></i>
                             Partager mon code
                         </button>
-                        <button id="view-results-btn" onclick="viewResults()" class="flex-1 inline-flex items-center justify-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-black hover:bg-gray-800" style="display: none;">
+                        <button id="seeResultsBtn" onclick="viewResults()" class="flex-1 inline-flex items-center justify-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-black hover:bg-gray-800">
                             <i class="fas fa-chart-pie mr-2"></i>
                             Voir mes résultats
                         </button>

--- a/public/index.html
+++ b/public/index.html
@@ -3610,21 +3610,13 @@ function showPrivacyPolicy() {
             
             // Afficher le message selon le statut (3 évaluations requises)
             displayStatusMessage(profile, completedEvaluations, 3);
-            
-            // Afficher/cacher le bouton "Voir mes résultats"
-            const viewResultsBtn = document.getElementById('view-results-btn');
-            if (completedEvaluations >= 1) {
-                viewResultsBtn.style.display = 'block';
-            } else {
-                viewResultsBtn.style.display = 'none';
-            }
         }
 
         function displayStatusMessage(profile, completedEvaluations, totalEvaluations) {
             const statusMessage = document.getElementById('status-message');
             const totalRequired = 3;
             const remaining = totalRequired - completedEvaluations;
-            
+
             if (completedEvaluations >= totalRequired) {
                 statusMessage.className = 'rounded-lg p-4 mb-4 bg-green-50 border border-green-200';
                 statusMessage.innerHTML = `
@@ -3640,10 +3632,10 @@ function showPrivacyPolicy() {
                         </div>
                     </div>
                 `;
+                updateResultsButtonState(0);
             } else {
                 statusMessage.className = 'rounded-lg p-4 mb-4 bg-yellow-50 border border-yellow-200';
                 const personText = remaining === 1 ? 'personne' : 'personnes';
-                const verbText = remaining === 1 ? 'complète' : 'complètent';
                 statusMessage.innerHTML = `
                     <div class="flex">
                         <div class="flex-shrink-0">
@@ -3652,12 +3644,38 @@ function showPrivacyPolicy() {
                         <div class="ml-3">
                             <h3 class="text-sm font-medium text-yellow-800">Évaluations en cours</h3>
                             <div class="mt-2 text-sm text-yellow-700">
-                                <p>Il reste <strong>${remaining} ${personText}</strong> qui ${remaining === 1 ? 'doit' : 'doivent'} ${verbText} l'évaluation pour améliorer votre niveau de certitude.</p>
-                                <p class="mt-1">Partagez votre code unique avec vos proches pour qu'ils puissent vous évaluer.</p>
+                                <p>Il reste <strong>${remaining} ${personText}</strong> qui ${remaining === 1 ? 'doit' : 'doivent'} compléter l’évaluation pour améliorer le niveau de certitude de votre profil et accéder à votre page de résultats détaillés. Cette page présente votre profil MBTI et votre profil Ennéagramme, leur niveau de certitude respectif, des graphiques pour y voir plus clair, une description personnalisée de votre profil par Psycho’Bot, ainsi que les résultats de chaque évaluateur et leur cohérence interne.</p>
+                                <p class="mt-1">Partagez votre code unique avec vos proches pour qu’ils puissent vous évaluer et vous donner accès à cette page.</p>
                             </div>
                         </div>
                     </div>
                 `;
+                updateResultsButtonState(remaining);
+            }
+        }
+
+        function updateResultsButtonState(remaining) {
+            const btn = document.getElementById('seeResultsBtn');
+            if (!btn) return;
+            if (remaining > 0) {
+                if (!btn.dataset.onclick && btn.getAttribute('onclick')) {
+                    btn.dataset.onclick = btn.getAttribute('onclick');
+                }
+                btn.removeAttribute('onclick');
+                btn.setAttribute('disabled', 'disabled');
+                btn.setAttribute('aria-disabled', 'true');
+                btn.classList.add('opacity-60', 'cursor-not-allowed', 'bg-gray-300');
+                btn.classList.remove('bg-black', 'hover:bg-gray-800');
+                btn.setAttribute('title', 'Complétez d’abord 3 évaluations externes pour accéder à vos résultats détaillés.');
+            } else {
+                if (btn.dataset.onclick) {
+                    btn.setAttribute('onclick', btn.dataset.onclick);
+                }
+                btn.removeAttribute('disabled');
+                btn.removeAttribute('aria-disabled');
+                btn.classList.remove('opacity-60', 'cursor-not-allowed', 'bg-gray-300');
+                btn.classList.add('bg-black', 'hover:bg-gray-800');
+                btn.removeAttribute('title');
             }
         }
 
@@ -4369,7 +4387,7 @@ function showPrivacyPolicy() {
                             <i class="fas fa-share mr-2"></i>
                             Partager mon code
                         </button>
-                        <button id="view-results-btn" onclick="viewResults()" class="flex-1 inline-flex items-center justify-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-black hover:bg-gray-800" style="display: none;">
+                        <button id="seeResultsBtn" onclick="viewResults()" class="flex-1 inline-flex items-center justify-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-black hover:bg-gray-800">
                             <i class="fas fa-chart-pie mr-2"></i>
                             Voir mes résultats
                         </button>

--- a/public/mbti.html
+++ b/public/mbti.html
@@ -3644,21 +3644,13 @@ function showPrivacyPolicy() {
             
             // Afficher le message selon le statut (3 évaluations requises)
             displayStatusMessage(profile, completedEvaluations, 3);
-            
-            // Afficher/cacher le bouton "Voir mes résultats"
-            const viewResultsBtn = document.getElementById('view-results-btn');
-            if (completedEvaluations >= 1) {
-                viewResultsBtn.style.display = 'block';
-            } else {
-                viewResultsBtn.style.display = 'none';
-            }
         }
 
         function displayStatusMessage(profile, completedEvaluations, totalEvaluations) {
             const statusMessage = document.getElementById('status-message');
             const totalRequired = 3;
             const remaining = totalRequired - completedEvaluations;
-            
+
             if (completedEvaluations >= totalRequired) {
                 statusMessage.className = 'rounded-lg p-4 mb-4 bg-green-50 border border-green-200';
                 statusMessage.innerHTML = `
@@ -3674,10 +3666,10 @@ function showPrivacyPolicy() {
                         </div>
                     </div>
                 `;
+                updateResultsButtonState(0);
             } else {
                 statusMessage.className = 'rounded-lg p-4 mb-4 bg-yellow-50 border border-yellow-200';
                 const personText = remaining === 1 ? 'personne' : 'personnes';
-                const verbText = remaining === 1 ? 'complète' : 'complètent';
                 statusMessage.innerHTML = `
                     <div class="flex">
                         <div class="flex-shrink-0">
@@ -3686,12 +3678,38 @@ function showPrivacyPolicy() {
                         <div class="ml-3">
                             <h3 class="text-sm font-medium text-yellow-800">Évaluations en cours</h3>
                             <div class="mt-2 text-sm text-yellow-700">
-                                <p>Il reste <strong>${remaining} ${personText}</strong> qui ${remaining === 1 ? 'doit' : 'doivent'} ${verbText} l'évaluation pour améliorer votre niveau de certitude.</p>
-                                <p class="mt-1">Partagez votre code unique avec vos proches pour qu'ils puissent vous évaluer.</p>
+                                <p>Il reste <strong>${remaining} ${personText}</strong> qui ${remaining === 1 ? 'doit' : 'doivent'} compléter l’évaluation pour améliorer le niveau de certitude de votre profil et accéder à votre page de résultats détaillés. Cette page présente votre profil MBTI et votre profil Ennéagramme, leur niveau de certitude respectif, des graphiques pour y voir plus clair, une description personnalisée de votre profil par Psycho’Bot, ainsi que les résultats de chaque évaluateur et leur cohérence interne.</p>
+                                <p class="mt-1">Partagez votre code unique avec vos proches pour qu’ils puissent vous évaluer et vous donner accès à cette page.</p>
                             </div>
                         </div>
                     </div>
                 `;
+                updateResultsButtonState(remaining);
+            }
+        }
+
+        function updateResultsButtonState(remaining) {
+            const btn = document.getElementById('seeResultsBtn');
+            if (!btn) return;
+            if (remaining > 0) {
+                if (!btn.dataset.onclick && btn.getAttribute('onclick')) {
+                    btn.dataset.onclick = btn.getAttribute('onclick');
+                }
+                btn.removeAttribute('onclick');
+                btn.setAttribute('disabled', 'disabled');
+                btn.setAttribute('aria-disabled', 'true');
+                btn.classList.add('opacity-60', 'cursor-not-allowed', 'bg-gray-300');
+                btn.classList.remove('bg-black', 'hover:bg-gray-800');
+                btn.setAttribute('title', 'Complétez d’abord 3 évaluations externes pour accéder à vos résultats détaillés.');
+            } else {
+                if (btn.dataset.onclick) {
+                    btn.setAttribute('onclick', btn.dataset.onclick);
+                }
+                btn.removeAttribute('disabled');
+                btn.removeAttribute('aria-disabled');
+                btn.classList.remove('opacity-60', 'cursor-not-allowed', 'bg-gray-300');
+                btn.classList.add('bg-black', 'hover:bg-gray-800');
+                btn.removeAttribute('title');
             }
         }
 
@@ -4393,7 +4411,7 @@ function showPrivacyPolicy() {
                             <i class="fas fa-share mr-2"></i>
                             Partager mon code
                         </button>
-                        <button id="view-results-btn" onclick="viewResults()" class="flex-1 inline-flex items-center justify-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-black hover:bg-gray-800" style="display: none;">
+                        <button id="seeResultsBtn" onclick="viewResults()" class="flex-1 inline-flex items-center justify-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-black hover:bg-gray-800">
                             <i class="fas fa-chart-pie mr-2"></i>
                             Voir mes résultats
                         </button>


### PR DESCRIPTION
## Summary
- enrichir le message d'avertissement lorsqu'il manque des évaluations externes
- désactiver le bouton "Voir mes résultats" tant que les 3 évaluations ne sont pas complétées

## Testing
- `npm test` (échec : Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68a0fa88cdf883219cdd54586514f85a