### PR TITLE
Move language switcher next to site title

### DIFF
--- a/public/blog-enneagramme-instincts.html
+++ b/public/blog-enneagramme-instincts.html
@@ -391,15 +391,15 @@
 
 </head>
 <body id="top" class="font-sans bg-white text-gray-900">
-    <div class="language-switcher flex gap-2 text-sm absolute top-4 right-4 z-50">
-      <button onclick="switchLang('fr')">🇫🇷 FR</button>
-      <button onclick="switchLang('en')">🇬🇧 EN</button>
-    </div>
 <!-- Navigation -->
     <header id="site-header" class="sticky-header">
         <div class="flex items-center">
             <div class="flex-shrink-0 flex items-center">
                 <img src="logo pc 3.png" alt="Personnalité Comparée logo" class="w-10 h-10 rounded-full object-cover"><span id="brand-home" class="ml-3 text-xl font-bold text-black" data-i18n="brand.name">Personnalité Comparée</span>
+            </div>
+            <div class="language-switcher ml-4 flex gap-2 text-sm">
+                <button onclick="switchLang('fr')">🇫🇷 FR</button>
+                <button onclick="switchLang('en')">🇬🇧 EN</button>
             </div>
         </div>
         <nav class="desktop-nav hidden md:ml-6 md:flex md:items-center md:space-x-8">

--- a/public/blog-mbti-4-dimensions.html
+++ b/public/blog-mbti-4-dimensions.html
@@ -391,15 +391,15 @@
 
 </head>
 <body id="top" class="font-sans bg-white text-gray-900">
-    <div class="language-switcher flex gap-2 text-sm absolute top-4 right-4 z-50">
-      <button onclick="switchLang('fr')">🇫🇷 FR</button>
-      <button onclick="switchLang('en')">🇬🇧 EN</button>
-    </div>
 <!-- Navigation -->
     <header id="site-header" class="sticky-header">
         <div class="flex items-center">
             <div class="flex-shrink-0 flex items-center">
                 <img src="logo pc 3.png" alt="Personnalité Comparée logo" class="w-10 h-10 rounded-full object-cover"><span id="brand-home" class="ml-3 text-xl font-bold text-black" data-i18n="brand.name">Personnalité Comparée</span>
+            </div>
+            <div class="language-switcher ml-4 flex gap-2 text-sm">
+                <button onclick="switchLang('fr')">🇫🇷 FR</button>
+                <button onclick="switchLang('en')">🇬🇧 EN</button>
             </div>
         </div>
         <nav class="desktop-nav hidden md:ml-6 md:flex md:items-center md:space-x-8">

--- a/public/blog.html
+++ b/public/blog.html
@@ -391,15 +391,15 @@
 
 </head>
 <body id="top" class="font-sans bg-white text-gray-900">
-    <div class="language-switcher flex gap-2 text-sm absolute top-4 right-4 z-50">
-      <button onclick="switchLang('fr')">🇫🇷 FR</button>
-      <button onclick="switchLang('en')">🇬🇧 EN</button>
-    </div>
 <!-- Navigation -->
 <header id="site-header" class="sticky-header">
         <div class="flex items-center">
             <div class="flex-shrink-0 flex items-center">
                 <img src="logo pc 3.png" alt="Personnalité Comparée logo" class="w-10 h-10 rounded-full object-cover"><span id="brand-home" class="ml-3 text-xl font-bold text-black" data-i18n="brand.name">Personnalité Comparée</span>
+            </div>
+            <div class="language-switcher ml-4 flex gap-2 text-sm">
+                <button onclick="switchLang('fr')">🇫🇷 FR</button>
+                <button onclick="switchLang('en')">🇬🇧 EN</button>
             </div>
         </div>
         <nav class="desktop-nav hidden md:ml-6 md:flex md:items-center md:space-x-8">

--- a/public/enneagramme.html
+++ b/public/enneagramme.html
@@ -391,15 +391,15 @@
 
 </head>
 <body id="top" class="font-sans bg-white text-gray-900">
