### PR TITLE
Refactor: centralize shared HTML includes

### DIFF
--- a/public/blog-enneagramme-instincts.html
+++ b/public/blog-enneagramme-instincts.html
@@ -392,124 +392,7 @@
 </head>
 <body id="top" class="font-sans bg-white text-gray-900">
 <!-- Navigation -->
-    <header id="site-header" class="sticky-header">
-        <div class="flex items-center">
-            <div class="flex-shrink-0 flex items-center">
-                <img src="logo pc 3.png" alt="Personnalité Comparée logo" class="w-10 h-10 rounded-full object-cover"><span id="brand-home" class="ml-3 text-xl font-bold text-black">Personnalité Comparée</span>
-            </div>
-        </div>
-        <nav class="desktop-nav hidden md:ml-6 md:flex md:items-center md:space-x-8">
-            <div id="home-menu-container" class="relative group">
-                <a id="home-menu-button" href="index.html" class="inline-flex items-center gap-2 text-gray-900 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
-                    Accueil
-                    <svg class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                </a>
-                <div id="home-menu" class="invisible opacity-0 group-hover:visible group-hover:opacity-100 transition absolute left-0 mt-2 w-64 rounded-xl shadow-lg bg-white ring-1 ring-black/5 z-50">
-                    <ul class="py-2 text-sm">
-                        <li><a href="index.html#home-how" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Comment ça marche</a></li>
-                        <li><a href="index.html#home-mbti" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Auto-évaluation</a></li>
-                        <li><a href="index.html#home-enneagramme" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Évaluer un proche</a></li>
-                        <li><a href="index.html#home-ia" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Parler avec Psycho'Bot</a></li>
-                        <li><a href="index.html#retourver-profil" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Retrouver un profil</a></li>
-                        <li><a href="index.html#home-blog" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Derniers articles</a></li>
-                        <li><a href="index.html#home-faq" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Questions fréquentes</a></li>
-                        <li><a href="index.html#home-about" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">À propos du projet</a></li>
-                    </ul>
-                </div>
-            </div>
-            <div id="mbti-menu-container" class="relative group">
-                <a id="mbti-menu-button" href="mbti.html" class="inline-flex items-center gap-2 text-gray-500 hover:text-gray-700 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
-                    MBTI
-                    <svg class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                </a>
-                <div id="mbti-menu" class="invisible opacity-0 group-hover:visible group-hover:opacity-100 transition absolute left-0 mt-2 w-64 rounded-xl shadow-lg bg-white ring-1 ring-black/5 z-50">
-                    <ul class="py-2 text-sm">
-                        <li><a href="mbti.html#mbti-hero" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Comprendre le MBTI</a></li>
-                        <li><a href="mbti.html#mbti-history" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Un peu d'histoire</a></li>
-                        <li><a href="mbti.html#mbti-types" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Les 16 types</a></li>
-                        <li><a href="mbti.html#mbti-faq" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">FAQ MBTI</a></li>
-                    </ul>
-                </div>
-            </div>
-            <div id="ennea-menu-container" class="relative group">
-                <a id="ennea-menu-button" href="enneagramme.html" class="inline-flex items-center gap-2 text-gray-500 hover:text-gray-700 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
-                    Ennéagramme
-                    <svg class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                </a>
-                <div id="ennea-menu" class="invisible opacity-0 group-hover:visible group-hover:opacity-100 transition absolute left-0 mt-2 w-64 rounded-xl shadow-lg bg-white ring-1 ring-black/5 z-50">
-                    <ul class="py-2 text-sm">
-                        <li><a href="enneagramme.html#ennea-hero" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Comprendre l’Ennéagramme</a></li>
-                        <li><a href="enneagramme.html#ennea-history" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Un peu d'histoire</a></li>
-                        <li><a href="enneagramme.html#ennea-types" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Les 9 types</a></li>
-                        <li><a href="enneagramme.html#ennea-faq" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">FAQ Ennéagramme</a></li>
-                    </ul>
-                </div>
-            </div>
-            <a href="index.html#home-ia" class="text-gray-500 hover:text-gray-700 inline-flex items-center px-1 pt-1 text-sm font-medium">IA spécialisée</a>
-            <a href="blog.html" class="text-gray-500 hover:text-gray-700 inline-flex items-center px-1 pt-1 text-sm font-medium">Blog</a>
-            <a href="index.html#home-faq" class="text-gray-500 hover:text-gray-700 inline-flex items-center px-1 pt-1 text-sm font-medium">FAQ</a>
-            <button id="profile-btn-desktop" onclick="openProfileModal()" class="ml-4 inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-black hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black">
-                Mon profil
-            </button>
-        </nav>
-        <div class="-mr-2 flex items-center md:hidden">
-            <button type="button" id="mobile-menu-button" class="inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500" aria-controls="mobile-menu" aria-expanded="false">
-                <span class="sr-only">Ouvrir le menu principal</span>
-                <i class="fas fa-bars" id="menu-icon"></i>
-            </button>
-        </div>
-        <!-- Menu mobile -->
-        <div class="mobile-menu md:hidden" id="mobile-menu">
-            <div class="px-2 pt-2 pb-3 space-y-1 sm:px-3 bg-white border-t border-gray-200">
-                <div>
-                    <a id="mobile-home-button" href="index.html" class="w-full flex items-center justify-between px-3 py-2 rounded-md text-base font-medium text-gray-900" aria-expanded="false">
-                        Accueil
-                        <svg id="mobile-home-caret" class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                    </a>
-                    <div id="mobile-home-menu" class="hidden pl-4 space-y-1">
-                        <a href="index.html#home-how" class="block px-3 py-2 rounded-md text-sm text-gray-700">Comment ça marche</a>
-                        <a href="index.html#home-mbti" class="block px-3 py-2 rounded-md text-sm text-gray-700">Auto-évaluation</a>
-                        <a href="index.html#home-enneagramme" class="block px-3 py-2 rounded-md text-sm text-gray-700">Évaluer un proche</a>
-                        <a href="index.html#home-ia" class="block px-3 py-2 rounded-md text-sm text-gray-700">Parler avec Psycho'Bot</a>
-                        <a href="index.html#retourver-profil" class="block px-3 py-2 rounded-md text-sm text-gray-700">Retrouver un profil</a>
-                        <a href="index.html#home-blog" class="block px-3 py-2 rounded-md text-sm text-gray-700">Derniers articles</a>
-                        <a href="index.html#home-faq" class="block px-3 py-2 rounded-md text-sm text-gray-700">Questions fréquentes</a>
-                        <a href="index.html#home-about" class="block px-3 py-2 rounded-md text-sm text-gray-700">À propos du projet</a>
-                    </div>
-                </div>
-                <div>
-                    <a id="mobile-mbti-button" href="mbti.html" class="w-full flex items-center justify-between px-3 py-2 rounded-md text-base font-medium text-gray-500" aria-expanded="false">
-                        MBTI
-                        <svg id="mobile-mbti-caret" class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                    </a>
-                    <div id="mobile-mbti-menu" class="hidden pl-4 space-y-1">
-                        <a href="mbti.html#mbti-hero" class="block px-3 py-2 rounded-md text-sm text-gray-700">Comprendre le MBTI</a>
-                        <a href="mbti.html#mbti-history" class="block px-3 py-2 rounded-md text-sm text-gray-700">Un peu d'histoire</a>
-                        <a href="mbti.html#mbti-types" class="block px-3 py-2 rounded-md text-sm text-gray-700">Les 16 types</a>
-                        <a href="mbti.html#mbti-faq" class="block px-3 py-2 rounded-md text-sm text-gray-700">FAQ MBTI</a>
-                    </div>
-                </div>
-                <div>
-                    <a id="mobile-ennea-button" href="enneagramme.html" class="w-full flex items-center justify-between px-3 py-2 rounded-md text-base font-medium text-gray-500" aria-expanded="false">
-                        Ennéagramme
-                        <svg id="mobile-ennea-caret" class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                    </a>
-                    <div id="mobile-ennea-menu" class="hidden pl-4 space-y-1">
-                        <a href="enneagramme.html#ennea-hero" class="block px-3 py-2 rounded-md text-sm text-gray-700">Comprendre l’Ennéagramme</a>
-                        <a href="enneagramme.html#ennea-history" class="block px-3 py-2 rounded-md text-sm text-gray-700">Un peu d'histoire</a>
-                        <a href="enneagramme.html#ennea-types" class="block px-3 py-2 rounded-md text-sm text-gray-700">Les 9 types</a>
-                        <a href="enneagramme.html#ennea-faq" class="block px-3 py-2 rounded-md text-sm text-gray-700">FAQ Ennéagramme</a>
-                    </div>
-                </div>
-                <a href="index.html#home-ia" class="text-gray-500 hover:text-gray-700 block px-3 py-2 rounded-md text-base font-medium">IA spécialisée</a>
-                <a href="blog.html" class="text-gray-500 hover:text-gray-700 block px-3 py-2 rounded-md text-base font-medium">Blog</a>
-                <a href="index.html#home-faq" class="text-gray-500 hover:text-gray-700 block px-3 py-2 rounded-md text-base font-medium">FAQ</a>
-                <button id="profile-btn-mobile" onclick="openProfileModal()" class="w-full mt-2 inline-flex items-center justify-center px-4 py-2 border border-transparent text-base font-medium rounded-md shadow-sm text-white bg-black hover:bg-gray-800">
-                    Mon profil
-                </button>
-            </div>
-        </div>
-    </header>
+    <div id="header"></div>
     <main>
         <div class="relative max-w-5xl mx-auto px-6 pb-8 text-center">
             <img src="/logobanniere.jpeg" alt="Nouveau logo" class="mx-auto mb-8 w-36 sm:w-40 h-auto">
@@ -528,66 +411,8 @@
             <a href="blog.html" class="inline-block mt-8 px-4 py-2 bg-black text-white rounded hover:bg-gray-800">← Retour au blog</a>
         </article>
     </main>
-    <footer class="bg-gray-800">
-        <div class="max-w-7xl mx-auto py-12 px-4 sm:px-6 lg:px-8">
-            <div class="grid grid-cols-2 md:grid-cols-4 gap-8">
-                <div>
-                    <h3 class="text-sm font-semibold text-gray-400 tracking-wider uppercase">Personnalité Comparée</h3>
-                    <ul class="mt-4 space-y-4">
-                        <li><a href="index.html" class="text-base text-gray-300 hover:text-white transition-colors">Accueil</a></li>
-                        <li><a href="mbti.html" class="text-base text-gray-300 hover:text-white transition-colors">MBTI</a></li>
-                        <li><a href="enneagramme.html" class="text-base text-gray-300 hover:text-white transition-colors">Ennéagramme</a></li>
-                        <li><a href="blog.html" class="text-base text-gray-300 hover:text-white transition-colors">Blog</a></li>
-                       <li><a href="index.html#home-ia" class="text-base text-gray-300 hover:text-white transition-colors">IA spécialisée</a></li>
-                        <li><a href="index.html#home-faq" class="text-base text-gray-300 hover:text-white transition-colors">FAQ</a></li>
-
-                    </ul>
-                </div>
-                <div>
-                    <h3 class="text-sm font-semibold text-gray-400 tracking-wider uppercase">Tests</h3>
-                    <ul class="mt-4 space-y-4">
-                        <li><a href="index.html#home-mbti" class="text-base text-gray-300 hover:text-white transition-colors">Auto-évaluation</a></li>
-                        <li><a href="index.html#home-enneagramme" class="text-base text-gray-300 hover:text-white transition-colors">Évaluer un proche</a></li>
-                        <li><a href="#retourver-profil" class="text-base text-gray-300 hover:text-white transition-colors">Mon profil</a></li>
-                    </ul>
-                </div>
-                <div>
-                    <h3 class="text-sm font-semibold text-gray-400 tracking-wider uppercase">Légal</h3>
-                    <ul class="mt-4 space-y-4">
-                        <li><a href="#" onclick="showPrivacyPolicy(); return false;" class="text-base text-gray-300 hover:text-white transition-colors">Confidentialité</a></li>
-                        <li><a href="#" onclick="showTermsOfService(); return false;" class="text-base text-gray-300 hover:text-white transition-colors">Conditions d'utilisation</a></li>
-                        <li><a href="#" onclick="showLegalNotices(); return false;" class="text-base text-gray-300 hover:text-white transition-colors">Mentions légales</a></li>
-                        <li><a href="#" onclick="showLegalNotices(); return false;" class="text-base text-gray-300 hover:text-white transition-colors">Cookies</a></li>
-                    </ul>
-                </div>
-                <div>
-                    <h3 class="text-sm font-semibold text-gray-400 tracking-wider uppercase">Contact</h3>
-                    <ul class="mt-4 space-y-4">
-                        <li><a href="#" onclick="showContact(); return false;" class="text-base text-gray-300 hover:text-white transition-colors">Support</a></li>
-                        <li class="flex space-x-6 pt-2">
-                            <a href="#" class="text-gray-400 hover:text-white transition-colors">
-                                <span class="sr-only">Facebook</span>
-                                <i class="fab fa-facebook-f"></i>
-                            </a>
-                            <a href="#" class="text-gray-400 hover:text-white transition-colors">
-                                <span class="sr-only">Instagram</span>
-                                <i class="fab fa-instagram"></i>
-                            </a>
-                            <a href="#" class="text-gray-400 hover:text-white transition-colors">
-                                <span class="sr-only">TikTok</span>
-                                <i class="fab fa-tiktok"></i>
-                            </a>
-                        </li>
-                    </ul>
-                </div>
-            </div>
-            <div class="mt-8 border-t border-gray-700 pt-8">
-                <p class="text-base text-gray-400 text-center">
-                    &copy; 2025 Personnalité Comparée. Tous droits réservés.
-                </p>
-            </div>
-        </div>
-    </footer>
+    <div id="footer"></div>
+    <div id="profile-modal-container"></div>
 <script>
   const mobileMenuButton = document.getElementById('mobile-menu-button');
   const mobileMenu = document.getElementById('mobile-menu');
@@ -629,6 +454,25 @@
   });
   function openProfileModal() {}
 </script>
-<script src="nav.js"></script>
+<script>
+  async function injectHTML(selector, file) {
+    const target = document.querySelector(selector);
+    if (target) {
+      const res = await fetch(file);
+      if (res.ok) {
+        target.innerHTML = await res.text();
+      }
+    }
+  }
+  Promise.all([
+    injectHTML("#header", "/includes/header.html"),
+    injectHTML("#footer", "/includes/footer.html"),
+    injectHTML("#profile-modal-container", "/includes/profile-modal.html")
+  ]).then(() => {
+    const s = document.createElement("script");
+    s.src = "/nav.js";
+    document.body.appendChild(s);
+  });
+</script>
 </body>
 </html>

