### PR TITLE
Fix translation application for Enneagram modals

### DIFF
--- a/public/common.js
+++ b/public/common.js
@@ -77,6 +77,9 @@ function showModal(title, content) {
         <div class="modal-body">${content}</div>
       </div>
     </div>`;
+  if (typeof applyTranslations === 'function') {
+    applyTranslations();
+  }
   document.addEventListener('keydown', e => { if (e.key === 'Escape') closeModal(); }, { once: true });
   document.getElementById('current-modal').addEventListener('click', e => {
     if (e.target === e.currentTarget) closeModal();

--- a/public/enneagramme.html
+++ b/public/enneagramme.html
@@ -2079,6 +2079,9 @@ function displayResults(results) {
                 </div>
             `;
             modalContainer.innerHTML = modalHTML;
+            if (typeof applyTranslations === 'function') {
+                applyTranslations();
+            }
             
             // Fermer avec ESC
             document.addEventListener('keydown', function(e) {

--- a/public/i18n.js
+++ b/public/i18n.js
@@ -4,7 +4,9 @@ function applyTranslations() {
   document.querySelectorAll('[data-i18n]').forEach(el => {
     const key = el.getAttribute('data-i18n');
     const translation = translations[lang] && translations[lang][key];
-    el.innerHTML = translation !== undefined ? translation : key;
+    if (translation !== undefined) {
+      el.innerHTML = translation;
+    }
   });
 }
 


### PR DESCRIPTION
## Summary
- Re-run translations whenever a modal is rendered so Enneagram profile dialogs reflect selected language.
- Apply the same translation refresh in shared modal utility.
- Preserve existing modal text when a translation key has no value.

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a28b4402188321becb14ddc64d7634