### PR TITLE
fix: restore desktop header shadow

### DIFF
--- a/public/blog-enneagramme-instincts.html
+++ b/public/blog-enneagramme-instincts.html
@@ -186,8 +186,8 @@
             top: 0;
             left: 0;
             right: 0;
-            z-index: 1000;
-            background: inherit;
+            z-index: 50;
+            background-color: white;
             height: 64px;
             display: flex;
             justify-content: space-between;
@@ -218,9 +218,9 @@
                 top: 0;
                 left: 0;
                 right: 0;
-                z-index: 1000;
-                background: inherit;
-                box-shadow: 0 2px 10px rgba(0,0,0,0.06);
+                z-index: 50;
+                background-color: white;
+                box-shadow: none;
                 height: 56px;
             }
             body {
@@ -391,7 +391,7 @@
 </head>
 <body id="top" class="font-sans bg-white text-gray-900">
 <!-- Navigation -->
-    <header id="site-header" class="sticky-header shadow-md">
+    <header id="site-header" class="sticky-header md:shadow-md">
         <div class="flex items-center">
             <div class="flex-shrink-0 flex items-center">
                 <img src="logo pc 3.png" alt="Personnalité Comparée logo" class="w-10 h-10 rounded-full object-cover"><span id="brand-home" class="ml-3 text-[1.05rem] sm:text-xl font-bold text-black" data-i18n="brand.name">Personnalité Comparée</span>

--- a/public/blog-mbti-4-dimensions.html
+++ b/public/blog-mbti-4-dimensions.html
@@ -186,8 +186,8 @@
             top: 0;
             left: 0;
             right: 0;
-            z-index: 1000;
-            background: inherit;
+            z-index: 50;
+            background-color: white;
             height: 64px;
             display: flex;
             justify-content: space-between;
@@ -218,9 +218,9 @@
                 top: 0;
                 left: 0;
                 right: 0;
-                z-index: 1000;
-                background: inherit;
-                box-shadow: 0 2px 10px rgba(0,0,0,0.06);
+                z-index: 50;
+                background-color: white;
+                box-shadow: none;
                 height: 56px;
             }
             body {
@@ -391,7 +391,7 @@
 </head>
 <body id="top" class="font-sans bg-white text-gray-900">
 <!-- Navigation -->
-    <header id="site-header" class="sticky-header shadow-md">
+    <header id="site-header" class="sticky-header md:shadow-md">
         <div class="flex items-center">
             <div class="flex-shrink-0 flex items-center">
                 <img src="logo pc 3.png" alt="Personnalité Comparée logo" class="w-10 h-10 rounded-full object-cover"><span id="brand-home" class="ml-3 text-[1.05rem] sm:text-xl font-bold text-black" data-i18n="brand.name">Personnalité Comparée</span>

--- a/public/blog.html
+++ b/public/blog.html
@@ -186,8 +186,8 @@
             top: 0;
             left: 0;
             right: 0;
-            z-index: 1000;
-            background: inherit;
+            z-index: 50;
+            background-color: white;
             height: 64px;
             display: flex;
             justify-content: space-between;
@@ -218,9 +218,9 @@
                 top: 0;
                 left: 0;
                 right: 0;
-                z-index: 1000;
-                background: inherit;
-                box-shadow: 0 2px 10px rgba(0,0,0,0.06);
+                z-index: 50;
+                background-color: white;
+                box-shadow: none;
                 height: 56px;
             }
             body {
@@ -391,7 +391,7 @@
 </head>
 <body id="top" class="font-sans bg-white text-gray-900">
 <!-- Navigation -->
-<header id="site-header" class="sticky-header shadow-md">
+<header id="site-header" class="sticky-header md:shadow-md">
         <div class="flex items-center">
             <div class="flex-shrink-0 flex items-center">
                 <img src="logo pc 3.png" alt="Personnalité Comparée logo" class="w-10 h-10 rounded-full object-cover"><span id="brand-home" class="ml-3 text-[1.05rem] sm:text-xl font-bold text-black" data-i18n="brand.name">Personnalité Comparée</span>

--- a/public/enneagramme.html
+++ b/public/enneagramme.html
@@ -186,14 +186,13 @@
             top: 0;
             left: 0;
             right: 0;
-            z-index: 1000;
-            background: inherit;
+            z-index: 50;
+            background-color: white;
             height: 64px;
             display: flex;
             justify-content: space-between;
             align-items: center;
             padding: 0 20px;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.06);
         }
 
         body {
@@ -219,9 +218,9 @@
                 top: 0;
                 left: 0;
                 right: 0;
-                z-index: 1000;
-                background: inherit;
-                box-shadow: 0 2px 8px rgba(0,0,0,0.06);
+                z-index: 50;
+                background-color: white;
+                box-shadow: none;
                 height: 56px;
             }
             body {
@@ -392,7 +391,7 @@
 </head>
 <body id="top" class="font-sans bg-white text-gray-900">
 <!-- Navigation -->
-<header id="site-header" class="sticky-header shadow-md">
+<header id="site-header" class="sticky-header md:shadow-md">
         <div class="flex items-center">
             <div class="flex-shrink-0 flex items-center">
                 <img src="logo pc 3.png" alt="Personnalité Comparée logo" class="w-10 h-10 rounded-full object-cover"><span id="brand-home" class="ml-3 text-[1.05rem] sm:text-xl font-bold text-black" data-i18n="brand.name">Personnalité Comparée</span>

--- a/public/index.html
+++ b/public/index.html
@@ -186,8 +186,8 @@
             top: 0;
             left: 0;
             right: 0;
-            z-index: 1000;
-            background: inherit;
+            z-index: 50;
+            background-color: white;
             height: 64px;
             display: flex;
             justify-content: space-between;
@@ -218,9 +218,9 @@
                 top: 0;
                 left: 0;
                 right: 0;
-                z-index: 1000;
-                background: inherit;
-                box-shadow: 0 2px 10px rgba(0,0,0,0.06);
+                z-index: 50;
+                background-color: white;
+                box-shadow: none;
                 height: 56px;
             }
             body {
@@ -418,7 +418,7 @@
 <body id="top" class="font-sans bg-white text-gray-900">
     <div id="beta-banner"><div class="banner-track"><span data-i18n="beta.banner">🚧 Ce site est encore en version bêta ! Certaines fonctions peuvent évoluer ou être améliorées. Revenez bientôt pour profiter d’une version 100% finalisée. Merci pour votre patience.</span><span aria-hidden="true" data-i18n="beta.banner">🚧 Ce site est encore en version bêta ! Certaines fonctions peuvent évoluer ou être améliorées. Revenez bientôt pour profiter d’une version 100% finalisée. Merci pour votre patience.</span></div></div>
     <!-- Navigation -->
-    <header id="site-header" class="sticky-header shadow-md">
+    <header id="site-header" class="sticky-header md:shadow-md">
         <div class="flex items-center">
             <div class="flex-shrink-0 flex items-center">
                 <img src="logo pc 3.png" alt="Personnalité Comparée logo" class="w-10 h-10 rounded-full object-cover"><span id="brand-home" class="ml-3 text-[1.05rem] sm:text-xl font-bold text-black" data-i18n="brand.name">Personnalité Comparée</span>

--- a/public/mbti.html
+++ b/public/mbti.html
@@ -186,8 +186,8 @@
             top: 0;
             left: 0;
             right: 0;
-            z-index: 1000;
-            background: inherit;
+            z-index: 50;
+            background-color: white;
             height: 64px;
             display: flex;
             justify-content: space-between;
@@ -218,9 +218,9 @@
                 top: 0;
                 left: 0;
                 right: 0;
-                z-index: 1000;
-                background: inherit;
-                box-shadow: 0 2px 10px rgba(0,0,0,0.06);
+                z-index: 50;
+                background-color: white;
+                box-shadow: none;
                 height: 56px;
             }
             body {
@@ -391,7 +391,7 @@
 </head>
 <body id="top" class="font-sans bg-white text-gray-900">
 <!-- Navigation -->
-<header id="site-header" class="sticky-header shadow-md">
+<header id="site-header" class="sticky-header md:shadow-md">
         <div class="flex items-center">
             <div class="flex-shrink-0 flex items-center">
                 <img src="logo pc 3.png" alt="Personnalité Comparée logo" class="w-10 h-10 rounded-full object-cover"><span id="brand-home" class="ml-3 text-[1.05rem] sm:text-xl font-bold text-black" data-i18n="brand.name">Personnalité Comparée</span>


### PR DESCRIPTION
## Summary
- scope header shadow to desktop only with `md:shadow-md`
- ensure sticky header has white background and z-50 to display shadow

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a2a0041aa483218c07ada0ea389c7d