--- a/public/blog-mbti-4-dimensions.html
+++ b/public/blog-mbti-4-dimensions.html
@@ -392,124 +392,7 @@
 </head>
 <body id="top" class="font-sans bg-white text-gray-900">
 <!-- Navigation -->
-    <header id="site-header" class="sticky-header">
-        <div class="flex items-center">
-            <div class="flex-shrink-0 flex items-center">
-                <img src="logo pc 3.png" alt="Personnalité Comparée logo" class="w-10 h-10 rounded-full object-cover"><span id="brand-home" class="ml-3 text-xl font-bold text-black">Personnalité Comparée</span>
-            </div>
-        </div>
-        <nav class="desktop-nav hidden md:ml-6 md:flex md:items-center md:space-x-8">
-            <div id="home-menu-container" class="relative group">
-                <a id="home-menu-button" href="index.html" class="inline-flex items-center gap-2 text-gray-900 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
-                    Accueil
-                    <svg class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                </a>
-                <div id="home-menu" class="invisible opacity-0 group-hover:visible group-hover:opacity-100 transition absolute left-0 mt-2 w-64 rounded-xl shadow-lg bg-white ring-1 ring-black/5 z-50">
-                    <ul class="py-2 text-sm">
-                        <li><a href="index.html#home-how" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Comment ça marche</a></li>
-                        <li><a href="index.html#home-mbti" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Auto-évaluation</a></li>
-                        <li><a href="index.html#home-enneagramme" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Évaluer un proche</a></li>
-                        <li><a href="index.html#home-ia" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Parler avec Psycho'Bot</a></li>
-                        <li><a href="index.html#retourver-profil" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Retrouver un profil</a></li>
-                        <li><a href="index.html#home-blog" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Derniers articles</a></li>
-                        <li><a href="index.html#home-faq" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Questions fréquentes</a></li>
-                        <li><a href="index.html#home-about" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">À propos du projet</a></li>
-                    </ul>
-                </div>
-            </div>
-            <div id="mbti-menu-container" class="relative group">
-                <a id="mbti-menu-button" href="mbti.html" class="inline-flex items-center gap-2 text-gray-500 hover:text-gray-700 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
-                    MBTI
-                    <svg class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                </a>
-                <div id="mbti-menu" class="invisible opacity-0 group-hover:visible group-hover:opacity-100 transition absolute left-0 mt-2 w-64 rounded-xl shadow-lg bg-white ring-1 ring-black/5 z-50">
-                    <ul class="py-2 text-sm">
-                        <li><a href="mbti.html#mbti-hero" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Comprendre le MBTI</a></li>
-                        <li><a href="mbti.html#mbti-history" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Un peu d'histoire</a></li>
-                        <li><a href="mbti.html#mbti-types" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Les 16 types</a></li>
-                        <li><a href="mbti.html#mbti-faq" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">FAQ MBTI</a></li>
-                    </ul>
-                </div>
-            </div>
-            <div id="ennea-menu-container" class="relative group">
-                <a id="ennea-menu-button" href="enneagramme.html" class="inline-flex items-center gap-2 text-gray-500 hover:text-gray-700 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
-                    Ennéagramme
-                    <svg class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                </a>
-                <div id="ennea-menu" class="invisible opacity-0 group-hover:visible group-hover:opacity-100 transition absolute left-0 mt-2 w-64 rounded-xl shadow-lg bg-white ring-1 ring-black/5 z-50">
-                    <ul class="py-2 text-sm">
-                        <li><a href="enneagramme.html#ennea-hero" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Comprendre l’Ennéagramme</a></li>
-                        <li><a href="enneagramme.html#ennea-history" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Un peu d'histoire</a></li>
-                        <li><a href="enneagramme.html#ennea-types" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Les 9 types</a></li>
-                        <li><a href="enneagramme.html#ennea-faq" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">FAQ Ennéagramme</a></li>
-                    </ul>
-                </div>
-            </div>
-            <a href="index.html#home-ia" class="text-gray-500 hover:text-gray-700 inline-flex items-center px-1 pt-1 text-sm font-medium">IA spécialisée</a>
-            <a href="blog.html" class="text-gray-500 hover:text-gray-700 inline-flex items-center px-1 pt-1 text-sm font-medium">Blog</a>
-            <a href="index.html#home-faq" class="text-gray-500 hover:text-gray-700 inline-flex items-center px-1 pt-1 text-sm font-medium">FAQ</a>
-            <button id="profile-btn-desktop" onclick="openProfileModal()" class="ml-4 inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-black hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black">
-                Mon profil
-            </button>
-        </nav>
-        <div class="-mr-2 flex items-center md:hidden">
-            <button type="button" id="mobile-menu-button" class="inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500" aria-controls="mobile-menu" aria-expanded="false">
-                <span class="sr-only">Ouvrir le menu principal</span>
-                <i class="fas fa-bars" id="menu-icon"></i>
-            </button>
-        </div>
-        <!-- Menu mobile -->
-        <div class="mobile-menu md:hidden" id="mobile-menu">
-            <div class="px-2 pt-2 pb-3 space-y-1 sm:px-3 bg-white border-t border-gray-200">
-                <div>
-                    <a id="mobile-home-button" href="index.html" class="w-full flex items-center justify-between px-3 py-2 rounded-md text-base font-medium text-gray-900" aria-expanded="false">
-                        Accueil
-                        <svg id="mobile-home-caret" class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                    </a>
-                    <div id="mobile-home-menu" class="hidden pl-4 space-y-1">
-                        <a href="index.html#home-how" class="block px-3 py-2 rounded-md text-sm text-gray-700">Comment ça marche</a>
-                        <a href="index.html#home-mbti" class="block px-3 py-2 rounded-md text-sm text-gray-700">Auto-évaluation</a>
-                        <a href="index.html#home-enneagramme" class="block px-3 py-2 rounded-md text-sm text-gray-700">Évaluer un proche</a>
-                        <a href="index.html#home-ia" class="block px-3 py-2 rounded-md text-sm text-gray-700">Parler avec Psycho'Bot</a>
-                        <a href="index.html#retourver-profil" class="block px-3 py-2 rounded-md text-sm text-gray-700">Retrouver un profil</a>
-                        <a href="index.html#home-blog" class="block px-3 py-2 rounded-md text-sm text-gray-700">Derniers articles</a>
-                        <a href="index.html#home-faq" class="block px-3 py-2 rounded-md text-sm text-gray-700">Questions fréquentes</a>
-                        <a href="index.html#home-about" class="block px-3 py-2 rounded-md text-sm text-gray-700">À propos du projet</a>
-                    </div>
-                </div>
-                <div>
-                    <a id="mobile-mbti-button" href="mbti.html" class="w-full flex items-center justify-between px-3 py-2 rounded-md text-base font-medium text-gray-500" aria-expanded="false">
-                        MBTI
-                        <svg id="mobile-mbti-caret" class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                    </a>
-                    <div id="mobile-mbti-menu" class="hidden pl-4 space-y-1">
-                        <a href="mbti.html#mbti-hero" class="block px-3 py-2 rounded-md text-sm text-gray-700">Comprendre le MBTI</a>
-                        <a href="mbti.html#mbti-history" class="block px-3 py-2 rounded-md text-sm text-gray-700">Un peu d'histoire</a>
-                        <a href="mbti.html#mbti-types" class="block px-3 py-2 rounded-md text-sm text-gray-700">Les 16 types</a>
-                        <a href="mbti.html#mbti-faq" class="block px-3 py-2 rounded-md text-sm text-gray-700">FAQ MBTI</a>
-                    </div>
-                </div>
-                <div>
-                    <a id="mobile-ennea-button" href="enneagramme.html" class="w-full flex items-center justify-between px-3 py-2 rounded-md text-base font-medium text-gray-500" aria-expanded="false">
-                        Ennéagramme
-                        <svg id="mobile-ennea-caret" class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                    </a>
-                    <div id="mobile-ennea-menu" class="hidden pl-4 space-y-1">
-                        <a href="enneagramme.html#ennea-hero" class="block px-3 py-2 rounded-md text-sm text-gray-700">Comprendre l’Ennéagramme</a>
-                        <a href="enneagramme.html#ennea-history" class="block px-3 py-2 rounded-md text-sm text-gray-700">Un peu d'histoire</a>
-                        <a href="enneagramme.html#ennea-types" class="block px-3 py-2 rounded-md text-sm text-gray-700">Les 9 types</a>
-                        <a href="enneagramme.html#ennea-faq" class="block px-3 py-2 rounded-md text-sm text-gray-700">FAQ Ennéagramme</a>
-                    </div>
-                </div>
-                <a href="index.html#home-ia" class="text-gray-500 hover:text-gray-700 block px-3 py-2 rounded-md text-base font-medium">IA spécialisée</a>
-                <a href="blog.html" class="text-gray-500 hover:text-gray-700 block px-3 py-2 rounded-md text-base font-medium">Blog</a>
-                <a href="index.html#home-faq" class="text-gray-500 hover:text-gray-700 block px-3 py-2 rounded-md text-base font-medium">FAQ</a>
-                <button id="profile-btn-mobile" onclick="openProfileModal()" class="w-full mt-2 inline-flex items-center justify-center px-4 py-2 border border-transparent text-base font-medium rounded-md shadow-sm text-white bg-black hover:bg-gray-800">
-                    Mon profil
-                </button>
-            </div>
-        </div>
-    </header>
+    <div id="header"></div>
     <main>
         <div class="relative max-w-5xl mx-auto px-6 pb-8 text-center">
             <img src="/logobanniere.jpeg" alt="Nouveau logo" class="mx-auto mb-8 w-36 sm:w-40 h-auto">
@@ -528,66 +411,8 @@
             <a href="blog.html" class="inline-block mt-8 px-4 py-2 bg-black text-white rounded hover:bg-gray-800">← Retour au blog</a>
         </article>
     </main>
-    <footer class="bg-gray-800">
-        <div class="max-w-7xl mx-auto py-12 px-4 sm:px-6 lg:px-8">
-            <div class="grid grid-cols-2 md:grid-cols-4 gap-8">
-                <div>
-                    <h3 class="text-sm font-semibold text-gray-400 tracking-wider uppercase">Personnalité Comparée</h3>
-                    <ul class="mt-4 space-y-4">
-                        <li><a href="index.html" class="text-base text-gray-300 hover:text-white transition-colors">Accueil</a></li>
-                        <li><a href="mbti.html" class="text-base text-gray-300 hover:text-white transition-colors">MBTI</a></li>
-                        <li><a href="enneagramme.html" class="text-base text-gray-300 hover:text-white transition-colors">Ennéagramme</a></li>
-                        <li><a href="blog.html" class="text-base text-gray-300 hover:text-white transition-colors">Blog</a></li>
-                       <li><a href="index.html#home-ia" class="text-base text-gray-300 hover:text-white transition-colors">IA spécialisée</a></li>
-                        <li><a href="index.html#home-faq" class="text-base text-gray-300 hover:text-white transition-colors">FAQ</a></li>
-
-                    </ul>
-                </div>
-                <div>
-                    <h3 class="text-sm font-semibold text-gray-400 tracking-wider uppercase">Tests</h3>
-                    <ul class="mt-4 space-y-4">
-                        <li><a href="index.html#home-mbti" class="text-base text-gray-300 hover:text-white transition-colors">Auto-évaluation</a></li>
-                        <li><a href="index.html#home-enneagramme" class="text-base text-gray-300 hover:text-white transition-colors">Évaluer un proche</a></li>
-                        <li><a href="#retourver-profil" class="text-base text-gray-300 hover:text-white transition-colors">Mon profil</a></li>
-                    </ul>
-                </div>
-                <div>
-                    <h3 class="text-sm font-semibold text-gray-400 tracking-wider uppercase">Légal</h3>
-                    <ul class="mt-4 space-y-4">
-                        <li><a href="#" onclick="showPrivacyPolicy(); return false;" class="text-base text-gray-300 hover:text-white transition-colors">Confidentialité</a></li>
-                        <li><a href="#" onclick="showTermsOfService(); return false;" class="text-base text-gray-300 hover:text-white transition-colors">Conditions d'utilisation</a></li>
-                        <li><a href="#" onclick="showLegalNotices(); return false;" class="text-base text-gray-300 hover:text-white transition-colors">Mentions légales</a></li>
-                        <li><a href="#" onclick="showLegalNotices(); return false;" class="text-base text-gray-300 hover:text-white transition-colors">Cookies</a></li>
-                    </ul>
-                </div>
-                <div>
-                    <h3 class="text-sm font-semibold text-gray-400 tracking-wider uppercase">Contact</h3>
-                    <ul class="mt-4 space-y-4">
-                        <li><a href="#" onclick="showContact(); return false;" class="text-base text-gray-300 hover:text-white transition-colors">Support</a></li>
-                        <li class="flex space-x-6 pt-2">
-                            <a href="#" class="text-gray-400 hover:text-white transition-colors">
-                                <span class="sr-only">Facebook</span>
-                                <i class="fab fa-facebook-f"></i>
-                            </a>
-                            <a href="#" class="text-gray-400 hover:text-white transition-colors">
-                                <span class="sr-only">Instagram</span>
-                                <i class="fab fa-instagram"></i>
-                            </a>
-                            <a href="#" class="text-gray-400 hover:text-white transition-colors">
-                                <span class="sr-only">TikTok</span>
-                                <i class="fab fa-tiktok"></i>
-                            </a>
-                        </li>
-                    </ul>
-                </div>
-            </div>
-            <div class="mt-8 border-t border-gray-700 pt-8">
-                <p class="text-base text-gray-400 text-center">
-                    &copy; 2025 Personnalité Comparée. Tous droits réservés.
-                </p>
-            </div>
-        </div>
-    </footer>
+    <div id="footer"></div>
+    <div id="profile-modal-container"></div>
 <script>
   const mobileMenuButton = document.getElementById('mobile-menu-button');
   const mobileMenu = document.getElementById('mobile-menu');
@@ -629,6 +454,25 @@
   });
   function openProfileModal() {}
 </script>
