### PR TITLE
style: refine about section visuals

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1006,27 +1006,27 @@ Oui. Vous pouvez interroger Psycho’Bot dans la section "Parler avec Psycho’B
             <div class="mt-8 grid grid-cols-1 md:grid-cols-3 gap-8">
                 <div class="text-center">
                     <div class="mx-auto flex items-center justify-center h-20 w-20 rounded-full text-[#B94E4E]" style="background-color: #F6D1D1;">
-                        <i class="fas fa-eye text-2xl"></i>
+                        <i class="fas fa-eye text-2xl drop-shadow-sm"></i>
                     </div>
-                    <h3 class="mt-6 text-lg font-medium text-gray-900">Vision objective</h3>
+                    <h3 class="mt-6 text-lg font-semibold text-gray-900">Vision objective</h3>
                     <p class="mt-3 text-sm text-gray-600">
                         Combiner plusieurs perspectives pour une analyse plus complète
                     </p>
                 </div>
                 <div class="text-center">
                     <div class="mx-auto flex items-center justify-center h-20 w-20 rounded-full text-[#C9A227]" style="background-color: #FFF3B0;">
-                        <i class="fas fa-shield-alt text-2xl"></i>
+                        <i class="fas fa-shield-alt text-2xl drop-shadow-sm"></i>
                     </div>
-                    <h3 class="mt-6 text-lg font-medium text-gray-900">Confidentialité</h3>
+                    <h3 class="mt-6 text-lg font-semibold text-gray-900">Confidentialité</h3>
                     <p class="mt-3 text-sm text-gray-600">
                         Vos données sont protégées et ne sont jamais partagées
                     </p>
                 </div>
                 <div class="text-center">
                     <div class="mx-auto flex items-center justify-center h-20 w-20 rounded-full text-[#3C8F7C]" style="background-color: #B7E4C7;">
-                        <i class="fas fa-graduation-cap text-2xl"></i>
+                        <i class="fas fa-graduation-cap text-2xl drop-shadow-sm"></i>
                     </div>
-                    <h3 class="mt-6 text-lg font-medium text-gray-900">Base scientifique</h3>
+                    <h3 class="mt-6 text-lg font-semibold text-gray-900">Base scientifique</h3>
                     <p class="mt-3 text-sm text-gray-600">
                         Fondé sur les recherches en psychologie de la personnalité
                     </p>


### PR DESCRIPTION
## Summary
- add subtle drop shadows to about-section icons
- make about-section headings bold for clarity

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a19cb7e9388321960d9adc0488f644