### PR TITLE
Add language switch to MBTI dimensions article and bold language toggle

### DIFF
--- a/public/blog-enneagramme-instincts.html
+++ b/public/blog-enneagramme-instincts.html
@@ -397,7 +397,7 @@
             <div class="flex-shrink-0 flex items-center">
                 <img src="logo pc 3.png" alt="Personnalité Comparée logo" class="w-10 h-10 rounded-full object-cover"><span id="brand-home" class="ml-3 text-xl font-bold text-black" data-i18n="brand.name">Personnalité Comparée</span>
             </div>
-            <div class="language-switcher ml-4 flex gap-0 text-sm">
+            <div class="language-switcher ml-4 flex gap-0 text-sm font-bold">
                 <button onclick="switchLang('fr')" data-i18n="lang.fr">FR</button><span> | </span><button onclick="switchLang('en')" data-i18n="lang.en">EN</button>
             </div>
         </div>

--- a/public/blog-mbti-4-dimensions.html
+++ b/public/blog-mbti-4-dimensions.html
@@ -397,7 +397,8 @@
             <div class="flex-shrink-0 flex items-center">
                 <img src="logo pc 3.png" alt="Personnalité Comparée logo" class="w-10 h-10 rounded-full object-cover"><span id="brand-home" class="ml-3 text-xl font-bold text-black" data-i18n="brand.name">Personnalité Comparée</span>
             </div>
-
+            <div class="language-switcher ml-4 flex gap-0 text-sm font-bold">
+                <button onclick="switchLang('fr')" data-i18n="lang.fr">FR</button><span> | </span><button onclick="switchLang('en')" data-i18n="lang.en">EN</button>
             </div>
         </div>
         <nav class="desktop-nav hidden md:ml-6 md:flex md:items-center md:space-x-8">

--- a/public/blog.html
+++ b/public/blog.html
@@ -397,7 +397,7 @@
             <div class="flex-shrink-0 flex items-center">
                 <img src="logo pc 3.png" alt="Personnalité Comparée logo" class="w-10 h-10 rounded-full object-cover"><span id="brand-home" class="ml-3 text-xl font-bold text-black" data-i18n="brand.name">Personnalité Comparée</span>
             </div>
-            <div class="language-switcher ml-4 flex gap-0 text-sm">
+            <div class="language-switcher ml-4 flex gap-0 text-sm font-bold">
                 <button onclick="switchLang('fr')" data-i18n="lang.fr">FR</button><span> | </span><button onclick="switchLang('en')" data-i18n="lang.en">EN</button>
             </div>
         </div>

--- a/public/enneagramme.html
+++ b/public/enneagramme.html
@@ -397,7 +397,7 @@
             <div class="flex-shrink-0 flex items-center">
                 <img src="logo pc 3.png" alt="Personnalité Comparée logo" class="w-10 h-10 rounded-full object-cover"><span id="brand-home" class="ml-3 text-xl font-bold text-black" data-i18n="brand.name">Personnalité Comparée</span>
             </div>
-            <div class="language-switcher ml-4 flex gap-0 text-sm">
+            <div class="language-switcher ml-4 flex gap-0 text-sm font-bold">
                 <button onclick="switchLang('fr')" data-i18n="lang.fr">FR</button><span> | </span><button onclick="switchLang('en')" data-i18n="lang.en">EN</button>
             </div>
         </div>

--- a/public/index.html
+++ b/public/index.html
@@ -424,7 +424,7 @@
             <div class="flex-shrink-0 flex items-center">
                 <img src="logo pc 3.png" alt="Personnalité Comparée logo" class="w-10 h-10 rounded-full object-cover"><span id="brand-home" class="ml-3 text-xl font-bold text-black" data-i18n="brand.name">Personnalité Comparée</span>
             </div>
-            <div class="language-switcher ml-4 flex gap-0 text-sm">
+            <div class="language-switcher ml-4 flex gap-0 text-sm font-bold">
                 <button onclick="switchLang('fr'); updatePlaceholders();" data-i18n="lang.fr">FR</button><span> | </span><button onclick="switchLang('en'); updatePlaceholders();" data-i18n="lang.en">EN</button>
             </div>
         </div>

--- a/public/mbti.html
+++ b/public/mbti.html
@@ -397,7 +397,7 @@
             <div class="flex-shrink-0 flex items-center">
                 <img src="logo pc 3.png" alt="Personnalité Comparée logo" class="w-10 h-10 rounded-full object-cover"><span id="brand-home" class="ml-3 text-xl font-bold text-black" data-i18n="brand.name">Personnalité Comparée</span>
             </div>
-            <div class="language-switcher ml-4 flex gap-0 text-sm">
+            <div class="language-switcher ml-4 flex gap-0 text-sm font-bold">
                 <button onclick="switchLang('fr')" data-i18n="lang.fr">FR</button><span> | </span><button onclick="switchLang('en')" data-i18n="lang.en">EN</button>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- Add FR/EN language switcher to "Les 4 dimensions du MBTI" blog post
- Display bold language toggle across all pages

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a25b23b1388321b77e67872264e2bd