### PR TITLE
Fix header shadow on desktop

### DIFF
--- a/public/blog-enneagramme-instincts.html
+++ b/public/blog-enneagramme-instincts.html
@@ -388,6 +388,16 @@
 
     </style>
 
+    <style>
+      @media (min-width: 768px) {
+        #site-header {
+          background-color: white;
+          z-index: 50;
+          box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+        }
+      }
+    </style>
+
 </head>
 <body id="top" class="font-sans bg-white text-gray-900">
 <!-- Navigation -->

--- a/public/blog-mbti-4-dimensions.html
+++ b/public/blog-mbti-4-dimensions.html
@@ -388,6 +388,16 @@
 
     </style>
 
+    <style>
+      @media (min-width: 768px) {
+        #site-header {
+          background-color: white;
+          z-index: 50;
+          box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+        }
+      }
+    </style>
+
 </head>
 <body id="top" class="font-sans bg-white text-gray-900">
 <!-- Navigation -->

--- a/public/blog.html
+++ b/public/blog.html
@@ -388,6 +388,16 @@
 
     </style>
 
+    <style>
+      @media (min-width: 768px) {
+        #site-header {
+          background-color: white;
+          z-index: 50;
+          box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+        }
+      }
+    </style>
+
 </head>
 <body id="top" class="font-sans bg-white text-gray-900">
 <!-- Navigation -->

--- a/public/enneagramme.html
+++ b/public/enneagramme.html
@@ -388,6 +388,16 @@
 
     </style>
 
+    <style>
+      @media (min-width: 768px) {
+        #site-header {
+          background-color: white;
+          z-index: 50;
+          box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+        }
+      }
+    </style>
+
 </head>
 <body id="top" class="font-sans bg-white text-gray-900">
 <!-- Navigation -->

--- a/public/index.html
+++ b/public/index.html
@@ -414,6 +414,16 @@
 
     </style>
 
+    <style>
+      @media (min-width: 768px) {
+        #site-header {
+          background-color: white;
+          z-index: 50;
+          box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+        }
+      }
+    </style>
+
 </head>
 <body id="top" class="font-sans bg-white text-gray-900">
     <div id="beta-banner"><div class="banner-track"><span data-i18n="beta.banner">🚧 Ce site est encore en version bêta ! Certaines fonctions peuvent évoluer ou être améliorées. Revenez bientôt pour profiter d’une version 100% finalisée. Merci pour votre patience.</span><span aria-hidden="true" data-i18n="beta.banner">🚧 Ce site est encore en version bêta ! Certaines fonctions peuvent évoluer ou être améliorées. Revenez bientôt pour profiter d’une version 100% finalisée. Merci pour votre patience.</span></div></div>

--- a/public/mbti.html
+++ b/public/mbti.html
@@ -388,6 +388,16 @@
 
     </style>
 
+    <style>
+      @media (min-width: 768px) {
+        #site-header {
+          background-color: white;
+          z-index: 50;
+          box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+        }
+      }
+    </style>
+
 </head>
 <body id="top" class="font-sans bg-white text-gray-900">
 <!-- Navigation -->


### PR DESCRIPTION
## Summary
- Add media-query style block for #site-header to ensure a subtle shadow on desktop across all pages

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a2a16d0f488321b7810fb6fc5422c1