### PR TITLE
Update auto-evaluation icon color

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -598,7 +598,7 @@
       
       <!-- Step 1 -->
       <div class="text-center p-6 rounded-[2rem] bg-white shadow-lg hover:shadow-xl transition-all duration-300 transform hover:-translate-y-2">
-        <div class="mx-auto flex items-center justify-center h-20 w-20 rounded-full text-blue-700 shadow-md" style="background-color: #A7C7E7;">
+        <div class="mx-auto flex items-center justify-center h-20 w-20 rounded-full text-blue-700 shadow-md" style="background-color: #FFD8A8;">
           <i class="fas fa-user text-2xl"></i>
         </div>
       <div class="mt-6">


### PR DESCRIPTION
## Summary
- switch auto-evaluation step icon background from pastel blue to pastel orange

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a180384b748321a9fbf7ac1dd4f19a