-<script src="nav.js"></script>
+<script>
+  async function injectHTML(selector, file) {
+    const target = document.querySelector(selector);
+    if (target) {
+      const res = await fetch(file);
+      if (res.ok) {
+        target.innerHTML = await res.text();
+      }
+    }
+  }
+  Promise.all([
+    injectHTML("#header", "/includes/header.html"),
+    injectHTML("#footer", "/includes/footer.html"),
+    injectHTML("#profile-modal-container", "/includes/profile-modal.html")
+  ]).then(() => {
+    const s = document.createElement("script");
+    s.src = "/nav.js";
+    document.body.appendChild(s);
+  });
+</script>
 </body>
 </html>

--- a/public/blog.html
+++ b/public/blog.html
@@ -392,124 +392,7 @@
 </head>
 <body id="top" class="font-sans bg-white text-gray-900">
 <!-- Navigation -->
-<header id="site-header" class="sticky-header">
-        <div class="flex items-center">
-            <div class="flex-shrink-0 flex items-center">
-                <img src="logo pc 3.png" alt="Personnalité Comparée logo" class="w-10 h-10 rounded-full object-cover"><span id="brand-home" class="ml-3 text-xl font-bold text-black">Personnalité Comparée</span>
-            </div>
-        </div>
-        <nav class="desktop-nav hidden md:ml-6 md:flex md:items-center md:space-x-8">
-            <div id="home-menu-container" class="relative group">
-                <a id="home-menu-button" href="index.html" class="inline-flex items-center gap-2 text-gray-900 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
-                    Accueil
-                    <svg class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                </a>
-                <div id="home-menu" class="invisible opacity-0 group-hover:visible group-hover:opacity-100 transition absolute left-0 mt-2 w-64 rounded-xl shadow-lg bg-white ring-1 ring-black/5 z-50">
-                    <ul class="py-2 text-sm">
-                        <li><a href="index.html#home-how" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Comment ça marche</a></li>
-                        <li><a href="index.html#home-mbti" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Auto-évaluation</a></li>
-                        <li><a href="index.html#home-enneagramme" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Évaluer un proche</a></li>
-                        <li><a href="index.html#home-ia" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Parler avec Psycho'Bot</a></li>
-                        <li><a href="index.html#retourver-profil" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Retrouver un profil</a></li>
-                        <li><a href="index.html#home-blog" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Derniers articles</a></li>
-                        <li><a href="index.html#home-faq" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Questions fréquentes</a></li>
-                        <li><a href="index.html#home-about" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">À propos du projet</a></li>
-                    </ul>
-                </div>
-            </div>
-            <div id="mbti-menu-container" class="relative group">
-                <a id="mbti-menu-button" href="mbti.html" class="inline-flex items-center gap-2 text-gray-500 hover:text-gray-700 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
-                    MBTI
-                    <svg class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                </a>
-                <div id="mbti-menu" class="invisible opacity-0 group-hover:visible group-hover:opacity-100 transition absolute left-0 mt-2 w-64 rounded-xl shadow-lg bg-white ring-1 ring-black/5 z-50">
-                    <ul class="py-2 text-sm">
-                        <li><a href="mbti.html#mbti-hero" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Comprendre le MBTI</a></li>
-                        <li><a href="mbti.html#mbti-history" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Un peu d'histoire</a></li>
-                        <li><a href="mbti.html#mbti-types" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Les 16 types</a></li>
-                        <li><a href="mbti.html#mbti-faq" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">FAQ MBTI</a></li>
-                    </ul>
-                </div>
-            </div>
-            <div id="ennea-menu-container" class="relative group">
-                <a id="ennea-menu-button" href="enneagramme.html" class="inline-flex items-center gap-2 text-gray-500 hover:text-gray-700 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
-                    Ennéagramme
-                    <svg class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                </a>
-                <div id="ennea-menu" class="invisible opacity-0 group-hover:visible group-hover:opacity-100 transition absolute left-0 mt-2 w-64 rounded-xl shadow-lg bg-white ring-1 ring-black/5 z-50">
-                    <ul class="py-2 text-sm">
-                        <li><a href="enneagramme.html#ennea-hero" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Comprendre l’Ennéagramme</a></li>
-                        <li><a href="enneagramme.html#ennea-history" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Un peu d'histoire</a></li>
-                        <li><a href="enneagramme.html#ennea-types" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Les 9 types</a></li>
-                        <li><a href="enneagramme.html#ennea-faq" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">FAQ Ennéagramme</a></li>
-                    </ul>
-                </div>
-            </div>
-            <a href="index.html#home-ia" class="text-gray-500 hover:text-gray-700 inline-flex items-center px-1 pt-1 text-sm font-medium">IA spécialisée</a>
-            <a href="blog.html" class="text-gray-500 hover:text-gray-700 inline-flex items-center px-1 pt-1 text-sm font-medium">Blog</a>
-            <a href="index.html#home-faq" class="text-gray-500 hover:text-gray-700 inline-flex items-center px-1 pt-1 text-sm font-medium">FAQ</a>
-            <button id="profile-btn-desktop" onclick="openProfileModal()" class="ml-4 inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-black hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black">
-                Mon profil
-            </button>
-        </nav>
-        <div class="-mr-2 flex items-center md:hidden">
-            <button type="button" id="mobile-menu-button" class="inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500" aria-controls="mobile-menu" aria-expanded="false">
-                <span class="sr-only">Ouvrir le menu principal</span>
-                <i class="fas fa-bars" id="menu-icon"></i>
-            </button>
-        </div>
-        <!-- Menu mobile -->
-        <div class="mobile-menu md:hidden" id="mobile-menu">
-            <div class="px-2 pt-2 pb-3 space-y-1 sm:px-3 bg-white border-t border-gray-200">
-                <div>
-                    <a id="mobile-home-button" href="index.html" class="w-full flex items-center justify-between px-3 py-2 rounded-md text-base font-medium text-gray-900" aria-expanded="false">
-                        Accueil
-                        <svg id="mobile-home-caret" class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                    </a>
-                    <div id="mobile-home-menu" class="hidden pl-4 space-y-1">
-                        <a href="index.html#home-how" class="block px-3 py-2 rounded-md text-sm text-gray-700">Comment ça marche</a>
-                        <a href="index.html#home-mbti" class="block px-3 py-2 rounded-md text-sm text-gray-700">Auto-évaluation</a>
-                        <a href="index.html#home-enneagramme" class="block px-3 py-2 rounded-md text-sm text-gray-700">Évaluer un proche</a>
-                        <a href="index.html#home-ia" class="block px-3 py-2 rounded-md text-sm text-gray-700">Parler avec Psycho'Bot</a>
-                        <a href="index.html#retourver-profil" class="block px-3 py-2 rounded-md text-sm text-gray-700">Retrouver un profil</a>
-                        <a href="index.html#home-blog" class="block px-3 py-2 rounded-md text-sm text-gray-700">Derniers articles</a>
-                        <a href="index.html#home-faq" class="block px-3 py-2 rounded-md text-sm text-gray-700">Questions fréquentes</a>
-                        <a href="index.html#home-about" class="block px-3 py-2 rounded-md text-sm text-gray-700">À propos du projet</a>
-                    </div>
-                </div>
-                <div>
-                    <a id="mobile-mbti-button" href="mbti.html" class="w-full flex items-center justify-between px-3 py-2 rounded-md text-base font-medium text-gray-500" aria-expanded="false">
-                        MBTI
-                        <svg id="mobile-mbti-caret" class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                    </a>
-                    <div id="mobile-mbti-menu" class="hidden pl-4 space-y-1">
-                        <a href="mbti.html#mbti-hero" class="block px-3 py-2 rounded-md text-sm text-gray-700">Comprendre le MBTI</a>
-                        <a href="mbti.html#mbti-history" class="block px-3 py-2 rounded-md text-sm text-gray-700">Un peu d'histoire</a>
-                        <a href="mbti.html#mbti-types" class="block px-3 py-2 rounded-md text-sm text-gray-700">Les 16 types</a>
-                        <a href="mbti.html#mbti-faq" class="block px-3 py-2 rounded-md text-sm text-gray-700">FAQ MBTI</a>
-                    </div>
-                </div>
-                <div>
-                    <a id="mobile-ennea-button" href="enneagramme.html" class="w-full flex items-center justify-between px-3 py-2 rounded-md text-base font-medium text-gray-500" aria-expanded="false">
-                        Ennéagramme
-                        <svg id="mobile-ennea-caret" class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                    </a>
-                    <div id="mobile-ennea-menu" class="hidden pl-4 space-y-1">
-                        <a href="enneagramme.html#ennea-hero" class="block px-3 py-2 rounded-md text-sm text-gray-700">Comprendre l’Ennéagramme</a>
-                        <a href="enneagramme.html#ennea-history" class="block px-3 py-2 rounded-md text-sm text-gray-700">Un peu d'histoire</a>
-                        <a href="enneagramme.html#ennea-types" class="block px-3 py-2 rounded-md text-sm text-gray-700">Les 9 types</a>
-                        <a href="enneagramme.html#ennea-faq" class="block px-3 py-2 rounded-md text-sm text-gray-700">FAQ Ennéagramme</a>
-                    </div>
-                </div>
-                <a href="index.html#home-ia" class="text-gray-500 hover:text-gray-700 block px-3 py-2 rounded-md text-base font-medium">IA spécialisée</a>
-                <a href="blog.html" class="text-gray-500 hover:text-gray-700 block px-3 py-2 rounded-md text-base font-medium">Blog</a>
-                <a href="index.html#home-faq" class="text-gray-500 hover:text-gray-700 block px-3 py-2 rounded-md text-base font-medium">FAQ</a>
-                <button id="profile-btn-mobile" onclick="openProfileModal()" class="w-full mt-2 inline-flex items-center justify-center px-4 py-2 border border-transparent text-base font-medium rounded-md shadow-sm text-white bg-black hover:bg-gray-800">
-                    Mon profil
-                </button>
-            </div>
-        </div>
-    </header>
+<div id="header"></div>
 
     <main>
         <section id="hero" class="px-4 sm:px-6 lg:px-8 relative overflow-hidden pc-hero mt-8 sm:mt-12" data-hero>
@@ -543,66 +426,7 @@
         </section>
     </main>
 
-    <footer class="bg-gray-800">
-        <div class="max-w-7xl mx-auto py-12 px-4 sm:px-6 lg:px-8">
-            <div class="grid grid-cols-2 md:grid-cols-4 gap-8">
-                <div>
-                    <h3 class="text-sm font-semibold text-gray-400 tracking-wider uppercase">Personnalité Comparée</h3>
-                    <ul class="mt-4 space-y-4">
-                        <li><a href="index.html" class="text-base text-gray-300 hover:text-white transition-colors">Accueil</a></li>
-                        <li><a href="mbti.html" class="text-base text-gray-300 hover:text-white transition-colors">MBTI</a></li>
-                        <li><a href="enneagramme.html" class="text-base text-gray-300 hover:text-white transition-colors">Ennéagramme</a></li>
-                        <li><a href="blog.html" class="text-base text-gray-300 hover:text-white transition-colors">Blog</a></li>
-                       <li><a href="index.html#home-ia" class="text-base text-gray-300 hover:text-white transition-colors">IA spécialisée</a></li>
-                        <li><a href="index.html#home-faq" class="text-base text-gray-300 hover:text-white transition-colors">FAQ</a></li>
-
-                    </ul>
-                </div>
-                <div>
-                    <h3 class="text-sm font-semibold text-gray-400 tracking-wider uppercase">Tests</h3>
-                    <ul class="mt-4 space-y-4">
-                        <li><a href="index.html#home-mbti" class="text-base text-gray-300 hover:text-white transition-colors">Auto-évaluation</a></li>
-                        <li><a href="index.html#home-enneagramme" class="text-base text-gray-300 hover:text-white transition-colors">Évaluer un proche</a></li>
-                        <li><a href="index.html#retourver-profil" class="text-base text-gray-300 hover:text-white transition-colors">Mon profil</a></li>
-                    </ul>
-                </div>
-                <div>
-                    <h3 class="text-sm font-semibold text-gray-400 tracking-wider uppercase">Légal</h3>
-                    <ul class="mt-4 space-y-4">
-                        <li><a href="#" onclick="showPrivacyPolicy(); return false;" class="text-base text-gray-300 hover:text-white transition-colors">Confidentialité</a></li>
-                        <li><a href="#" onclick="showTermsOfService(); return false;" class="text-base text-gray-300 hover:text-white transition-colors">Conditions d'utilisation</a></li>
-                        <li><a href="#" onclick="showLegalNotices(); return false;" class="text-base text-gray-300 hover:text-white transition-colors">Mentions légales</a></li>
-                        <li><a href="#" onclick="showLegalNotices(); return false;" class="text-base text-gray-300 hover:text-white transition-colors">Cookies</a></li>
-                    </ul>
-                </div>
-                <div>
-                    <h3 class="text-sm font-semibold text-gray-400 tracking-wider uppercase">Contact</h3>
-                    <ul class="mt-4 space-y-4">
-                        <li><a href="#" onclick="showContact(); return false;" class="text-base text-gray-300 hover:text-white transition-colors">Support</a></li>
-                        <li class="flex space-x-6 pt-2">
-                            <a href="#" class="text-gray-400 hover:text-white transition-colors">
-                                <span class="sr-only">Facebook</span>
-                                <i class="fab fa-facebook-f"></i>
-                            </a>
-                            <a href="#" class="text-gray-400 hover:text-white transition-colors">
-                                <span class="sr-only">Instagram</span>
-                                <i class="fab fa-instagram"></i>
-                            </a>
-                            <a href="#" class="text-gray-400 hover:text-white transition-colors">
-                                <span class="sr-only">TikTok</span>
-                                <i class="fab fa-tiktok"></i>
-                            </a>
-                        </li>
-                    </ul>
-                </div>
-            </div>
-            <div class="mt-8 border-t border-gray-700 pt-8">
-                <p class="text-base text-gray-400 text-center">
-                    &copy; 2025 Personnalité Comparée. Tous droits réservés.
-                </p>
-            </div>
-        </div>
-    </footer>
+    <div id="footer"></div>
     <script src="questions-v2.js"></script>
 
    
@@ -3781,13 +3605,7 @@ function showPrivacyPolicy() {
     <!-- Modales pour les descriptions détaillées -->
     <div id="modal-container"></div>
 
-    <!-- Modale Espace Personnel -->
-    <div id="profile-modal" class="modal">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h2 class="text-xl font-bold text-gray-900">Mon Espace Personnel</h2>
-                <span class="close" onclick="closeProfileModal()">&times;</span>
-            </div>
+    <div id="profile-modal-container"></div>
             <div class="modal-body">
                 <!-- Étape 1: Saisie du code -->
                 <div id="code-input-step" class="profile-step">
@@ -4465,10 +4283,29 @@ async function trackEvent(eventName, meta = {}) {
 })();
 </script>
 
