### PR TITLE
Remove card container in About section

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1004,8 +1004,8 @@ Oui. Vous pouvez interroger Psycho’Bot dans la section "Parler avec Psycho’B
                 "Personnalité Comparée" est né de la volonté de créer un outil plus objectif pour comprendre sa personnalité. Contrairement aux tests traditionnels qui reposent uniquement sur l'auto-évaluation, notre approche combine votre perception avec celle de votre entourage pour un résultat plus nuancé et fidèle.
             </p>
             <div class="mt-8 grid grid-cols-1 md:grid-cols-3 gap-8">
-                <div class="text-center p-6 rounded-[2rem] bg-white shadow-lg hover:shadow-xl transition-all duration-300 transform hover:-translate-y-2">
-                    <div class="mx-auto flex items-center justify-center h-20 w-20 rounded-full text-[#B94E4E] shadow-md" style="background-color: #F6D1D1;">
+                <div class="text-center">
+                    <div class="mx-auto flex items-center justify-center h-20 w-20 rounded-full text-[#B94E4E]" style="background-color: #F6D1D1;">
                         <i class="fas fa-eye text-2xl"></i>
                     </div>
                     <h3 class="mt-6 text-lg font-medium text-gray-900">Vision objective</h3>
@@ -1013,8 +1013,8 @@ Oui. Vous pouvez interroger Psycho’Bot dans la section "Parler avec Psycho’B
                         Combiner plusieurs perspectives pour une analyse plus complète
                     </p>
                 </div>
-                <div class="text-center p-6 rounded-[2rem] bg-white shadow-lg hover:shadow-xl transition-all duration-300 transform hover:-translate-y-2">
-                    <div class="mx-auto flex items-center justify-center h-20 w-20 rounded-full text-[#C9A227] shadow-md" style="background-color: #FFF3B0;">
+                <div class="text-center">
+                    <div class="mx-auto flex items-center justify-center h-20 w-20 rounded-full text-[#C9A227]" style="background-color: #FFF3B0;">
                         <i class="fas fa-shield-alt text-2xl"></i>
                     </div>
                     <h3 class="mt-6 text-lg font-medium text-gray-900">Confidentialité</h3>
@@ -1022,8 +1022,8 @@ Oui. Vous pouvez interroger Psycho’Bot dans la section "Parler avec Psycho’B
                         Vos données sont protégées et ne sont jamais partagées
                     </p>
                 </div>
-                <div class="text-center p-6 rounded-[2rem] bg-white shadow-lg hover:shadow-xl transition-all duration-300 transform hover:-translate-y-2">
-                    <div class="mx-auto flex items-center justify-center h-20 w-20 rounded-full text-[#3C8F7C] shadow-md" style="background-color: #B7E4C7;">
+                <div class="text-center">
+                    <div class="mx-auto flex items-center justify-center h-20 w-20 rounded-full text-[#3C8F7C]" style="background-color: #B7E4C7;">
                         <i class="fas fa-graduation-cap text-2xl"></i>
                     </div>
                     <h3 class="mt-6 text-lg font-medium text-gray-900">Base scientifique</h3>


### PR DESCRIPTION
## Summary
- remove card-like containers from About section for a flatter design

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68a19b9957388321aef7bf824ae3028d