### PR TITLE
fix: translate results section after test

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1971,6 +1971,8 @@ function displayResults(results) {
         initCountUp(resultsSection);
         addPDFDownloadHandler(resultsSection);
 
+        applyTranslations();
+
         setTimeout(() => {
             resultsSection.scrollIntoView({ behavior: 'smooth' });
         }, 100);


### PR DESCRIPTION
## Summary
- ensure results section is translated by running applyTranslations after injecting HTML

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a28825df5883218df0a0da7090a2aa