### PR TITLE
Reduce MBTI article hero image size for desktop

### DIFF
--- a/public/blog-mbti-4-dimensions.html
+++ b/public/blog-mbti-4-dimensions.html
@@ -512,7 +512,7 @@
     </header>
     <main class="mt-16">
         <article class="px-4 sm:px-6 lg:px-8 max-w-3xl mx-auto">
-            <img src="blog1.jpeg" alt="Illustration symbolisant les quatre dimensions du MBTI" class="w-full h-64 sm:h-80 md:h-80 object-cover rounded-lg mb-8">
+            <img src="blog1.jpeg" alt="Illustration symbolisant les quatre dimensions du MBTI" class="w-full h-auto max-h-64 sm:max-h-72 md:max-h-80 object-contain rounded-lg mb-8">
             <h1 class="text-3xl font-bold mb-4">Les 4 dimensions du MBTI expliquées simplement</h1>
             <p class="text-gray-500 mb-8">17 août 2025 · Lecture ~8 min</p>
             <nav class="mb-12" aria-label="Sommaire">

--- a/public/blog.html
+++ b/public/blog.html
@@ -526,7 +526,7 @@
                 <div class="grid gap-8 md:grid-cols-2">
                     <article class="border rounded-lg p-6 shadow-sm hover:shadow-md transition">
                         <a href="blog-mbti-4-dimensions.html" class="block">
-                            <img src="blog1.jpeg" alt="Illustration MBTI" class="w-full h-48 object-cover rounded mb-4">
+                            <img src="blog1.jpeg" alt="Illustration MBTI" class="w-full h-auto max-h-48 object-contain rounded mb-4">
                             <h2 class="text-xl font-semibold mb-2">Les 4 dimensions du MBTI expliquées simplement</h2>
                             <p class="text-gray-700 mb-4">Tu veux enfin comprendre la différence entre un E et un I ? Voici un guide clair pour t’y retrouver.</p>
                             <span class="inline-block px-4 py-2 bg-black text-white rounded hover:bg-gray-800">Lire l’article</span>

--- a/public/index.html
+++ b/public/index.html
@@ -854,7 +854,7 @@
     </div>
     <div class="mt-12 grid gap-6 md:grid-cols-2">
       <a href="blog-mbti-4-dimensions.html" class="block p-6 rounded-xl bg-white shadow hover:shadow-md transition">
-        <img src="blog1.jpeg" alt="Illustration MBTI" class="w-full h-40 object-cover rounded mb-4">
+        <img src="blog1.jpeg" alt="Illustration MBTI" class="w-full h-auto max-h-40 object-contain rounded mb-4">
         <h3 class="text-lg font-semibold text-gray-900 mb-2">Les 4 dimensions du MBTI</h3>
         <p class="text-gray-600 text-sm">Comprenez les axes fondamentaux qui structurent les 16 types de personnalité.</p>
       </a>


### PR DESCRIPTION
## Summary
- Make MBTI article hero image responsive so the full image is visible on desktop
- Apply the same responsive sizing to the homepage and blog index thumbnails

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a13055be98832190f4cd61f78ea322