-<script src="nav.js"></script>
 
 
 
+<script>
+  async function injectHTML(selector, file) {
+    const target = document.querySelector(selector);
+    if (target) {
+      const res = await fetch(file);
+      if (res.ok) {
+        target.innerHTML = await res.text();
+      }
+    }
+  }
+  Promise.all([
+    injectHTML("#header", "/includes/header.html"),
+    injectHTML("#footer", "/includes/footer.html"),
+    injectHTML("#profile-modal-container", "/includes/profile-modal.html")
+  ]).then(() => {
+    const s = document.createElement("script");
+    s.src = "/nav.js";
+    document.body.appendChild(s);
+  });
+</script>
 </body>
 </html>
 

--- a/public/enneagramme.html
+++ b/public/enneagramme.html
@@ -392,122 +392,7 @@
 </head>
 <body id="top" class="font-sans bg-white text-gray-900">
 <!-- Navigation -->
-<header id="site-header" class="sticky-header">
-        <div class="flex items-center">
-            <div class="flex-shrink-0 flex items-center">
-                <img src="logo pc 3.png" alt="Personnalité Comparée logo" class="w-10 h-10 rounded-full object-cover"><span id="brand-home" class="ml-3 text-xl font-bold text-black">Personnalité Comparée</span>
-            </div>
-        </div>
-        <nav class="desktop-nav hidden md:ml-6 md:flex md:items-center md:space-x-8">
-            <div id="home-menu-container" class="relative group">
-                <a id="home-menu-button" href="index.html" class="inline-flex items-center gap-2 text-gray-900 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
-                    Accueil
-                    <svg class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                </a>
-                <div id="home-menu" class="invisible opacity-0 group-hover:visible group-hover:opacity-100 transition absolute left-0 mt-2 w-64 rounded-xl shadow-lg bg-white ring-1 ring-black/5 z-50">
-                    <ul class="py-2 text-sm">
-                        <li><a href="index.html#home-how" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Comment ça marche</a></li>
-                        <li><a href="index.html#home-mbti" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Auto-évaluation</a></li>
-                        <li><a href="index.html#home-enneagramme" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Évaluer un proche</a></li>
-                        <li><a href="index.html#home-ia" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Parler avec Psycho'Bot</a></li>
-                        <li><a href="index.html#retourver-profil" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Retrouver un profil</a></li>
-                        <li><a href="index.html#home-blog" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Derniers articles</a></li>
-                        <li><a href="index.html#home-faq" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Questions fréquentes</a></li>
-                        <li><a href="index.html#home-about" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">À propos du projet</a></li>
-                    </ul>
-                </div>
-            </div>
-            <div id="mbti-menu-container" class="relative group">
-                <a id="mbti-menu-button" href="mbti.html" class="inline-flex items-center gap-2 text-gray-500 hover:text-gray-700 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
-                    MBTI
-                    <svg class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                </a>
-                <div id="mbti-menu" class="invisible opacity-0 group-hover:visible group-hover:opacity-100 transition absolute left-0 mt-2 w-64 rounded-xl shadow-lg bg-white ring-1 ring-black/5 z-50">
-                    <ul class="py-2 text-sm">
-                        <li><a href="mbti.html#mbti-hero" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Comprendre le MBTI</a></li>
-                        <li><a href="mbti.html#mbti-history" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Un peu d'histoire</a></li>
-                        <li><a href="mbti.html#mbti-types" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Les 16 types</a></li>
-                        <li><a href="mbti.html#mbti-faq" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">FAQ MBTI</a></li>
-                    </ul>
-                </div>
-            </div>
-            <div id="ennea-menu-container" class="relative group">
-                <a id="ennea-menu-button" href="enneagramme.html" class="inline-flex items-center gap-2 text-gray-500 hover:text-gray-700 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
-                    Ennéagramme
-                    <svg class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                </a>
-                <div id="ennea-menu" class="invisible opacity-0 group-hover:visible group-hover:opacity-100 transition absolute left-0 mt-2 w-64 rounded-xl shadow-lg bg-white ring-1 ring-black/5 z-50">
-                    <ul class="py-2 text-sm">
-                        <li><a href="enneagramme.html#ennea-hero" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Comprendre l’Ennéagramme</a></li>
-                        <li><a href="enneagramme.html#ennea-history" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Un peu d'histoire</a></li>
-                        <li><a href="enneagramme.html#ennea-types" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Les 9 types</a></li>
-                        <li><a href="enneagramme.html#ennea-faq" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">FAQ Ennéagramme</a></li>
-                    </ul>
-                </div>
-            </div>
-            <a href="index.html#home-ia" class="text-gray-500 hover:text-gray-700 inline-flex items-center px-1 pt-1 text-sm font-medium">IA spécialisée</a>
-            <a href="blog.html" class="text-gray-500 hover:text-gray-700 inline-flex items-center px-1 pt-1 text-sm font-medium">Blog</a>
-            <a href="index.html#home-faq" class="text-gray-500 hover:text-gray-700 inline-flex items-center px-1 pt-1 text-sm font-medium">FAQ</a>
-            <button id="profile-btn-desktop" onclick="openProfileModal" class="ml-4 inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-black hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black">Mon profil</button>
-        </nav>
-        <div class="-mr-2 flex items-center md:hidden">
-            <button type="button" id="mobile-menu-button" class="inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500" aria-controls="mobile-menu" aria-expanded="false">
-                <span class="sr-only">Ouvrir le menu principal</span>
-                <i class="fas fa-bars" id="menu-icon"></i>
-            </button>
-        </div>
-        <!-- Menu mobile -->
-        <div class="mobile-menu md:hidden" id="mobile-menu">
-            <div class="px-2 pt-2 pb-3 space-y-1 sm:px-3 bg-white border-t border-gray-200">
-                <div>
-                    <a id="mobile-home-button" href="index.html" class="w-full flex items-center justify-between px-3 py-2 rounded-md text-base font-medium text-gray-900" aria-expanded="false">
-                        Accueil
-                        <svg id="mobile-home-caret" class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                    </a>
-                    <div id="mobile-home-menu" class="hidden pl-4 space-y-1">
-                        <a href="index.html#home-how" class="block px-3 py-2 rounded-md text-sm text-gray-700">Comment ça marche</a>
-                        <a href="index.html#home-mbti" class="block px-3 py-2 rounded-md text-sm text-gray-700">Auto-évaluation</a>
-                        <a href="index.html#home-enneagramme" class="block px-3 py-2 rounded-md text-sm text-gray-700">Évaluer un proche</a>
-                        <a href="index.html#home-ia" class="block px-3 py-2 rounded-md text-sm text-gray-700">Parler avec Psycho'Bot</a>
-                        <a href="index.html#retourver-profil" class="block px-3 py-2 rounded-md text-sm text-gray-700">Retrouver un profil</a>
-                        <a href="index.html#home-blog" class="block px-3 py-2 rounded-md text-sm text-gray-700">Derniers articles</a>
-                        <a href="index.html#home-faq" class="block px-3 py-2 rounded-md text-sm text-gray-700">Questions fréquentes</a>
-                        <a href="index.html#home-about" class="block px-3 py-2 rounded-md text-sm text-gray-700">À propos du projet</a>
-                    </div>
-                </div>
-                <div>
-                    <a id="mobile-mbti-button" href="mbti.html" class="w-full flex items-center justify-between px-3 py-2 rounded-md text-base font-medium text-gray-500" aria-expanded="false">
-                        MBTI
-                        <svg id="mobile-mbti-caret" class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                    </a>
-                    <div id="mobile-mbti-menu" class="hidden pl-4 space-y-1">
-                        <a href="mbti.html#mbti-hero" class="block px-3 py-2 rounded-md text-sm text-gray-700">Comprendre le MBTI</a>
-                        <a href="mbti.html#mbti-history" class="block px-3 py-2 rounded-md text-sm text-gray-700">Un peu d'histoire</a>
-                        <a href="mbti.html#mbti-types" class="block px-3 py-2 rounded-md text-sm text-gray-700">Les 16 types</a>
-                        <a href="mbti.html#mbti-faq" class="block px-3 py-2 rounded-md text-sm text-gray-700">FAQ MBTI</a>
-                    </div>
-                </div>
-                <div>
-                    <a id="mobile-ennea-button" href="enneagramme.html" class="w-full flex items-center justify-between px-3 py-2 rounded-md text-base font-medium text-gray-500" aria-expanded="false">
-                        Ennéagramme
-                        <svg id="mobile-ennea-caret" class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                    </a>
-                    <div id="mobile-ennea-menu" class="hidden pl-4 space-y-1">
-                        <a href="enneagramme.html#ennea-hero" class="block px-3 py-2 rounded-md text-sm text-gray-700">Comprendre l’Ennéagramme</a>
-                        <a href="enneagramme.html#ennea-history" class="block px-3 py-2 rounded-md text-sm text-gray-700">Un peu d'histoire</a>
-                        <a href="enneagramme.html#ennea-types" class="block px-3 py-2 rounded-md text-sm text-gray-700">Les 9 types</a>
-                        <a href="enneagramme.html#ennea-faq" class="block px-3 py-2 rounded-md text-sm text-gray-700">FAQ Ennéagramme</a>
-                    </div>
-                </div>
-                <a href="index.html#home-ia" class="text-gray-500 hover:text-gray-700 block px-3 py-2 rounded-md text-base font-medium">IA spécialisée</a>
-                <a href="blog.html" class="text-gray-500 hover:text-gray-700 block px-3 py-2 rounded-md text-base font-medium">Blog</a>
-                <a href="index.html#home-faq" class="text-gray-500 hover:text-gray-700 block px-3 py-2 rounded-md text-base font-medium">FAQ</a>
-                <button id="profile-btn-mobile" onclick="openProfileModal()" class="w-full mt-2 inline-flex items-center justify-center px-4 py-2 border border-transparent text-base font-medium rounded-md shadow-sm text-white bg-black hover:bg-gray-800">
-                    Mon profil
-                </button>
-            </div>
-        </div>
-    </header>
+<div id="header"></div>
 
     <main>
 <section id="ennea-hero" class="px-4 sm:px-6 lg:px-8 relative overflow-hidden pc-hero mt-8 sm:mt-12" data-hero>
@@ -970,66 +855,7 @@
         </div>
     </div>
 
-    <footer class="bg-gray-800">
-        <div class="max-w-7xl mx-auto py-12 px-4 sm:px-6 lg:px-8">
-            <div class="grid grid-cols-2 md:grid-cols-4 gap-8">
-                <div>
-                    <h3 class="text-sm font-semibold text-gray-400 tracking-wider uppercase">Personnalité Comparée</h3>
-                    <ul class="mt-4 space-y-4">
-                        <li><a href="index.html" class="text-base text-gray-300 hover:text-white transition-colors">Accueil</a></li>
-                        <li><a href="mbti.html" class="text-base text-gray-300 hover:text-white transition-colors">MBTI</a></li>
-                        <li><a href="enneagramme.html" class="text-base text-gray-300 hover:text-white transition-colors">Ennéagramme</a></li>
-                        <li><a href="blog.html" class="text-base text-gray-300 hover:text-white transition-colors">Blog</a></li>
-                       <li><a href="index.html#home-ia" class="text-base text-gray-300 hover:text-white transition-colors">IA spécialisée</a></li>
-                        <li><a href="index.html#home-faq" class="text-base text-gray-300 hover:text-white transition-colors">FAQ</a></li>
-
-                    </ul>
-                </div>
-                <div>
-                    <h3 class="text-sm font-semibold text-gray-400 tracking-wider uppercase">Tests</h3>
-                    <ul class="mt-4 space-y-4">
-                        <li><a href="index.html#home-mbti" class="text-base text-gray-300 hover:text-white transition-colors">Auto-évaluation</a></li>
-                        <li><a href="index.html#home-enneagramme" class="text-base text-gray-300 hover:text-white transition-colors">Évaluer un proche</a></li>
-                        <li><a href="index.html#retourver-profil" class="text-base text-gray-300 hover:text-white transition-colors">Mon profil</a></li>
-                    </ul>
-                </div>
-                <div>
-                    <h3 class="text-sm font-semibold text-gray-400 tracking-wider uppercase">Légal</h3>
-                    <ul class="mt-4 space-y-4">
-                        <li><a href="#" onclick="showPrivacyPolicy(); return false;" class="text-base text-gray-300 hover:text-white transition-colors">Confidentialité</a></li>
-                        <li><a href="#" onclick="showTermsOfService(); return false;" class="text-base text-gray-300 hover:text-white transition-colors">Conditions d'utilisation</a></li>
-                        <li><a href="#" onclick="showLegalNotices(); return false;" class="text-base text-gray-300 hover:text-white transition-colors">Mentions légales</a></li>
-                        <li><a href="#" onclick="showLegalNotices(); return false;" class="text-base text-gray-300 hover:text-white transition-colors">Cookies</a></li>
-                    </ul>
-                </div>
-                <div>
-                    <h3 class="text-sm font-semibold text-gray-400 tracking-wider uppercase">Contact</h3>
-                    <ul class="mt-4 space-y-4">
-                        <li><a href="#" onclick="showContact(); return false;" class="text-base text-gray-300 hover:text-white transition-colors">Support</a></li>
-                        <li class="flex space-x-6 pt-2">
-                            <a href="#" class="text-gray-400 hover:text-white transition-colors">
-                                <span class="sr-only">Facebook</span>
-                                <i class="fab fa-facebook-f"></i>
-                            </a>
-                            <a href="#" class="text-gray-400 hover:text-white transition-colors">
-                                <span class="sr-only">Instagram</span>
-                                <i class="fab fa-instagram"></i>
-                            </a>
-                            <a href="#" class="text-gray-400 hover:text-white transition-colors">
-                                <span class="sr-only">TikTok</span>
-                                <i class="fab fa-tiktok"></i>
-                            </a>
-                        </li>
-                    </ul>
-                </div>
-            </div>
-            <div class="mt-8 border-t border-gray-700 pt-8">
-                <p class="text-base text-gray-400 text-center">
-                    &copy; 2025 Personnalité Comparée. Tous droits réservés.
-                </p>
-            </div>
-        </div>
-    </footer>
+    <div id="footer"></div>
     <script src="questions-v2.js"></script>
 
    
