### PR TITLE
fix profile button and restore desktop header shadow

### DIFF
--- a/public/blog-enneagramme-instincts.html
+++ b/public/blog-enneagramme-instincts.html
@@ -391,7 +391,7 @@
 </head>
 <body id="top" class="font-sans bg-white text-gray-900">
 <!-- Navigation -->
-    <header id="site-header" class="sticky-header">
+    <header id="site-header" class="sticky-header md:shadow-md">
         <div class="flex items-center">
             <div class="flex-shrink-0 flex items-center">
                 <img src="logo pc 3.png" alt="Personnalité Comparée logo" class="w-10 h-10 rounded-full object-cover"><span id="brand-home" class="ml-3 text-[1.05rem] sm:text-xl font-bold text-black" data-i18n="brand.name">Personnalité Comparée</span>

--- a/public/blog-mbti-4-dimensions.html
+++ b/public/blog-mbti-4-dimensions.html
@@ -391,7 +391,7 @@
 </head>
 <body id="top" class="font-sans bg-white text-gray-900">
 <!-- Navigation -->
-    <header id="site-header" class="sticky-header">
+    <header id="site-header" class="sticky-header md:shadow-md">
         <div class="flex items-center">
             <div class="flex-shrink-0 flex items-center">
                 <img src="logo pc 3.png" alt="Personnalité Comparée logo" class="w-10 h-10 rounded-full object-cover"><span id="brand-home" class="ml-3 text-[1.05rem] sm:text-xl font-bold text-black" data-i18n="brand.name">Personnalité Comparée</span>

--- a/public/blog.html
+++ b/public/blog.html
@@ -391,7 +391,7 @@
 </head>
 <body id="top" class="font-sans bg-white text-gray-900">
 <!-- Navigation -->
-<header id="site-header" class="sticky-header">
+<header id="site-header" class="sticky-header md:shadow-md">
         <div class="flex items-center">
             <div class="flex-shrink-0 flex items-center">
                 <img src="logo pc 3.png" alt="Personnalité Comparée logo" class="w-10 h-10 rounded-full object-cover"><span id="brand-home" class="ml-3 text-[1.05rem] sm:text-xl font-bold text-black" data-i18n="brand.name">Personnalité Comparée</span>

--- a/public/enneagramme.html
+++ b/public/enneagramme.html
@@ -392,7 +392,7 @@
 </head>
 <body id="top" class="font-sans bg-white text-gray-900">
 <!-- Navigation -->
-<header id="site-header" class="sticky-header">
+<header id="site-header" class="sticky-header md:shadow-md">
         <div class="flex items-center">
             <div class="flex-shrink-0 flex items-center">
                 <img src="logo pc 3.png" alt="Personnalité Comparée logo" class="w-10 h-10 rounded-full object-cover"><span id="brand-home" class="ml-3 text-[1.05rem] sm:text-xl font-bold text-black" data-i18n="brand.name">Personnalité Comparée</span>
@@ -451,14 +451,9 @@
             <a href="index.html#home-ia" class="text-gray-500 hover:text-gray-700 inline-flex items-center px-1 pt-1 text-sm font-medium" data-i18n="menu.ai">IA spécialisée</a>
             <a href="blog.html" class="text-gray-500 hover:text-gray-700 inline-flex items-center px-1 pt-1 text-sm font-medium" data-i18n="menu.blog">Blog</a>
             <a href="index.html#home-faq" class="text-gray-500 hover:text-gray-700 inline-flex items-center px-1 pt-1 text-sm font-medium" data-i18n="menu.faq">FAQ</a>
-<button
-  id="profile-btn-desktop"
-  onclick="openProfileModal()"
-  class="ml-4 inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-black hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black"
-  data-i18n="menu.profile"
->
-  Mon profil
-</button>
+            <button id="profile-btn-desktop" onclick="openProfileModal()" class="ml-4 inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-black hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black" data-i18n="menu.profile">
+                Mon profil
+            </button>
 
         </nav>
         <div class="-mr-2 flex items-center md:hidden">
