### PR TITLE
style: improve mbti cards hover and modal animation

### DIFF
--- a/public/mbti.html
+++ b/public/mbti.html
@@ -112,7 +112,7 @@
             max-height: 80vh;
             overflow-y: auto;
             box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
-            animation: modalSlideIn 0.3s ease-out;
+            animation: modalZoomIn 0.3s ease-out;
         }
         
         .modal-header {
@@ -145,14 +145,14 @@
             to { opacity: 1; }
         }
         
-        @keyframes modalSlideIn {
-            from { 
+        @keyframes modalZoomIn {
+            from {
                 opacity: 0;
-                transform: translateY(-50px) scale(0.95);
+                transform: scale(0.9);
             }
-            to { 
+            to {
                 opacity: 1;
-                transform: translateY(0) scale(1);
+                transform: scale(1);
             }
         }
         
@@ -597,7 +597,7 @@
             
             <div class="mt-12 grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-4">
                 <!-- Analystes (NT) -->
-                <div class="type-card bg-white overflow-hidden shadow rounded-lg transition-all duration-300">
+                <div class="type-card bg-white overflow-hidden shadow rounded-[32px] transform transition duration-300 ease-in-out hover:-translate-y-1 hover:shadow-[0_4px_12px_rgba(0,0,0,0.1)]">
                     <div class="px-4 py-5 sm:p-6">
                         <div class="flex items-center">
                             <div class="flex-shrink-0 bg-blue-500 rounded-md p-3">
@@ -621,7 +621,7 @@
                     </div>
                 </div>
                 
-                <div class="type-card bg-white overflow-hidden shadow rounded-lg transition-all duration-300">
+                <div class="type-card bg-white overflow-hidden shadow rounded-[32px] transform transition duration-300 ease-in-out hover:-translate-y-1 hover:shadow-[0_4px_12px_rgba(0,0,0,0.1)]">
                     <div class="px-4 py-5 sm:p-6">
                         <div class="flex items-center">
                             <div class="flex-shrink-0 bg-blue-500 rounded-md p-3">
@@ -645,7 +645,7 @@
                     </div>
                 </div>
                 
-                <div class="type-card bg-white overflow-hidden shadow rounded-lg transition-all duration-300">
+                <div class="type-card bg-white overflow-hidden shadow rounded-[32px] transform transition duration-300 ease-in-out hover:-translate-y-1 hover:shadow-[0_4px_12px_rgba(0,0,0,0.1)]">
                     <div class="px-4 py-5 sm:p-6">
                         <div class="flex items-center">
                             <div class="flex-shrink-0 bg-indigo-500 rounded-md p-3">
@@ -670,7 +670,7 @@
                 </div>
                 
                 <!-- Diplomates (NF) -->
-                <div class="type-card bg-white overflow-hidden shadow rounded-lg transition-all duration-300">
+                <div class="type-card bg-white overflow-hidden shadow rounded-[32px] transform transition duration-300 ease-in-out hover:-translate-y-1 hover:shadow-[0_4px_12px_rgba(0,0,0,0.1)]">
                     <div class="px-4 py-5 sm:p-6">
                         <div class="flex items-center">
                             <div class="flex-shrink-0 bg-green-500 rounded-md p-3">
@@ -694,7 +694,7 @@
                     </div>
                 </div>
                 
-                <div class="type-card bg-white overflow-hidden shadow rounded-lg transition-all duration-300">
+                <div class="type-card bg-white overflow-hidden shadow rounded-[32px] transform transition duration-300 ease-in-out hover:-translate-y-1 hover:shadow-[0_4px_12px_rgba(0,0,0,0.1)]">
                     <div class="px-4 py-5 sm:p-6">
                         <div class="flex items-center">
                             <div class="flex-shrink-0 bg-red-500 rounded-md p-3">
@@ -718,7 +718,7 @@
                     </div>
                 </div>
                 
-                <div class="type-card bg-white overflow-hidden shadow rounded-lg transition-all duration-300">
+                <div class="type-card bg-white overflow-hidden shadow rounded-[32px] transform transition duration-300 ease-in-out hover:-translate-y-1 hover:shadow-[0_4px_12px_rgba(0,0,0,0.1)]">
                     <div class="px-4 py-5 sm:p-6">
                         <div class="flex items-center">
                             <div class="flex-shrink-0 bg-teal-500 rounded-md p-3">
@@ -742,7 +742,7 @@
                     </div>
                 </div>
                 
-                <div class="type-card bg-white overflow-hidden shadow rounded-lg transition-all duration-300">
+                <div class="type-card bg-white overflow-hidden shadow rounded-[32px] transform transition duration-300 ease-in-out hover:-translate-y-1 hover:shadow-[0_4px_12px_rgba(0,0,0,0.1)]">
                     <div class="px-4 py-5 sm:p-6">
                         <div class="flex items-center">
                             <div class="flex-shrink-0 bg-pink-500 rounded-md p-3">
@@ -767,7 +767,7 @@
                 </div>
                 
                 <!-- Sentinelles (SJ) -->
-                <div class="type-card bg-white overflow-hidden shadow rounded-lg transition-all duration-300">
+                <div class="type-card bg-white overflow-hidden shadow rounded-[32px] transform transition duration-300 ease-in-out hover:-translate-y-1 hover:shadow-[0_4px_12px_rgba(0,0,0,0.1)]">
                     <div class="px-4 py-5 sm:p-6">
                         <div class="flex items-center">
                             <div class="flex-shrink-0 bg-gray-600 rounded-md p-3">
@@ -791,7 +791,7 @@
                     </div>
                 </div>
                 
-                <div class="type-card bg-white overflow-hidden shadow rounded-lg transition-all duration-300">
+                <div class="type-card bg-white overflow-hidden shadow rounded-[32px] transform transition duration-300 ease-in-out hover:-translate-y-1 hover:shadow-[0_4px_12px_rgba(0,0,0,0.1)]">
                     <div class="px-4 py-5 sm:p-6">
                         <div class="flex items-center">
                             <div class="flex-shrink-0 bg-orange-500 rounded-md p-3">
@@ -815,7 +815,7 @@
                     </div>
                 </div>
                 
-                <div class="type-card bg-white overflow-hidden shadow rounded-lg transition-all duration-300">
+                <div class="type-card bg-white overflow-hidden shadow rounded-[32px] transform transition duration-300 ease-in-out hover:-translate-y-1 hover:shadow-[0_4px_12px_rgba(0,0,0,0.1)]">
                     <div class="px-4 py-5 sm:p-6">
                         <div class="flex items-center">
                             <div class="flex-shrink-0 bg-red-600 rounded-md p-3">
@@ -839,7 +839,7 @@
                     </div>
                 </div>
                 
-                <div class="type-card bg-white overflow-hidden shadow rounded-lg transition-all duration-300">
+                <div class="type-card bg-white overflow-hidden shadow rounded-[32px] transform transition duration-300 ease-in-out hover:-translate-y-1 hover:shadow-[0_4px_12px_rgba(0,0,0,0.1)]">
                     <div class="px-4 py-5 sm:p-6">
                         <div class="flex items-center">
                             <div class="flex-shrink-0 bg-green-600 rounded-md p-3">
@@ -864,7 +864,7 @@
                 </div>
                 
                 <!-- Explorateurs (SP) -->
-                <div class="type-card bg-white overflow-hidden shadow rounded-lg transition-all duration-300">
+                <div class="type-card bg-white overflow-hidden shadow rounded-[32px] transform transition duration-300 ease-in-out hover:-translate-y-1 hover:shadow-[0_4px_12px_rgba(0,0,0,0.1)]">
                     <div class="px-4 py-5 sm:p-6">
                         <div class="flex items-center">
                             <div class="flex-shrink-0 bg-yellow-600 rounded-md p-3">
@@ -888,7 +888,7 @@
                     </div>
                 </div>
                 
-                <div class="type-card bg-white overflow-hidden shadow rounded-lg transition-all duration-300">
+                <div class="type-card bg-white overflow-hidden shadow rounded-[32px] transform transition duration-300 ease-in-out hover:-translate-y-1 hover:shadow-[0_4px_12px_rgba(0,0,0,0.1)]">
                     <div class="px-4 py-5 sm:p-6">
                         <div class="flex items-center">
                             <div class="flex-shrink-0 bg-blue-600 rounded-md p-3">
@@ -912,7 +912,7 @@
                     </div>
                 </div>
                 
-                <div class="type-card bg-white overflow-hidden shadow rounded-lg transition-all duration-300">
+                <div class="type-card bg-white overflow-hidden shadow rounded-[32px] transform transition duration-300 ease-in-out hover:-translate-y-1 hover:shadow-[0_4px_12px_rgba(0,0,0,0.1)]">
                     <div class="px-4 py-5 sm:p-6">
                         <div class="flex items-center">
                             <div class="flex-shrink-0 bg-blue-600 rounded-md p-3">
@@ -936,7 +936,7 @@
                     </div>
                 </div>
                 
-                <div class="type-card bg-white overflow-hidden shadow rounded-lg transition-all duration-300">
+                <div class="type-card bg-white overflow-hidden shadow rounded-[32px] transform transition duration-300 ease-in-out hover:-translate-y-1 hover:shadow-[0_4px_12px_rgba(0,0,0,0.1)]">
                     <div class="px-4 py-5 sm:p-6">
                         <div class="flex items-center">
                             <div class="flex-shrink-0 bg-pink-600 rounded-md p-3">


### PR DESCRIPTION
## Summary
- round MBTI profile cards like Psycho'Bot section
- add hover lift and soft shadow to MBTI cards
- zoom-in modal animation for MBTI details

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a264e125c08321bdddd16cdb715faf