@@ -4232,13 +4058,7 @@ function showPrivacyPolicy() {
     <!-- Modales pour les descriptions détaillées -->
     <div id="modal-container"></div>
 
-    <!-- Modale Espace Personnel -->
-    <div id="profile-modal" class="modal">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h2 class="text-xl font-bold text-gray-900">Mon Espace Personnel</h2>
-                <span class="close" onclick="closeProfileModal()">&times;</span>
-            </div>
+    <div id="profile-modal-container"></div>
             <div class="modal-body">
                 <!-- Étape 1: Saisie du code -->
                 <div id="code-input-step" class="profile-step">
@@ -4916,10 +4736,29 @@ async function trackEvent(eventName, meta = {}) {
 })();
 </script>
 
-<script src="nav.js"></script>
 
 
 
+<script>
+  async function injectHTML(selector, file) {
+    const target = document.querySelector(selector);
+    if (target) {
+      const res = await fetch(file);
+      if (res.ok) {
+        target.innerHTML = await res.text();
+      }
+    }
+  }
+  Promise.all([
+    injectHTML("#header", "/includes/header.html"),
+    injectHTML("#footer", "/includes/footer.html"),
+    injectHTML("#profile-modal-container", "/includes/profile-modal.html")
+  ]).then(() => {
+    const s = document.createElement("script");
+    s.src = "/nav.js";
+    document.body.appendChild(s);
+  });
+</script>
 </body>
 </html>
 

--- a/public/includes/footer.html
+++ b/public/includes/footer.html
@@ -1,0 +1,60 @@
+    <footer class="bg-gray-800">
+        <div class="max-w-7xl mx-auto py-12 px-4 sm:px-6 lg:px-8">
+            <div class="grid grid-cols-2 md:grid-cols-4 gap-8">
+                <div>
+                    <h3 class="text-sm font-semibold text-gray-400 tracking-wider uppercase">Personnalité Comparée</h3>
+                    <ul class="mt-4 space-y-4">
+                        <li><a href="index.html" class="text-base text-gray-300 hover:text-white transition-colors">Accueil</a></li>
+                        <li><a href="mbti.html" class="text-base text-gray-300 hover:text-white transition-colors">MBTI</a></li>
+                        <li><a href="enneagramme.html" class="text-base text-gray-300 hover:text-white transition-colors">Ennéagramme</a></li>
+                        <li><a href="blog.html" class="text-base text-gray-300 hover:text-white transition-colors">Blog</a></li>
+                       <li><a href="#home-ia" class="text-base text-gray-300 hover:text-white transition-colors">IA spécialisée</a></li>
+                        <li><a href="#home-faq" class="text-base text-gray-300 hover:text-white transition-colors">FAQ</a></li>
+
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="text-sm font-semibold text-gray-400 tracking-wider uppercase">Tests</h3>
+                    <ul class="mt-4 space-y-4">
+                        <li><a href="#home-mbti" class="text-base text-gray-300 hover:text-white transition-colors">Auto-évaluation</a></li>
+                        <li><a href="#home-enneagramme" class="text-base text-gray-300 hover:text-white transition-colors">Évaluer un proche</a></li>
+                        <li><a href="#retourver-profil" class="text-base text-gray-300 hover:text-white transition-colors">Mon profil</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="text-sm font-semibold text-gray-400 tracking-wider uppercase">Légal</h3>
+                    <ul class="mt-4 space-y-4">
+                        <li><a href="#" onclick="showPrivacyPolicy(); return false;" class="text-base text-gray-300 hover:text-white transition-colors">Confidentialité</a></li>
+                        <li><a href="#" onclick="showTermsOfService(); return false;" class="text-base text-gray-300 hover:text-white transition-colors">Conditions d'utilisation</a></li>
+                        <li><a href="#" onclick="showLegalNotices(); return false;" class="text-base text-gray-300 hover:text-white transition-colors">Mentions légales</a></li>
+                        <li><a href="#" onclick="showLegalNotices(); return false;" class="text-base text-gray-300 hover:text-white transition-colors">Cookies</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="text-sm font-semibold text-gray-400 tracking-wider uppercase">Contact</h3>
+                    <ul class="mt-4 space-y-4">
+                        <li><a href="#" onclick="showContact(); return false;" class="text-base text-gray-300 hover:text-white transition-colors">Support</a></li>
+                        <li class="flex space-x-6 pt-2">
+                            <a href="#" class="text-gray-400 hover:text-white transition-colors">
+                                <span class="sr-only">Facebook</span>
+                                <i class="fab fa-facebook-f"></i>
+                            </a>
+                            <a href="#" class="text-gray-400 hover:text-white transition-colors">
+                                <span class="sr-only">Instagram</span>
+                                <i class="fab fa-instagram"></i>
+                            </a>
+                            <a href="#" class="text-gray-400 hover:text-white transition-colors">
+                                <span class="sr-only">TikTok</span>
+                                <i class="fab fa-tiktok"></i>
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+            <div class="mt-8 border-t border-gray-700 pt-8">
+                <p class="text-base text-gray-400 text-center">
+                    &copy; 2025 Personnalité Comparée. Tous droits réservés.
+                </p>
+            </div>
+        </div>
+    </footer>

--- a/public/includes/header.html
+++ b/public/includes/header.html
@@ -1,0 +1,118 @@
+    <header id="site-header" class="sticky-header">
+        <div class="flex items-center">
+            <div class="flex-shrink-0 flex items-center">
+                <img src="logo pc 3.png" alt="Personnalité Comparée logo" class="w-10 h-10 rounded-full object-cover"><span id="brand-home" class="ml-3 text-xl font-bold text-black">Personnalité Comparée</span>
+            </div>
+        </div>
+        <nav class="desktop-nav hidden md:ml-6 md:flex md:items-center md:space-x-8">
+            <div id="home-menu-container" class="relative">
+                <a id="home-menu-button" href="index.html" class="inline-flex items-center gap-2 text-gray-900 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
+                    Accueil
+                    <svg class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
+                </a>
+                <div id="home-menu" class="invisible opacity-0 transition absolute left-0 mt-2 w-64 rounded-xl shadow-lg bg-white ring-1 ring-black/5 z-50">
+                    <ul class="py-2 text-sm">
+                        <li><a href="index.html#home-how" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Comment ça marche</a></li>
+                        <li><a href="index.html#home-mbti" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Auto-évaluation</a></li>
+                        <li><a href="index.html#home-enneagramme" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Évaluer un proche</a></li>
+                        <li><a href="index.html#home-ia" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Parler avec Psycho'Bot</a></li>
+                        <li><a href="index.html#retourver-profil" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Retrouver un profil</a></li>
+                        <li><a href="index.html#home-blog" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Derniers articles</a></li>
+                        <li><a href="index.html#home-faq" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Questions fréquentes</a></li>
+                        <li><a href="index.html#home-about" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">À propos du projet</a></li>
+                    </ul>
+                </div>
+            </div>
+            <div id="mbti-menu-container" class="relative">
+                <a id="mbti-menu-button" href="mbti.html" class="inline-flex items-center gap-2 text-gray-500 hover:text-gray-700 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
+                    MBTI
+                    <svg class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
+                </a>
+                <div id="mbti-menu" class="invisible opacity-0 transition absolute left-0 mt-2 w-64 rounded-xl shadow-lg bg-white ring-1 ring-black/5 z-50">
+                    <ul class="py-2 text-sm">
+                        <li><a href="mbti.html#mbti-hero" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Comprendre le MBTI</a></li>
+                        <li><a href="mbti.html#mbti-history" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Un peu d'histoire</a></li>
+                        <li><a href="mbti.html#mbti-types" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Les 16 types</a></li>
+                        <li><a href="mbti.html#mbti-faq" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">FAQ MBTI</a></li>
+                    </ul>
+                </div>
+            </div>
+            <div id="ennea-menu-container" class="relative">
+                <a id="ennea-menu-button" href="enneagramme.html" class="inline-flex items-center gap-2 text-gray-500 hover:text-gray-700 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
+                    Ennéagramme
+                    <svg class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
+                </a>
+                <div id="ennea-menu" class="invisible opacity-0 transition absolute left-0 mt-2 w-64 rounded-xl shadow-lg bg-white ring-1 ring-black/5 z-50">
+                    <ul class="py-2 text-sm">
+                        <li><a href="enneagramme.html#ennea-hero" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Comprendre l’Ennéagramme</a></li>
+                        <li><a href="enneagramme.html#ennea-history" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Un peu d'histoire</a></li>
+                        <li><a href="enneagramme.html#ennea-types" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Les 9 types</a></li>
+                        <li><a href="enneagramme.html#ennea-faq" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">FAQ Ennéagramme</a></li>
+                    </ul>
+                </div>
+            </div>
+            <a href="index.html#home-ia" class="text-gray-500 hover:text-gray-700 inline-flex items-center px-1 pt-1 text-sm font-medium">IA spécialisée</a>
+            <a href="blog.html" class="text-gray-500 hover:text-gray-700 inline-flex items-center px-1 pt-1 text-sm font-medium">Blog</a>
+            <a href="index.html#home-faq" class="text-gray-500 hover:text-gray-700 inline-flex items-center px-1 pt-1 text-sm font-medium">FAQ</a>
+            <button id="profile-btn-desktop" onclick="openProfileModal()" class="ml-4 inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-black hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black">
+                Mon profil
+            </button>
+        </nav>
+        <div class="-mr-2 flex items-center md:hidden">
+            <button type="button" id="mobile-menu-button" class="inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500" aria-controls="mobile-menu" aria-expanded="false">
+                <span class="sr-only">Ouvrir le menu principal</span>
+                <i class="fas fa-bars" id="menu-icon"></i>
+            </button>
+        </div>
+        <!-- Menu mobile -->
+        <div class="mobile-menu md:hidden" id="mobile-menu">
+            <div class="px-2 pt-2 pb-3 space-y-1 sm:px-3 bg-white border-t border-gray-200">
+                <div>
+                    <a id="mobile-home-button" href="index.html" class="w-full flex items-center justify-between px-3 py-2 rounded-md text-base font-medium text-gray-900" aria-expanded="false">
+                        Accueil
+                        <svg id="mobile-home-caret" class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
+                    </a>
+                    <div id="mobile-home-menu" class="hidden pl-4 space-y-1">
+                        <a href="index.html#home-how" class="block px-3 py-2 rounded-md text-sm text-gray-700">Comment ça marche</a>
+                        <a href="index.html#home-mbti" class="block px-3 py-2 rounded-md text-sm text-gray-700">Auto-évaluation</a>
+                        <a href="index.html#home-enneagramme" class="block px-3 py-2 rounded-md text-sm text-gray-700">Évaluer un proche</a>
+                        <a href="index.html#home-ia" class="block px-3 py-2 rounded-md text-sm text-gray-700">Parler avec Psycho'Bot</a>
+                        <a href="index.html#retourver-profil" class="block px-3 py-2 rounded-md text-sm text-gray-700">Retrouver un profil</a>
+                        <a href="index.html#home-blog" class="block px-3 py-2 rounded-md text-sm text-gray-700">Derniers articles</a>
+                        <a href="index.html#home-faq" class="block px-3 py-2 rounded-md text-sm text-gray-700">Questions fréquentes</a>
+                        <a href="index.html#home-about" class="block px-3 py-2 rounded-md text-sm text-gray-700">À propos du projet</a>
+                    </div>
+                </div>
+                <div>
+                    <a id="mobile-mbti-button" href="mbti.html" class="w-full flex items-center justify-between px-3 py-2 rounded-md text-base font-medium text-gray-500" aria-expanded="false">
+                        MBTI
+                        <svg id="mobile-mbti-caret" class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
+                    </a>
+                    <div id="mobile-mbti-menu" class="hidden pl-4 space-y-1">
+                        <a href="mbti.html#mbti-hero" class="block px-3 py-2 rounded-md text-sm text-gray-700">Comprendre le MBTI</a>
+                        <a href="mbti.html#mbti-history" class="block px-3 py-2 rounded-md text-sm text-gray-700">Un peu d'histoire</a>
+                        <a href="mbti.html#mbti-types" class="block px-3 py-2 rounded-md text-sm text-gray-700">Les 16 types</a>
+                        <a href="mbti.html#mbti-faq" class="block px-3 py-2 rounded-md text-sm text-gray-700">FAQ MBTI</a>
+                    </div>
+                </div>
+                <div>
+                    <a id="mobile-ennea-button" href="enneagramme.html" class="w-full flex items-center justify-between px-3 py-2 rounded-md text-base font-medium text-gray-500" aria-expanded="false">
+                        Ennéagramme
+                        <svg id="mobile-ennea-caret" class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
+                    </a>
+                    <div id="mobile-ennea-menu" class="hidden pl-4 space-y-1">
+                        <a href="enneagramme.html#ennea-hero" class="block px-3 py-2 rounded-md text-sm text-gray-700">Comprendre l’Ennéagramme</a>
+                        <a href="enneagramme.html#ennea-history" class="block px-3 py-2 rounded-md text-sm text-gray-700">Un peu d'histoire</a>
+                        <a href="enneagramme.html#ennea-types" class="block px-3 py-2 rounded-md text-sm text-gray-700">Les 9 types</a>
+                        <a href="enneagramme.html#ennea-faq" class="block px-3 py-2 rounded-md text-sm text-gray-700">FAQ Ennéagramme</a>
+                    </div>
+                </div>
+                <a href="index.html#home-ia" class="text-gray-500 hover:text-gray-700 block px-3 py-2 rounded-md text-base font-medium">IA spécialisée</a>
+                <a href="blog.html" class="text-gray-500 hover:text-gray-700 block px-3 py-2 rounded-md text-base font-medium">Blog</a>
+                <a href="index.html#home-faq" class="text-gray-500 hover:text-gray-700 block px-3 py-2 rounded-md text-base font-medium">FAQ</a>
+                <button id="profile-btn-mobile" onclick="openProfileModal()" class="w-full mt-2 inline-flex items-center justify-center px-4 py-2 border border-transparent text-base font-medium rounded-md shadow-sm text-white bg-black hover:bg-gray-800">
+                    Mon profil
+                </button>
+            </div>
+        </div>
+    </header>

