### PR TITLE
Fix pastel icon design in About section

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1005,7 +1005,7 @@ Oui. Vous pouvez interroger Psycho’Bot dans la section "Parler avec Psycho’B
             </p>
             <div class="mt-8 grid grid-cols-1 md:grid-cols-3 gap-8">
                 <div class="text-center p-6 rounded-[2rem] bg-white shadow-lg hover:shadow-xl transition-all duration-300 transform hover:-translate-y-2">
-                    <div class="mx-auto flex items-center justify-center h-20 w-20 text-[#B94E4E]">
+                    <div class="mx-auto flex items-center justify-center w-12 h-12 rounded-full bg-[#F6D1D1] text-[#B94E4E] shadow-md">
                         <i class="fas fa-eye text-2xl"></i>
                     </div>
                     <h3 class="mt-4 text-lg font-medium text-gray-900">Vision objective</h3>
@@ -1014,7 +1014,7 @@ Oui. Vous pouvez interroger Psycho’Bot dans la section "Parler avec Psycho’B
                     </p>
                 </div>
                 <div class="text-center p-6 rounded-[2rem] bg-white shadow-lg hover:shadow-xl transition-all duration-300 transform hover:-translate-y-2">
-                    <div class="mx-auto flex items-center justify-center h-20 w-20 text-[#C9A227]">
+                    <div class="mx-auto flex items-center justify-center w-12 h-12 rounded-full bg-[#FFF3B0] text-[#C9A227] shadow-md">
                         <i class="fas fa-shield-alt text-2xl"></i>
                     </div>
                     <h3 class="mt-4 text-lg font-medium text-gray-900">Confidentialité</h3>
@@ -1023,7 +1023,7 @@ Oui. Vous pouvez interroger Psycho’Bot dans la section "Parler avec Psycho’B
                     </p>
                 </div>
                 <div class="text-center p-6 rounded-[2rem] bg-white shadow-lg hover:shadow-xl transition-all duration-300 transform hover:-translate-y-2">
-                    <div class="mx-auto flex items-center justify-center h-20 w-20 text-[#3C8F7C]">
+                    <div class="mx-auto flex items-center justify-center w-12 h-12 rounded-full bg-[#B7E4C7] text-[#3C8F7C] shadow-md">
                         <i class="fas fa-graduation-cap text-2xl"></i>
                     </div>
                     <h3 class="mt-4 text-lg font-medium text-gray-900">Base scientifique</h3>


### PR DESCRIPTION
## Summary
- Restore pastel bubbles around About section icons for Vision objective, Confidentialité, and Base scientifique to match the style used in "Comment ça marche".

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a198d1032c8321b004884825ea3a0c