-    <div class="language-switcher flex gap-2 text-sm absolute top-4 right-4 z-50">
-      <button onclick="switchLang('fr')">🇫🇷 FR</button>
-      <button onclick="switchLang('en')">🇬🇧 EN</button>
-    </div>
 <!-- Navigation -->
 <header id="site-header" class="sticky-header">
         <div class="flex items-center">
             <div class="flex-shrink-0 flex items-center">
                 <img src="logo pc 3.png" alt="Personnalité Comparée logo" class="w-10 h-10 rounded-full object-cover"><span id="brand-home" class="ml-3 text-xl font-bold text-black" data-i18n="brand.name">Personnalité Comparée</span>
+            </div>
+            <div class="language-switcher ml-4 flex gap-2 text-sm">
+                <button onclick="switchLang('fr')">🇫🇷 FR</button>
+                <button onclick="switchLang('en')">🇬🇧 EN</button>
             </div>
         </div>
         <nav class="desktop-nav hidden md:ml-6 md:flex md:items-center md:space-x-8">

--- a/public/index.html
+++ b/public/index.html
@@ -417,16 +417,16 @@
 
 </head>
 <body id="top" class="font-sans bg-white text-gray-900">
-    <div class="language-switcher flex gap-2 text-sm absolute top-4 right-4 z-50">
-      <button onclick="switchLang('fr')">🇫🇷 FR</button>
-      <button onclick="switchLang('en')">🇬🇧 EN</button>
-    </div>
     <div id="beta-banner"><div class="banner-track"><span>🚧 Ce site est encore en version bêta ! Certaines fonctions peuvent évoluer ou être améliorées. Revenez bientôt pour profiter d’une version 100% finalisée. Merci pour votre patience.</span><span aria-hidden="true">🚧 Ce site est encore en version bêta ! Certaines fonctions peuvent évoluer ou être améliorées. Revenez bientôt pour profiter d’une version 100% finalisée. Merci pour votre patience.</span></div></div>
     <!-- Navigation -->
     <header id="site-header" class="sticky-header">
         <div class="flex items-center">
             <div class="flex-shrink-0 flex items-center">
                 <img src="logo pc 3.png" alt="Personnalité Comparée logo" class="w-10 h-10 rounded-full object-cover"><span id="brand-home" class="ml-3 text-xl font-bold text-black" data-i18n="brand.name">Personnalité Comparée</span>
+            </div>
+            <div class="language-switcher ml-4 flex gap-2 text-sm">
+                <button onclick="switchLang('fr')">🇫🇷 FR</button>
+                <button onclick="switchLang('en')">🇬🇧 EN</button>
             </div>
         </div>
         <nav class="desktop-nav hidden md:ml-6 md:flex md:items-center md:space-x-8">

--- a/public/mbti.html
+++ b/public/mbti.html
@@ -391,15 +391,15 @@
 
 </head>
 <body id="top" class="font-sans bg-white text-gray-900">
-    <div class="language-switcher flex gap-2 text-sm absolute top-4 right-4 z-50">
-      <button onclick="switchLang('fr')">🇫🇷 FR</button>
-      <button onclick="switchLang('en')">🇬🇧 EN</button>
-    </div>
 <!-- Navigation -->
 <header id="site-header" class="sticky-header">
         <div class="flex items-center">
             <div class="flex-shrink-0 flex items-center">
                 <img src="logo pc 3.png" alt="Personnalité Comparée logo" class="w-10 h-10 rounded-full object-cover"><span id="brand-home" class="ml-3 text-xl font-bold text-black" data-i18n="brand.name">Personnalité Comparée</span>
+            </div>
+            <div class="language-switcher ml-4 flex gap-2 text-sm">
+                <button onclick="switchLang('fr')">🇫🇷 FR</button>
+                <button onclick="switchLang('en')">🇬🇧 EN</button>
             </div>
         </div>
         <nav class="desktop-nav hidden md:ml-6 md:flex md:items-center md:space-x-8">


### PR DESCRIPTION
## Summary
- relocate FR/EN language toggle beside the site name on all pages

## Testing
- `npm test` (fails: missing script)


------
https://chatgpt.com/codex/tasks/task_e_68a24788a53883219c485602bb6a9e45