--- a/public/includes/profile-modal.html
+++ b/public/includes/profile-modal.html
@@ -1,0 +1,105 @@
+    <div id="profile-modal" class="modal">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h2 class="text-xl font-bold text-gray-900">Mon Espace Personnel</h2>
+                <span class="close" onclick="closeProfileModal()">&times;</span>
+            </div>
+            <div class="modal-body">
+                <!-- Étape 1: Saisie du code -->
+                <div id="code-input-step" class="profile-step">
+                    <div class="text-center mb-6">
+                        <div class="mx-auto flex items-center justify-center h-12 w-12 rounded-full bg-blue-100 mb-4">
+                            <i class="fas fa-key text-blue-600 text-xl"></i>
+                        </div>
+                        <h3 class="text-lg font-medium text-gray-900 mb-2">Accédez à votre profil</h3>
+                        <p class="text-sm text-gray-500">Entrez votre code unique pour consulter vos résultats</p>
+                    </div>
+                    
+                    <div class="space-y-4">
+                        <div>
+                            <label for="profile-code" class="block text-sm font-medium text-gray-700 mb-2">Code unique</label>
+                            <input type="text" id="profile-code" placeholder="Entrez votre code (ex: ABC123)" 
+                                   class="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 text-center text-lg font-mono tracking-wider uppercase">
+                        </div>
+                        <button onclick="checkProfileCode()" class="w-full inline-flex items-center justify-center px-4 py-2 border border-transparent text-base font-medium rounded-md text-white bg-black hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black">
+                            <i class="fas fa-sign-in-alt mr-2"></i>
+                            Accéder à mon profil
+                        </button>
+                    </div>
+                </div>
+
+                <!-- Étape 2: Statut des évaluations -->
+                <div id="profile-status-step" class="profile-step" style="display: none;">
+                    <div class="text-center mb-6">
+                        <div class="mx-auto flex items-center justify-center h-12 w-12 rounded-full bg-blue-100 mb-4">
+                            <i class="fas fa-user-circle text-blue-600 text-xl"></i>
+                        </div>
+                        <h3 class="text-lg font-medium text-gray-900 mb-2">Profil de <span id="profile-name"></span></h3>
+                        <p class="text-sm text-gray-500">Code: <span id="display-code" class="font-mono font-bold"></span></p>
+                    </div>
+
+                    <!-- Statut des évaluations -->
+                    <div class="bg-gray-50 rounded-lg p-4 mb-6">
+                        <h4 class="font-medium text-gray-900 mb-3">Statut des évaluations</h4>
+                        <div class="space-y-3">
+                            <div class="flex items-center justify-between">
+                                <span class="text-sm text-gray-600">Votre auto-évaluation</span>
+                                <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">
+                                    <i class="fas fa-check mr-1"></i> Terminée
+                                </span>
+                            </div>
+                            <div class="flex items-center justify-between">
+                                <span class="text-sm text-gray-600">Évaluations des proches</span>
+                                <span id="evaluations-status" class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium">
+                                    <!-- Sera rempli dynamiquement -->
+                                </span>
+                            </div>
+                        </div>
+                        
+                        <!-- Barre de progression -->
+                        <div class="mt-4">
+                            <div class="flex justify-between text-sm text-gray-600 mb-1">
+                                <span>Progression globale</span>
+                                <span id="progress-text">0/4 terminé</span>
+                            </div>
+                            <div class="w-full bg-gray-200 rounded-full h-2">
+                                <div id="progress-bar" class="bg-blue-600 h-2 rounded-full transition-all duration-500" style="width: 0%"></div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- Message selon le statut -->
+                    <div id="status-message" class="rounded-lg p-4 mb-4">
+                        <!-- Sera rempli dynamiquement -->
+                    </div>
+
+                    <!-- Actions -->
+                    <div class="flex space-x-3">
+                        <button onclick="shareCode()" class="flex-1 inline-flex items-center justify-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50">
+                            <i class="fas fa-share mr-2"></i>
+                            Partager mon code
+                        </button>
+                        <button id="seeResultsBtn" onclick="viewResults()" class="flex-1 inline-flex items-center justify-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-black hover:bg-gray-800">
+                            <i class="fas fa-chart-pie mr-2"></i>
+                            Voir mes résultats
+                        </button>
+                    </div>
+                </div>
+
+                <!-- Message d'erreur -->
+                <div id="error-message" class="profile-step" style="display: none;">
+                    <div class="text-center">
+                        <div class="mx-auto flex items-center justify-center h-12 w-12 rounded-full bg-red-100 mb-4">
+                            <i class="fas fa-exclamation-triangle text-red-600 text-xl"></i>
+                        </div>
+                        <h3 class="text-lg font-medium text-gray-900 mb-2">Code introuvable</h3>
+                        <p class="text-sm text-gray-500 mb-4">Le code que vous avez entré n'existe pas ou est incorrect.</p>
+                        <button onclick="resetProfileModal()" class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-black hover:bg-gray-800">
+                            Réessayer
+                        </button>
+                    </div>
+                </div>
+    </div>
+        </div>
+    </div>
+

--- a/public/index.html
+++ b/public/index.html
@@ -392,124 +392,7 @@
 </head>
 <body id="top" class="font-sans bg-white text-gray-900">
     <!-- Navigation -->
-    <header id="site-header" class="sticky-header">
-        <div class="flex items-center">
-            <div class="flex-shrink-0 flex items-center">
-                <img src="logo pc 3.png" alt="Personnalité Comparée logo" class="w-10 h-10 rounded-full object-cover"><span id="brand-home" class="ml-3 text-xl font-bold text-black">Personnalité Comparée</span>
-            </div>
-        </div>
-        <nav class="desktop-nav hidden md:ml-6 md:flex md:items-center md:space-x-8">
-            <div id="home-menu-container" class="relative">
-                <a id="home-menu-button" href="index.html" class="inline-flex items-center gap-2 text-gray-900 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
-                    Accueil
-                    <svg class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                </a>
-                <div id="home-menu" class="invisible opacity-0 transition absolute left-0 mt-2 w-64 rounded-xl shadow-lg bg-white ring-1 ring-black/5 z-50">
-                    <ul class="py-2 text-sm">
-                        <li><a href="index.html#home-how" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Comment ça marche</a></li>
-                        <li><a href="index.html#home-mbti" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Auto-évaluation</a></li>
-                        <li><a href="index.html#home-enneagramme" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Évaluer un proche</a></li>
-                        <li><a href="index.html#home-ia" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Parler avec Psycho'Bot</a></li>
-                        <li><a href="index.html#retourver-profil" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Retrouver un profil</a></li>
-                        <li><a href="index.html#home-blog" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Derniers articles</a></li>
-                        <li><a href="index.html#home-faq" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Questions fréquentes</a></li>
-                        <li><a href="index.html#home-about" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">À propos du projet</a></li>
-                    </ul>
-                </div>
-            </div>
-            <div id="mbti-menu-container" class="relative">
-                <a id="mbti-menu-button" href="mbti.html" class="inline-flex items-center gap-2 text-gray-500 hover:text-gray-700 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
-                    MBTI
-                    <svg class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                </a>
-                <div id="mbti-menu" class="invisible opacity-0 transition absolute left-0 mt-2 w-64 rounded-xl shadow-lg bg-white ring-1 ring-black/5 z-50">
-                    <ul class="py-2 text-sm">
-                        <li><a href="mbti.html#mbti-hero" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Comprendre le MBTI</a></li>
-                        <li><a href="mbti.html#mbti-history" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Un peu d'histoire</a></li>
-                        <li><a href="mbti.html#mbti-types" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Les 16 types</a></li>
-                        <li><a href="mbti.html#mbti-faq" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">FAQ MBTI</a></li>
-                    </ul>
-                </div>
-            </div>
-            <div id="ennea-menu-container" class="relative">
-                <a id="ennea-menu-button" href="enneagramme.html" class="inline-flex items-center gap-2 text-gray-500 hover:text-gray-700 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
-                    Ennéagramme
-                    <svg class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                </a>
-                <div id="ennea-menu" class="invisible opacity-0 transition absolute left-0 mt-2 w-64 rounded-xl shadow-lg bg-white ring-1 ring-black/5 z-50">
-                    <ul class="py-2 text-sm">
-                        <li><a href="enneagramme.html#ennea-hero" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Comprendre l’Ennéagramme</a></li>
-                        <li><a href="enneagramme.html#ennea-history" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Un peu d'histoire</a></li>
-                        <li><a href="enneagramme.html#ennea-types" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Les 9 types</a></li>
-                        <li><a href="enneagramme.html#ennea-faq" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">FAQ Ennéagramme</a></li>
-                    </ul>
-                </div>
-            </div>
-            <a href="index.html#home-ia" class="text-gray-500 hover:text-gray-700 inline-flex items-center px-1 pt-1 text-sm font-medium">IA spécialisée</a>
-            <a href="blog.html" class="text-gray-500 hover:text-gray-700 inline-flex items-center px-1 pt-1 text-sm font-medium">Blog</a>
-            <a href="index.html#home-faq" class="text-gray-500 hover:text-gray-700 inline-flex items-center px-1 pt-1 text-sm font-medium">FAQ</a>
-            <button id="profile-btn-desktop" onclick="openProfileModal()" class="ml-4 inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-black hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black">
-                Mon profil
-            </button>
-        </nav>
-        <div class="-mr-2 flex items-center md:hidden">
-            <button type="button" id="mobile-menu-button" class="inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500" aria-controls="mobile-menu" aria-expanded="false">
-                <span class="sr-only">Ouvrir le menu principal</span>
-                <i class="fas fa-bars" id="menu-icon"></i>
-            </button>
-        </div>
-        <!-- Menu mobile -->
-        <div class="mobile-menu md:hidden" id="mobile-menu">
-            <div class="px-2 pt-2 pb-3 space-y-1 sm:px-3 bg-white border-t border-gray-200">
-                <div>
-                    <a id="mobile-home-button" href="index.html" class="w-full flex items-center justify-between px-3 py-2 rounded-md text-base font-medium text-gray-900" aria-expanded="false">
-                        Accueil
-                        <svg id="mobile-home-caret" class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                    </a>
-                    <div id="mobile-home-menu" class="hidden pl-4 space-y-1">
-                        <a href="index.html#home-how" class="block px-3 py-2 rounded-md text-sm text-gray-700">Comment ça marche</a>
-                        <a href="index.html#home-mbti" class="block px-3 py-2 rounded-md text-sm text-gray-700">Auto-évaluation</a>
-                        <a href="index.html#home-enneagramme" class="block px-3 py-2 rounded-md text-sm text-gray-700">Évaluer un proche</a>
-                        <a href="index.html#home-ia" class="block px-3 py-2 rounded-md text-sm text-gray-700">Parler avec Psycho'Bot</a>
-                        <a href="index.html#retourver-profil" class="block px-3 py-2 rounded-md text-sm text-gray-700">Retrouver un profil</a>
-                        <a href="index.html#home-blog" class="block px-3 py-2 rounded-md text-sm text-gray-700">Derniers articles</a>
-                        <a href="index.html#home-faq" class="block px-3 py-2 rounded-md text-sm text-gray-700">Questions fréquentes</a>
-                        <a href="index.html#home-about" class="block px-3 py-2 rounded-md text-sm text-gray-700">À propos du projet</a>
-                    </div>
-                </div>
-                <div>
-                    <a id="mobile-mbti-button" href="mbti.html" class="w-full flex items-center justify-between px-3 py-2 rounded-md text-base font-medium text-gray-500" aria-expanded="false">
-                        MBTI
-                        <svg id="mobile-mbti-caret" class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                    </a>
-                    <div id="mobile-mbti-menu" class="hidden pl-4 space-y-1">
-                        <a href="mbti.html#mbti-hero" class="block px-3 py-2 rounded-md text-sm text-gray-700">Comprendre le MBTI</a>
-                        <a href="mbti.html#mbti-history" class="block px-3 py-2 rounded-md text-sm text-gray-700">Un peu d'histoire</a>
-                        <a href="mbti.html#mbti-types" class="block px-3 py-2 rounded-md text-sm text-gray-700">Les 16 types</a>
-                        <a href="mbti.html#mbti-faq" class="block px-3 py-2 rounded-md text-sm text-gray-700">FAQ MBTI</a>
-                    </div>
-                </div>
-                <div>
-                    <a id="mobile-ennea-button" href="enneagramme.html" class="w-full flex items-center justify-between px-3 py-2 rounded-md text-base font-medium text-gray-500" aria-expanded="false">
-                        Ennéagramme
-                        <svg id="mobile-ennea-caret" class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                    </a>
-                    <div id="mobile-ennea-menu" class="hidden pl-4 space-y-1">
-                        <a href="enneagramme.html#ennea-hero" class="block px-3 py-2 rounded-md text-sm text-gray-700">Comprendre l’Ennéagramme</a>
-                        <a href="enneagramme.html#ennea-history" class="block px-3 py-2 rounded-md text-sm text-gray-700">Un peu d'histoire</a>
-                        <a href="enneagramme.html#ennea-types" class="block px-3 py-2 rounded-md text-sm text-gray-700">Les 9 types</a>
-                        <a href="enneagramme.html#ennea-faq" class="block px-3 py-2 rounded-md text-sm text-gray-700">FAQ Ennéagramme</a>
-                    </div>
-                </div>
-                <a href="index.html#home-ia" class="text-gray-500 hover:text-gray-700 block px-3 py-2 rounded-md text-base font-medium">IA spécialisée</a>
-                <a href="blog.html" class="text-gray-500 hover:text-gray-700 block px-3 py-2 rounded-md text-base font-medium">Blog</a>
-                <a href="index.html#home-faq" class="text-gray-500 hover:text-gray-700 block px-3 py-2 rounded-md text-base font-medium">FAQ</a>
-                <button id="profile-btn-mobile" onclick="openProfileModal()" class="w-full mt-2 inline-flex items-center justify-center px-4 py-2 border border-transparent text-base font-medium rounded-md shadow-sm text-white bg-black hover:bg-gray-800">
-                    Mon profil
-                </button>
-            </div>
-        </div>
-    </header>
+    <div id="header"></div>
 
   <!-- Hero Section Premium -->
     <section id="home-hero" data-aos="fade-up" class="section section-clair relative flex items-center justify-center overflow-hidden pc-hero mt-8 sm:mt-12" data-hero style="min-height: 80vh;">
@@ -1012,66 +895,7 @@ Oui. Vous pouvez interroger Psycho’Bot dans la section "Parler avec Psycho’B
     </div>
 
     <!-- Footer -->