@@ -513,7 +508,7 @@
                 <a href="index.html#home-ia" class="text-gray-500 hover:text-gray-700 block px-3 py-2 rounded-md text-base font-medium" data-i18n="menu.ai">IA spécialisée</a>
                 <a href="blog.html" class="text-gray-500 hover:text-gray-700 block px-3 py-2 rounded-md text-base font-medium" data-i18n="menu.blog">Blog</a>
                 <a href="index.html#home-faq" class="text-gray-500 hover:text-gray-700 block px-3 py-2 rounded-md text-base font-medium" data-i18n="menu.faq">FAQ</a>
-                <button id="profile-btn-mobile" class="w-full mt-2 inline-flex items-center justify-center px-4 py-2 border border-transparent text-base font-medium rounded-md shadow-sm text-white bg-black hover:bg-gray-800" data-i18n="menu.profile">
+                <button id="profile-btn-mobile" onclick="openProfileModal()" class="w-full mt-2 inline-flex items-center justify-center px-4 py-2 border border-transparent text-base font-medium rounded-md shadow-sm text-white bg-black hover:bg-gray-800" data-i18n="menu.profile">
                     Mon profil
                 </button>
             </div>
@@ -3401,14 +3396,6 @@ function showPrivacyPolicy() {
                 });
             }
 
-            const profileBtnDesktop = document.getElementById('profile-btn-desktop');
-            const profileBtnMobile = document.getElementById('profile-btn-mobile');
-            if (profileBtnDesktop) {
-                profileBtnDesktop.addEventListener('click', () => openProfileModal());
-            }
-            if (profileBtnMobile) {
-                profileBtnMobile.addEventListener('click', () => openProfileModal());
-            }
         });
         
         // ===== ESPACE PERSONNEL =====

--- a/public/index.html
+++ b/public/index.html
@@ -418,7 +418,7 @@
 <body id="top" class="font-sans bg-white text-gray-900">
     <div id="beta-banner"><div class="banner-track"><span data-i18n="beta.banner">🚧 Ce site est encore en version bêta ! Certaines fonctions peuvent évoluer ou être améliorées. Revenez bientôt pour profiter d’une version 100% finalisée. Merci pour votre patience.</span><span aria-hidden="true" data-i18n="beta.banner">🚧 Ce site est encore en version bêta ! Certaines fonctions peuvent évoluer ou être améliorées. Revenez bientôt pour profiter d’une version 100% finalisée. Merci pour votre patience.</span></div></div>
     <!-- Navigation -->
-    <header id="site-header" class="sticky-header">
+    <header id="site-header" class="sticky-header md:shadow-md">
         <div class="flex items-center">
             <div class="flex-shrink-0 flex items-center">
                 <img src="logo pc 3.png" alt="Personnalité Comparée logo" class="w-10 h-10 rounded-full object-cover"><span id="brand-home" class="ml-3 text-[1.05rem] sm:text-xl font-bold text-black" data-i18n="brand.name">Personnalité Comparée</span>

--- a/public/mbti.html
+++ b/public/mbti.html
@@ -391,7 +391,7 @@
 </head>
 <body id="top" class="font-sans bg-white text-gray-900">
 <!-- Navigation -->
-<header id="site-header" class="sticky-header">
+<header id="site-header" class="sticky-header md:shadow-md">
         <div class="flex items-center">
             <div class="flex-shrink-0 flex items-center">
                 <img src="logo pc 3.png" alt="Personnalité Comparée logo" class="w-10 h-10 rounded-full object-cover"><span id="brand-home" class="ml-3 text-[1.05rem] sm:text-xl font-bold text-black" data-i18n="brand.name">Personnalité Comparée</span>


### PR DESCRIPTION
## Summary
- add desktop-only shadow to header across pages
- fix profile modal button in enneagramme page

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a29c7870308321862099f9760cddbb