### PR TITLE
feat: add header shadow on desktop

### DIFF
--- a/public/blog-enneagramme-instincts.html
+++ b/public/blog-enneagramme-instincts.html
@@ -189,6 +189,7 @@
             right: 0;
             z-index: 1000;
             background: inherit;
+            box-shadow: 0 4px 10px rgba(0, 0, 0, 0.06);
             height: 64px;
             display: flex;
             justify-content: space-between;

--- a/public/blog-mbti-4-dimensions.html
+++ b/public/blog-mbti-4-dimensions.html
@@ -189,6 +189,7 @@
             right: 0;
             z-index: 1000;
             background: inherit;
+            box-shadow: 0 4px 10px rgba(0, 0, 0, 0.06);
             height: 64px;
             display: flex;
             justify-content: space-between;

--- a/public/blog.html
+++ b/public/blog.html
@@ -189,6 +189,7 @@
             right: 0;
             z-index: 1000;
             background: inherit;
+            box-shadow: 0 4px 10px rgba(0, 0, 0, 0.06);
             height: 64px;
             display: flex;
             justify-content: space-between;

--- a/public/enneagramme.html
+++ b/public/enneagramme.html
@@ -189,6 +189,7 @@
             right: 0;
             z-index: 1000;
             background: inherit;
+            box-shadow: 0 4px 10px rgba(0, 0, 0, 0.06);
             height: 64px;
             display: flex;
             justify-content: space-between;

--- a/public/index.html
+++ b/public/index.html
@@ -189,6 +189,7 @@
             right: 0;
             z-index: 1000;
             background: inherit;
+            box-shadow: 0 4px 10px rgba(0, 0, 0, 0.06);
             height: 64px;
             display: flex;
             justify-content: space-between;

--- a/public/mbti.html
+++ b/public/mbti.html
@@ -189,6 +189,7 @@
             right: 0;
             z-index: 1000;
             background: inherit;
+            box-shadow: 0 4px 10px rgba(0, 0, 0, 0.06);
             height: 64px;
             display: flex;
             justify-content: space-between;


### PR DESCRIPTION
## Summary
- add subtle desktop box-shadow to #site-header across public pages

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a2f36e3a0c83219460f4bb31df67ef