-    <footer class="bg-gray-800">
-        <div class="max-w-7xl mx-auto py-12 px-4 sm:px-6 lg:px-8">
-            <div class="grid grid-cols-2 md:grid-cols-4 gap-8">
-                <div>
-                    <h3 class="text-sm font-semibold text-gray-400 tracking-wider uppercase">Personnalité Comparée</h3>
-                    <ul class="mt-4 space-y-4">
-                        <li><a href="index.html" class="text-base text-gray-300 hover:text-white transition-colors">Accueil</a></li>
-                        <li><a href="mbti.html" class="text-base text-gray-300 hover:text-white transition-colors">MBTI</a></li>
-                        <li><a href="enneagramme.html" class="text-base text-gray-300 hover:text-white transition-colors">Ennéagramme</a></li>
-                        <li><a href="blog.html" class="text-base text-gray-300 hover:text-white transition-colors">Blog</a></li>
-                       <li><a href="#home-ia" class="text-base text-gray-300 hover:text-white transition-colors">IA spécialisée</a></li>
-                        <li><a href="#home-faq" class="text-base text-gray-300 hover:text-white transition-colors">FAQ</a></li>
-
-                    </ul>
-                </div>
-                <div>
-                    <h3 class="text-sm font-semibold text-gray-400 tracking-wider uppercase">Tests</h3>
-                    <ul class="mt-4 space-y-4">
-                        <li><a href="#home-mbti" class="text-base text-gray-300 hover:text-white transition-colors">Auto-évaluation</a></li>
-                        <li><a href="#home-enneagramme" class="text-base text-gray-300 hover:text-white transition-colors">Évaluer un proche</a></li>
-                        <li><a href="#retourver-profil" class="text-base text-gray-300 hover:text-white transition-colors">Mon profil</a></li>
-                    </ul>
-                </div>
-                <div>
-                    <h3 class="text-sm font-semibold text-gray-400 tracking-wider uppercase">Légal</h3>
-                    <ul class="mt-4 space-y-4">
-                        <li><a href="#" onclick="showPrivacyPolicy(); return false;" class="text-base text-gray-300 hover:text-white transition-colors">Confidentialité</a></li>
-                        <li><a href="#" onclick="showTermsOfService(); return false;" class="text-base text-gray-300 hover:text-white transition-colors">Conditions d'utilisation</a></li>
-                        <li><a href="#" onclick="showLegalNotices(); return false;" class="text-base text-gray-300 hover:text-white transition-colors">Mentions légales</a></li>
-                        <li><a href="#" onclick="showLegalNotices(); return false;" class="text-base text-gray-300 hover:text-white transition-colors">Cookies</a></li>
-                    </ul>
-                </div>
-                <div>
-                    <h3 class="text-sm font-semibold text-gray-400 tracking-wider uppercase">Contact</h3>
-                    <ul class="mt-4 space-y-4">
-                        <li><a href="#" onclick="showContact(); return false;" class="text-base text-gray-300 hover:text-white transition-colors">Support</a></li>
-                        <li class="flex space-x-6 pt-2">
-                            <a href="#" class="text-gray-400 hover:text-white transition-colors">
-                                <span class="sr-only">Facebook</span>
-                                <i class="fab fa-facebook-f"></i>
-                            </a>
-                            <a href="#" class="text-gray-400 hover:text-white transition-colors">
-                                <span class="sr-only">Instagram</span>
-                                <i class="fab fa-instagram"></i>
-                            </a>
-                            <a href="#" class="text-gray-400 hover:text-white transition-colors">
-                                <span class="sr-only">TikTok</span>
-                                <i class="fab fa-tiktok"></i>
-                            </a>
-                        </li>
-                    </ul>
-                </div>
-            </div>
-            <div class="mt-8 border-t border-gray-700 pt-8">
-                <p class="text-base text-gray-400 text-center">
-                    &copy; 2025 Personnalité Comparée. Tous droits réservés.
-                </p>
-            </div>
-        </div>
-    </footer>
+    <div id="footer"></div>
     <script src="questions-v2.js"></script>
 
    
