### PR TITLE
Reduce brand title on mobile screens

### DIFF
--- a/public/blog-enneagramme-instincts.html
+++ b/public/blog-enneagramme-instincts.html
@@ -395,7 +395,7 @@
     <header id="site-header" class="sticky-header">
         <div class="flex items-center">
             <div class="flex-shrink-0 flex items-center">
-                <img src="logo pc 3.png" alt="Personnalité Comparée logo" class="w-10 h-10 rounded-full object-cover"><span id="brand-home" class="ml-3 text-xl font-bold text-black" data-i18n="brand.name">Personnalité Comparée</span>
+                <img src="logo pc 3.png" alt="Personnalité Comparée logo" class="w-10 h-10 rounded-full object-cover"><span id="brand-home" class="ml-3 text-base sm:text-xl font-bold text-black" data-i18n="brand.name">Personnalité Comparée</span>
             </div>
             <div class="language-switcher ml-4 flex gap-0 text-sm font-bold">
                 <button onclick="switchLang('fr')" data-i18n="lang.fr">FR</button><span> | </span><button onclick="switchLang('en')" data-i18n="lang.en">EN</button>

--- a/public/blog-mbti-4-dimensions.html
+++ b/public/blog-mbti-4-dimensions.html
@@ -395,7 +395,7 @@
     <header id="site-header" class="sticky-header">
         <div class="flex items-center">
             <div class="flex-shrink-0 flex items-center">
-                <img src="logo pc 3.png" alt="Personnalité Comparée logo" class="w-10 h-10 rounded-full object-cover"><span id="brand-home" class="ml-3 text-xl font-bold text-black" data-i18n="brand.name">Personnalité Comparée</span>
+                <img src="logo pc 3.png" alt="Personnalité Comparée logo" class="w-10 h-10 rounded-full object-cover"><span id="brand-home" class="ml-3 text-base sm:text-xl font-bold text-black" data-i18n="brand.name">Personnalité Comparée</span>
             </div>
             <div class="language-switcher ml-4 flex gap-0 text-sm font-bold">
                 <button onclick="switchLang('fr')" data-i18n="lang.fr">FR</button><span> | </span><button onclick="switchLang('en')" data-i18n="lang.en">EN</button>

--- a/public/blog.html
+++ b/public/blog.html
@@ -395,7 +395,7 @@
 <header id="site-header" class="sticky-header">
         <div class="flex items-center">
             <div class="flex-shrink-0 flex items-center">
-                <img src="logo pc 3.png" alt="Personnalité Comparée logo" class="w-10 h-10 rounded-full object-cover"><span id="brand-home" class="ml-3 text-xl font-bold text-black" data-i18n="brand.name">Personnalité Comparée</span>
+                <img src="logo pc 3.png" alt="Personnalité Comparée logo" class="w-10 h-10 rounded-full object-cover"><span id="brand-home" class="ml-3 text-base sm:text-xl font-bold text-black" data-i18n="brand.name">Personnalité Comparée</span>
             </div>
             <div class="language-switcher ml-4 flex gap-0 text-sm font-bold">
                 <button onclick="switchLang('fr')" data-i18n="lang.fr">FR</button><span> | </span><button onclick="switchLang('en')" data-i18n="lang.en">EN</button>

--- a/public/enneagramme.html
+++ b/public/enneagramme.html
@@ -395,7 +395,7 @@
 <header id="site-header" class="sticky-header">
         <div class="flex items-center">
             <div class="flex-shrink-0 flex items-center">
-                <img src="logo pc 3.png" alt="Personnalité Comparée logo" class="w-10 h-10 rounded-full object-cover"><span id="brand-home" class="ml-3 text-xl font-bold text-black" data-i18n="brand.name">Personnalité Comparée</span>
+                <img src="logo pc 3.png" alt="Personnalité Comparée logo" class="w-10 h-10 rounded-full object-cover"><span id="brand-home" class="ml-3 text-base sm:text-xl font-bold text-black" data-i18n="brand.name">Personnalité Comparée</span>
             </div>
             <div class="language-switcher ml-4 flex gap-0 text-sm font-bold">
                 <button onclick="switchLang('fr')" data-i18n="lang.fr">FR</button><span> | </span><button onclick="switchLang('en')" data-i18n="lang.en">EN</button>

--- a/public/index.html
+++ b/public/index.html
@@ -422,7 +422,7 @@
     <header id="site-header" class="sticky-header">
         <div class="flex items-center">
             <div class="flex-shrink-0 flex items-center">
-                <img src="logo pc 3.png" alt="Personnalité Comparée logo" class="w-10 h-10 rounded-full object-cover"><span id="brand-home" class="ml-3 text-xl font-bold text-black" data-i18n="brand.name">Personnalité Comparée</span>
+                <img src="logo pc 3.png" alt="Personnalité Comparée logo" class="w-10 h-10 rounded-full object-cover"><span id="brand-home" class="ml-3 text-base sm:text-xl font-bold text-black" data-i18n="brand.name">Personnalité Comparée</span>
             </div>
             <div class="language-switcher ml-4 flex gap-0 text-sm font-bold">
                 <button onclick="switchLang('fr'); updatePlaceholders();" data-i18n="lang.fr">FR</button><span> | </span><button onclick="switchLang('en'); updatePlaceholders();" data-i18n="lang.en">EN</button>

--- a/public/mbti.html
+++ b/public/mbti.html
@@ -395,7 +395,7 @@
 <header id="site-header" class="sticky-header">
         <div class="flex items-center">
             <div class="flex-shrink-0 flex items-center">
-                <img src="logo pc 3.png" alt="Personnalité Comparée logo" class="w-10 h-10 rounded-full object-cover"><span id="brand-home" class="ml-3 text-xl font-bold text-black" data-i18n="brand.name">Personnalité Comparée</span>
+                <img src="logo pc 3.png" alt="Personnalité Comparée logo" class="w-10 h-10 rounded-full object-cover"><span id="brand-home" class="ml-3 text-base sm:text-xl font-bold text-black" data-i18n="brand.name">Personnalité Comparée</span>
             </div>
             <div class="language-switcher ml-4 flex gap-0 text-sm font-bold">
                 <button onclick="switchLang('fr')" data-i18n="lang.fr">FR</button><span> | </span><button onclick="switchLang('en')" data-i18n="lang.en">EN</button>


### PR DESCRIPTION
## Summary
- shrink "Personnalité Comparée" title using responsive classes to avoid header overlap on small screens

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a279120b608321b5df6aa45b642ad8