@@ -4305,111 +4129,7 @@ function showPrivacyPolicy() {
     <!-- Modales pour les descriptions détaillées -->
     <div id="modal-container"></div>
 
-    <!-- Modale Espace Personnel -->
-    <div id="profile-modal" class="modal">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h2 class="text-xl font-bold text-gray-900">Mon Espace Personnel</h2>
-                <span class="close" onclick="closeProfileModal()">&times;</span>
-            </div>
-            <div class="modal-body">
-                <!-- Étape 1: Saisie du code -->
-                <div id="code-input-step" class="profile-step">
-                    <div class="text-center mb-6">
-                        <div class="mx-auto flex items-center justify-center h-12 w-12 rounded-full bg-blue-100 mb-4">
-                            <i class="fas fa-key text-blue-600 text-xl"></i>
-                        </div>
-                        <h3 class="text-lg font-medium text-gray-900 mb-2">Accédez à votre profil</h3>
-                        <p class="text-sm text-gray-500">Entrez votre code unique pour consulter vos résultats</p>
-                    </div>
-                    
-                    <div class="space-y-4">
-                        <div>
-                            <label for="profile-code" class="block text-sm font-medium text-gray-700 mb-2">Code unique</label>
-                            <input type="text" id="profile-code" placeholder="Entrez votre code (ex: ABC123)" 
-                                   class="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 text-center text-lg font-mono tracking-wider uppercase">
-                        </div>
-                        <button onclick="checkProfileCode()" class="w-full inline-flex items-center justify-center px-4 py-2 border border-transparent text-base font-medium rounded-md text-white bg-black hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black">
-                            <i class="fas fa-sign-in-alt mr-2"></i>
-                            Accéder à mon profil
-                        </button>
-                    </div>
-                </div>
-
-                <!-- Étape 2: Statut des évaluations -->
-                <div id="profile-status-step" class="profile-step" style="display: none;">
-                    <div class="text-center mb-6">
-                        <div class="mx-auto flex items-center justify-center h-12 w-12 rounded-full bg-blue-100 mb-4">
-                            <i class="fas fa-user-circle text-blue-600 text-xl"></i>
-                        </div>
-                        <h3 class="text-lg font-medium text-gray-900 mb-2">Profil de <span id="profile-name"></span></h3>
-                        <p class="text-sm text-gray-500">Code: <span id="display-code" class="font-mono font-bold"></span></p>
-                    </div>
-
-                    <!-- Statut des évaluations -->
-                    <div class="bg-gray-50 rounded-lg p-4 mb-6">
-                        <h4 class="font-medium text-gray-900 mb-3">Statut des évaluations</h4>
-                        <div class="space-y-3">
-                            <div class="flex items-center justify-between">
-                                <span class="text-sm text-gray-600">Votre auto-évaluation</span>
-                                <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">
-                                    <i class="fas fa-check mr-1"></i> Terminée
-                                </span>
-                            </div>
-                            <div class="flex items-center justify-between">
-                                <span class="text-sm text-gray-600">Évaluations des proches</span>
-                                <span id="evaluations-status" class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium">
-                                    <!-- Sera rempli dynamiquement -->
-                                </span>
-                            </div>
-                        </div>
-                        
-                        <!-- Barre de progression -->
-                        <div class="mt-4">
-                            <div class="flex justify-between text-sm text-gray-600 mb-1">
-                                <span>Progression globale</span>
-                                <span id="progress-text">0/4 terminé</span>
-                            </div>
-                            <div class="w-full bg-gray-200 rounded-full h-2">
-                                <div id="progress-bar" class="bg-blue-600 h-2 rounded-full transition-all duration-500" style="width: 0%"></div>
-                            </div>
-                        </div>
-                    </div>
-
-                    <!-- Message selon le statut -->
-                    <div id="status-message" class="rounded-lg p-4 mb-4">
-                        <!-- Sera rempli dynamiquement -->
-                    </div>
-
-                    <!-- Actions -->
-                    <div class="flex space-x-3">
-                        <button onclick="shareCode()" class="flex-1 inline-flex items-center justify-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50">
-                            <i class="fas fa-share mr-2"></i>
-                            Partager mon code
-                        </button>
-                        <button id="seeResultsBtn" onclick="viewResults()" class="flex-1 inline-flex items-center justify-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-black hover:bg-gray-800">
-                            <i class="fas fa-chart-pie mr-2"></i>
-                            Voir mes résultats
-                        </button>
-                    </div>
-                </div>
-
-                <!-- Message d'erreur -->
-                <div id="error-message" class="profile-step" style="display: none;">
-                    <div class="text-center">
-                        <div class="mx-auto flex items-center justify-center h-12 w-12 rounded-full bg-red-100 mb-4">
-                            <i class="fas fa-exclamation-triangle text-red-600 text-xl"></i>
-                        </div>
-                        <h3 class="text-lg font-medium text-gray-900 mb-2">Code introuvable</h3>
-                        <p class="text-sm text-gray-500 mb-4">Le code que vous avez entré n'existe pas ou est incorrect.</p>
-                        <button onclick="resetProfileModal()" class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-black hover:bg-gray-800">
-                            Réessayer
-                        </button>
-                    </div>
-                </div>
-    </div>
-        </div>
-    </div>
+    <div id="profile-modal-container"></div>
 
 
 
@@ -4482,111 +4202,6 @@ function showPrivacyPolicy() {
   }
 </script>
 
-<script src="https://cdn.jsdelivr.net/npm/aos@2.3.4/dist/aos.js"></script>
-<script>
-  AOS.init({
-    duration: 600,
-    easing: 'ease-out',
-    once: true
-  });
-</script>
-
-<script>
-document.addEventListener('DOMContentLoaded', () => {
-  (function(){
-  const wrap = (()=>{
-    // Essaie plusieurs sélecteurs raisonnables
-    return document.querySelector('section#hero, section.hero, .hero, .banner, [data-hero]') ||
-           [...document.querySelectorAll('section')].find(s => /vraiment|analyse/i.test(s.textContent)) ||
-           document.body;
-  })();
-  wrap.classList.add('pc-hero');
-
-  // Si pas déjà présent, injecte le canvas
-  let canvas = document.getElementById('pc-constellation');
-  if(!canvas){
-    canvas = document.createElement('canvas');
-    canvas.id = 'pc-constellation';
-    wrap.prepend(canvas);
-  }
-  // Classe de position déjà ajoutée pour garantir la superposition correcte
-
-  const ctx = canvas.getContext('2d', { alpha: true });
-  const DPR = Math.min(window.devicePixelRatio || 1, 2);
-
-  const N = 80;               // nombre de points
-  let LINK_DIST = 100;        // distance de connexion
-  let MAX_LINKS = N;          // connexions maximales par point
-  let BASE_OPACITY = 0.25;    // opacité maximale des lignes
-  const mouse = { x:0, y:0, inside:false };
-  const DRIFT = 0.008;                  // amplitude du drift autonome
-  const ALLOW_DRIFT = matchMedia('(pointer: coarse)').matches;
-  let pts = [], W=0, H=0;
-
-  function resize(){
-    const { width, height } = wrap.getBoundingClientRect();
-    W = canvas.width  = Math.floor(width * DPR);
-    H = canvas.height = Math.floor(height * DPR);
-    canvas.style.width  = width + 'px';
-    canvas.style.height = height + 'px';
-    ctx.setTransform(DPR,0,0,DPR,0,0);
-    if(!pts.length){
-      pts = Array.from({length:N}, ()=>({
-        x: Math.random()*width,
-        y: Math.random()*height,
-        vx: (Math.random()-.5)*.25,
-        vy: (Math.random()-.5)*.25
-      }));
-    }
-  }
-
-  function updateConnectivity(){
-    if (window.innerWidth <= 768) {
-      LINK_DIST = 65;         // distance de connexion augmentée
-      MAX_LINKS = 3;          // un peu plus de liaisons par point
-      BASE_OPACITY = 0.55;    // mobile
-    } else {
-      LINK_DIST = 120;        // distance de connexion augmentée
-      MAX_LINKS = N;          // inchangé pour desktop
-      BASE_OPACITY = 0.45;    // desktop
-    }
-  }
-
-  resize();
-  updateConnectivity();
-  addEventListener('resize', () => { resize(); updateConnectivity(); });
-
-  // Suivi souris uniquement dans la bannière
-  wrap.addEventListener('mouseenter', ()=>mouse.inside = true);
-  wrap.addEventListener('mouseleave', ()=>mouse.inside = false);
-  wrap.addEventListener('mousemove', e=>{
-    const r = canvas.getBoundingClientRect();
-    mouse.x = e.clientX - r.left;
-    mouse.y = e.clientY - r.top;
-  });
-
-  let stop = matchMedia('(prefers-reduced-motion: reduce)').matches;
-  matchMedia('(prefers-reduced-motion: reduce)').addEventListener?.('change', e=>{ stop = e.matches; });
-
-  function frame(){
-    if(stop) return; // respect R.M.
-    const r = canvas.getBoundingClientRect();
-    ctx.clearRect(0,0,r.width,r.height);
-
-    // --- Move
-    for(const p of pts){
-      if(mouse.inside){
-        const dx = mouse.x - p.x, dy = mouse.y - p.y;
-        const d = Math.hypot(dx,dy) || 1;
-        // Attraction "un cran au-dessus de modéré"
-        const force = Math.min(0.035, 9/(d*d));
-        p.vx += (dx/d)*force;
-        p.vy += (dy/d)*force;
-      } else if(ALLOW_DRIFT){
-        // léger mouvement autonome sur mobile
-        p.vx += (Math.random()-.5)*DRIFT;
-        p.vy += (Math.random()-.5)*DRIFT;
-      }
       // friction + clamp
       p.vx *= 0.991; p.vy *= 0.991;
       const vmax = 0.9; // vitesse max
@@ -4989,10 +4604,29 @@ async function trackEvent(eventName, meta = {}) {
 })();
 </script>
 
-<script src="nav.js"></script>
 
 
 
+<script>
+  async function injectHTML(selector, file) {
+    const target = document.querySelector(selector);
+    if (target) {
+      const res = await fetch(file);
+      if (res.ok) {
+        target.innerHTML = await res.text();
+      }
+    }
+  }
+  Promise.all([
+    injectHTML("#header", "/includes/header.html"),
+    injectHTML("#footer", "/includes/footer.html"),
+    injectHTML("#profile-modal-container", "/includes/profile-modal.html")
+  ]).then(() => {
+    const s = document.createElement("script");
+    s.src = "/nav.js";
+    document.body.appendChild(s);
+  });
+</script>
 </body>
 </html>
 

--- a/public/mbti.html
+++ b/public/mbti.html
@@ -392,124 +392,7 @@
 </head>
 <body id="top" class="font-sans bg-white text-gray-900">
 <!-- Navigation -->
-<header id="site-header" class="sticky-header">
-        <div class="flex items-center">
-            <div class="flex-shrink-0 flex items-center">
-                <img src="logo pc 3.png" alt="Personnalité Comparée logo" class="w-10 h-10 rounded-full object-cover"><span id="brand-home" class="ml-3 text-xl font-bold text-black">Personnalité Comparée</span>
-            </div>
-        </div>
-        <nav class="desktop-nav hidden md:ml-6 md:flex md:items-center md:space-x-8">
-            <div id="home-menu-container" class="relative group">
-                <a id="home-menu-button" href="index.html" class="inline-flex items-center gap-2 text-gray-900 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
-                    Accueil
-                    <svg class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                </a>
-                <div id="home-menu" class="invisible opacity-0 group-hover:visible group-hover:opacity-100 transition absolute left-0 mt-2 w-64 rounded-xl shadow-lg bg-white ring-1 ring-black/5 z-50">
-                    <ul class="py-2 text-sm">
-                        <li><a href="index.html#home-how" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Comment ça marche</a></li>
-                        <li><a href="index.html#home-mbti" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Auto-évaluation</a></li>
-                        <li><a href="index.html#home-enneagramme" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Évaluer un proche</a></li>
-                        <li><a href="index.html#home-ia" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Parler avec Psycho'Bot</a></li>
-                        <li><a href="index.html#retourver-profil" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Retrouver un profil</a></li>
-                        <li><a href="index.html#home-blog" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Derniers articles</a></li>
-                        <li><a href="index.html#home-faq" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Questions fréquentes</a></li>
-                        <li><a href="index.html#home-about" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">À propos du projet</a></li>
-                    </ul>
-                </div>
-            </div>
-            <div id="mbti-menu-container" class="relative group">
-                <a id="mbti-menu-button" href="mbti.html" class="inline-flex items-center gap-2 text-gray-500 hover:text-gray-700 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
-                    MBTI
-                    <svg class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                </a>
-                <div id="mbti-menu" class="invisible opacity-0 group-hover:visible group-hover:opacity-100 transition absolute left-0 mt-2 w-64 rounded-xl shadow-lg bg-white ring-1 ring-black/5 z-50">
-                    <ul class="py-2 text-sm">
-                        <li><a href="mbti.html#mbti-hero" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Comprendre le MBTI</a></li>
-                        <li><a href="mbti.html#mbti-history" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Un peu d'histoire</a></li>
-                        <li><a href="mbti.html#mbti-types" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Les 16 types</a></li>
-                        <li><a href="mbti.html#mbti-faq" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">FAQ MBTI</a></li>
-                    </ul>
-                </div>
-            </div>
-            <div id="ennea-menu-container" class="relative group">
-                <a id="ennea-menu-button" href="enneagramme.html" class="inline-flex items-center gap-2 text-gray-500 hover:text-gray-700 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
-                    Ennéagramme
-                    <svg class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                </a>
-                <div id="ennea-menu" class="invisible opacity-0 group-hover:visible group-hover:opacity-100 transition absolute left-0 mt-2 w-64 rounded-xl shadow-lg bg-white ring-1 ring-black/5 z-50">
-                    <ul class="py-2 text-sm">
-                        <li><a href="enneagramme.html#ennea-hero" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Comprendre l’Ennéagramme</a></li>
-                        <li><a href="enneagramme.html#ennea-history" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Un peu d'histoire</a></li>
-                        <li><a href="enneagramme.html#ennea-types" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">Les 9 types</a></li>
-                        <li><a href="enneagramme.html#ennea-faq" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100">FAQ Ennéagramme</a></li>
-                    </ul>
-                </div>
-            </div>
-            <a href="index.html#home-ia" class="text-gray-500 hover:text-gray-700 inline-flex items-center px-1 pt-1 text-sm font-medium">IA spécialisée</a>
-            <a href="blog.html" class="text-gray-500 hover:text-gray-700 inline-flex items-center px-1 pt-1 text-sm font-medium">Blog</a>
-            <a href="index.html#home-faq" class="text-gray-500 hover:text-gray-700 inline-flex items-center px-1 pt-1 text-sm font-medium">FAQ</a>
-            <button id="profile-btn-desktop" onclick="openProfileModal()" class="ml-4 inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-black hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black">
-                Mon profil
-            </button>
-        </nav>
-        <div class="-mr-2 flex items-center md:hidden">
-            <button type="button" id="mobile-menu-button" class="inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500" aria-controls="mobile-menu" aria-expanded="false">
-                <span class="sr-only">Ouvrir le menu principal</span>
-                <i class="fas fa-bars" id="menu-icon"></i>
-            </button>
-        </div>
-        <!-- Menu mobile -->
-        <div class="mobile-menu md:hidden" id="mobile-menu">
-            <div class="px-2 pt-2 pb-3 space-y-1 sm:px-3 bg-white border-t border-gray-200">
-                <div>
-                    <a id="mobile-home-button" href="index.html" class="w-full flex items-center justify-between px-3 py-2 rounded-md text-base font-medium text-gray-900" aria-expanded="false">
-                        Accueil
-                        <svg id="mobile-home-caret" class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                    </a>
-                    <div id="mobile-home-menu" class="hidden pl-4 space-y-1">
-                        <a href="index.html#home-how" class="block px-3 py-2 rounded-md text-sm text-gray-700">Comment ça marche</a>
-                        <a href="index.html#home-mbti" class="block px-3 py-2 rounded-md text-sm text-gray-700">Auto-évaluation</a>
-                        <a href="index.html#home-enneagramme" class="block px-3 py-2 rounded-md text-sm text-gray-700">Évaluer un proche</a>
-                        <a href="index.html#home-ia" class="block px-3 py-2 rounded-md text-sm text-gray-700">Parler avec Psycho'Bot</a>
-                        <a href="index.html#retourver-profil" class="block px-3 py-2 rounded-md text-sm text-gray-700">Retrouver un profil</a>
-                        <a href="index.html#home-blog" class="block px-3 py-2 rounded-md text-sm text-gray-700">Derniers articles</a>
-                        <a href="index.html#home-faq" class="block px-3 py-2 rounded-md text-sm text-gray-700">Questions fréquentes</a>
-                        <a href="index.html#home-about" class="block px-3 py-2 rounded-md text-sm text-gray-700">À propos du projet</a>
-                    </div>
-                </div>
-                <div>
-                    <a id="mobile-mbti-button" href="mbti.html" class="w-full flex items-center justify-between px-3 py-2 rounded-md text-base font-medium text-gray-500" aria-expanded="false">
-                        MBTI
-                        <svg id="mobile-mbti-caret" class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                    </a>
-                    <div id="mobile-mbti-menu" class="hidden pl-4 space-y-1">
-                        <a href="mbti.html#mbti-hero" class="block px-3 py-2 rounded-md text-sm text-gray-700">Comprendre le MBTI</a>
-                        <a href="mbti.html#mbti-history" class="block px-3 py-2 rounded-md text-sm text-gray-700">Un peu d'histoire</a>
-                        <a href="mbti.html#mbti-types" class="block px-3 py-2 rounded-md text-sm text-gray-700">Les 16 types</a>
-                        <a href="mbti.html#mbti-faq" class="block px-3 py-2 rounded-md text-sm text-gray-700">FAQ MBTI</a>
-                    </div>
-                </div>
-                <div>
-                    <a id="mobile-ennea-button" href="enneagramme.html" class="w-full flex items-center justify-between px-3 py-2 rounded-md text-base font-medium text-gray-500" aria-expanded="false">
-                        Ennéagramme
-                        <svg id="mobile-ennea-caret" class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                    </a>
-                    <div id="mobile-ennea-menu" class="hidden pl-4 space-y-1">
-                        <a href="enneagramme.html#ennea-hero" class="block px-3 py-2 rounded-md text-sm text-gray-700">Comprendre l’Ennéagramme</a>
-                        <a href="enneagramme.html#ennea-history" class="block px-3 py-2 rounded-md text-sm text-gray-700">Un peu d'histoire</a>
-                        <a href="enneagramme.html#ennea-types" class="block px-3 py-2 rounded-md text-sm text-gray-700">Les 9 types</a>
-                        <a href="enneagramme.html#ennea-faq" class="block px-3 py-2 rounded-md text-sm text-gray-700">FAQ Ennéagramme</a>
-                    </div>
-                </div>
-                <a href="index.html#home-ia" class="text-gray-500 hover:text-gray-700 block px-3 py-2 rounded-md text-base font-medium">IA spécialisée</a>
-                <a href="blog.html" class="text-gray-500 hover:text-gray-700 block px-3 py-2 rounded-md text-base font-medium">Blog</a>
-                <a href="index.html#home-faq" class="text-gray-500 hover:text-gray-700 block px-3 py-2 rounded-md text-base font-medium">FAQ</a>
-                <button id="profile-btn-mobile" onclick="openProfileModal()" class="w-full mt-2 inline-flex items-center justify-center px-4 py-2 border border-transparent text-base font-medium rounded-md shadow-sm text-white bg-black hover:bg-gray-800">
-                    Mon profil
-                </button>
-            </div>
-        </div>
-    </header>
+<div id="header"></div>
 
     <main>
 <section id="mbti-hero" class="px-4 sm:px-6 lg:px-8 relative overflow-hidden pc-hero mt-8 sm:mt-12" data-hero>
@@ -1067,66 +950,7 @@
         </div>
     </div>
 
-    <footer class="bg-gray-800">
-        <div class="max-w-7xl mx-auto py-12 px-4 sm:px-6 lg:px-8">
-            <div class="grid grid-cols-2 md:grid-cols-4 gap-8">
-                <div>
-                    <h3 class="text-sm font-semibold text-gray-400 tracking-wider uppercase">Personnalité Comparée</h3>
-                    <ul class="mt-4 space-y-4">
-                        <li><a href="index.html" class="text-base text-gray-300 hover:text-white transition-colors">Accueil</a></li>
-                        <li><a href="mbti.html" class="text-base text-gray-300 hover:text-white transition-colors">MBTI</a></li>
-                        <li><a href="enneagramme.html" class="text-base text-gray-300 hover:text-white transition-colors">Ennéagramme</a></li>
-                        <li><a href="blog.html" class="text-base text-gray-300 hover:text-white transition-colors">Blog</a></li>
-                        <li><a href="index.html#home-ia" class="text-base text-gray-300 hover:text-white transition-colors">IA spécialisée</a></li>
-                        <li><a href="index.html#home-faq" class="text-base text-gray-300 hover:text-white transition-colors">FAQ</a></li>
-
-                    </ul>
-                </div>
-                <div>
-                    <h3 class="text-sm font-semibold text-gray-400 tracking-wider uppercase">Tests</h3>
-                    <ul class="mt-4 space-y-4">
-                        <li><a href="index.html#home-mbti" class="text-base text-gray-300 hover:text-white transition-colors">Auto-évaluation</a></li>
-                        <li><a href="index.html#home-enneagramme" class="text-base text-gray-300 hover:text-white transition-colors">Évaluer un proche</a></li>
-                        <li><a href="index.html#retourver-profil" class="text-base text-gray-300 hover:text-white transition-colors">Mon profil</a></li>
-                    </ul>
-                </div>
-                <div>
-                    <h3 class="text-sm font-semibold text-gray-400 tracking-wider uppercase">Légal</h3>
-                    <ul class="mt-4 space-y-4">
-                        <li><a href="#" onclick="showPrivacyPolicy(); return false;" class="text-base text-gray-300 hover:text-white transition-colors">Confidentialité</a></li>
-                        <li><a href="#" onclick="showTermsOfService(); return false;" class="text-base text-gray-300 hover:text-white transition-colors">Conditions d'utilisation</a></li>
-                        <li><a href="#" onclick="showLegalNotices(); return false;" class="text-base text-gray-300 hover:text-white transition-colors">Mentions légales</a></li>
-                        <li><a href="#" onclick="showLegalNotices(); return false;" class="text-base text-gray-300 hover:text-white transition-colors">Cookies</a></li>
-                    </ul>
-                </div>
-                <div>
-                    <h3 class="text-sm font-semibold text-gray-400 tracking-wider uppercase">Contact</h3>
-                    <ul class="mt-4 space-y-4">
-                        <li><a href="#" onclick="showContact(); return false;" class="text-base text-gray-300 hover:text-white transition-colors">Support</a></li>
-                        <li class="flex space-x-6 pt-2">
-                            <a href="#" class="text-gray-400 hover:text-white transition-colors">
-                                <span class="sr-only">Facebook</span>
-                                <i class="fab fa-facebook-f"></i>
-                            </a>
-                            <a href="#" class="text-gray-400 hover:text-white transition-colors">
-                                <span class="sr-only">Instagram</span>
-                                <i class="fab fa-instagram"></i>
-                            </a>
-                            <a href="#" class="text-gray-400 hover:text-white transition-colors">
-                                <span class="sr-only">TikTok</span>
-                                <i class="fab fa-tiktok"></i>
-                            </a>
-                        </li>
-                    </ul>
-                </div>
-            </div>
-            <div class="mt-8 border-t border-gray-700 pt-8">
-                <p class="text-base text-gray-400 text-center">
-                    &copy; 2025 Personnalité Comparée. Tous droits réservés.
-                </p>
-            </div>
-        </div>
-    </footer>
+    <div id="footer"></div>
     <script src="questions-v2.js"></script>
 
    
@@ -4329,13 +4153,7 @@ function showPrivacyPolicy() {
     <!-- Modales pour les descriptions détaillées -->
     <div id="modal-container"></div>
 
-    <!-- Modale Espace Personnel -->
-    <div id="profile-modal" class="modal">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h2 class="text-xl font-bold text-gray-900">Mon Espace Personnel</h2>
-                <span class="close" onclick="closeProfileModal()">&times;</span>
-            </div>
+    <div id="profile-modal-container"></div>
             <div class="modal-body">
                 <!-- Étape 1: Saisie du code -->
                 <div id="code-input-step" class="profile-step">
@@ -5013,10 +4831,29 @@ async function trackEvent(eventName, meta = {}) {
 })();
 </script>
 
-<script src="nav.js"></script>
 
 
 
+<script>
+  async function injectHTML(selector, file) {
+    const target = document.querySelector(selector);
+    if (target) {
+      const res = await fetch(file);
+      if (res.ok) {
+        target.innerHTML = await res.text();
+      }
+    }
+  }
+  Promise.all([
+    injectHTML("#header", "/includes/header.html"),
+    injectHTML("#footer", "/includes/footer.html"),
+    injectHTML("#profile-modal-container", "/includes/profile-modal.html")
+  ]).then(() => {
+    const s = document.createElement("script");
+    s.src = "/nav.js";
+    document.body.appendChild(s);
+  });
+</script>
 </body>
 </html>
 


### PR DESCRIPTION
## Summary
- centralize navigation header into `public/includes/header.html`
- centralize footer and profile modal includes
- replace per-page header/footer markup with injected placeholders

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a108f076348321a0d80c0e683f32c3