### PR TITLE
Prevent default scrolling on footer modal links

### DIFF
--- a/public/blog-enneagramme-instincts.html
+++ b/public/blog-enneagramme-instincts.html
@@ -672,16 +672,16 @@
                 <div>
                     <h3 class="text-sm font-semibold text-gray-400 tracking-wider uppercase" data-i18n="footer.legal_title">Légal</h3>
                     <ul class="mt-4 space-y-4">
-                        <li><a href="#" onclick="showPrivacyPolicy(); return false;" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.privacy">Confidentialité</a></li>
-                        <li><a href="#" onclick="showTermsOfService(); return false;" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.terms">Conditions d'utilisation</a></li>
-                        <li><a href="#" onclick="showLegalNotices(); return false;" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.legal">Mentions légales</a></li>
-                        <li><a href="#" onclick="showLegalNotices(); return false;" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.cookies">Cookies</a></li>
+                        <li><a href="#" onclick="event.preventDefault(); showPrivacyPolicy();" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.privacy">Confidentialité</a></li>
+                        <li><a href="#" onclick="event.preventDefault(); showTermsOfService();" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.terms">Conditions d'utilisation</a></li>
+                        <li><a href="#" onclick="event.preventDefault(); showLegalNotices();" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.legal">Mentions légales</a></li>
+                        <li><a href="#" onclick="event.preventDefault(); showLegalNotices();" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.cookies">Cookies</a></li>
                     </ul>
                 </div>
                 <div>
                     <h3 class="text-sm font-semibold text-gray-400 tracking-wider uppercase" data-i18n="footer.contact_title">Contact</h3>
                     <ul class="mt-4 space-y-4">
-                        <li><a href="#" onclick="showContact(); return false;" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.support">Support</a></li>
+                        <li><a href="#" onclick="event.preventDefault(); showContact();" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.support">Support</a></li>
                         <li class="flex space-x-6 pt-2">
                             <a href="#" class="text-gray-400 hover:text-white transition-colors">
                                 <span class="sr-only">Facebook</span>

--- a/public/blog-mbti-4-dimensions.html
+++ b/public/blog-mbti-4-dimensions.html
@@ -623,16 +623,16 @@
                 <div>
                     <h3 class="text-sm font-semibold text-gray-400 tracking-wider uppercase" data-i18n="footer.legal_title">Légal</h3>
                     <ul class="mt-4 space-y-4">
-                        <li><a href="#" onclick="showPrivacyPolicy(); return false;" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.privacy">Confidentialité</a></li>
-                        <li><a href="#" onclick="showTermsOfService(); return false;" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.terms">Conditions d'utilisation</a></li>
-                        <li><a href="#" onclick="showLegalNotices(); return false;" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.legal">Mentions légales</a></li>
-                        <li><a href="#" onclick="showLegalNotices(); return false;" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.cookies">Cookies</a></li>
+                        <li><a href="#" onclick="event.preventDefault(); showPrivacyPolicy();" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.privacy">Confidentialité</a></li>
+                        <li><a href="#" onclick="event.preventDefault(); showTermsOfService();" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.terms">Conditions d'utilisation</a></li>
+                        <li><a href="#" onclick="event.preventDefault(); showLegalNotices();" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.legal">Mentions légales</a></li>
+                        <li><a href="#" onclick="event.preventDefault(); showLegalNotices();" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.cookies">Cookies</a></li>
                     </ul>
                 </div>
                 <div>
                     <h3 class="text-sm font-semibold text-gray-400 tracking-wider uppercase" data-i18n="footer.contact_title">Contact</h3>
                     <ul class="mt-4 space-y-4">
-                        <li><a href="#" onclick="showContact(); return false;" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.support">Support</a></li>
+                        <li><a href="#" onclick="event.preventDefault(); showContact();" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.support">Support</a></li>
                         <li class="flex space-x-6 pt-2">
                             <a href="#" class="text-gray-400 hover:text-white transition-colors">
                                 <span class="sr-only">Facebook</span>

--- a/public/blog.html
+++ b/public/blog.html
@@ -576,16 +576,16 @@
                 <div>
                     <h3 class="text-sm font-semibold text-gray-400 tracking-wider uppercase" data-i18n="footer.legal_title">Légal</h3>
                     <ul class="mt-4 space-y-4">
-                        <li><a href="#" onclick="showPrivacyPolicy(); return false;" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.privacy">Confidentialité</a></li>
-                        <li><a href="#" onclick="showTermsOfService(); return false;" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.terms">Conditions d'utilisation</a></li>
-                        <li><a href="#" onclick="showLegalNotices(); return false;" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.legal">Mentions légales</a></li>
-                        <li><a href="#" onclick="showLegalNotices(); return false;" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.cookies">Cookies</a></li>
+                        <li><a href="#" onclick="event.preventDefault(); showPrivacyPolicy();" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.privacy">Confidentialité</a></li>
+                        <li><a href="#" onclick="event.preventDefault(); showTermsOfService();" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.terms">Conditions d'utilisation</a></li>
+                        <li><a href="#" onclick="event.preventDefault(); showLegalNotices();" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.legal">Mentions légales</a></li>
+                        <li><a href="#" onclick="event.preventDefault(); showLegalNotices();" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.cookies">Cookies</a></li>
                     </ul>
                 </div>
                 <div>
                     <h3 class="text-sm font-semibold text-gray-400 tracking-wider uppercase" data-i18n="footer.contact_title">Contact</h3>
                     <ul class="mt-4 space-y-4">
-                        <li><a href="#" onclick="showContact(); return false;" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.support">Support</a></li>
+                        <li><a href="#" onclick="event.preventDefault(); showContact();" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.support">Support</a></li>
                         <li class="flex space-x-6 pt-2">
                             <a href="#" class="text-gray-400 hover:text-white transition-colors">
                                 <span class="sr-only">Facebook</span>

--- a/public/enneagramme.html
+++ b/public/enneagramme.html
@@ -1000,16 +1000,16 @@
                 <div>
                     <h3 class="text-sm font-semibold text-gray-400 tracking-wider uppercase" data-i18n="footer.legal_title">Légal</h3>
                     <ul class="mt-4 space-y-4">
-                        <li><a href="#" onclick="showPrivacyPolicy(); return false;" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.privacy">Confidentialité</a></li>
-                        <li><a href="#" onclick="showTermsOfService(); return false;" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.terms">Conditions d'utilisation</a></li>
-                        <li><a href="#" onclick="showLegalNotices(); return false;" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.legal">Mentions légales</a></li>
-                        <li><a href="#" onclick="showLegalNotices(); return false;" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.cookies">Cookies</a></li>
+                        <li><a href="#" onclick="event.preventDefault(); showPrivacyPolicy();" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.privacy">Confidentialité</a></li>
+                        <li><a href="#" onclick="event.preventDefault(); showTermsOfService();" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.terms">Conditions d'utilisation</a></li>
+                        <li><a href="#" onclick="event.preventDefault(); showLegalNotices();" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.legal">Mentions légales</a></li>
+                        <li><a href="#" onclick="event.preventDefault(); showLegalNotices();" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.cookies">Cookies</a></li>
                     </ul>
                 </div>
                 <div>
                     <h3 class="text-sm font-semibold text-gray-400 tracking-wider uppercase" data-i18n="footer.contact_title">Contact</h3>
                     <ul class="mt-4 space-y-4">
-                        <li><a href="#" onclick="showContact(); return false;" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.support">Support</a></li>
+                        <li><a href="#" onclick="event.preventDefault(); showContact();" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.support">Support</a></li>
                         <li class="flex space-x-6 pt-2">
                             <a href="#" class="text-gray-400 hover:text-white transition-colors">
                                 <span class="sr-only" data-i18n="social.facebook">Facebook</span>

--- a/public/index.html
+++ b/public/index.html
@@ -1064,16 +1064,16 @@
                 <div>
                     <h3 class="text-sm font-semibold text-gray-400 tracking-wider uppercase" data-i18n="footer.legal_title">Légal</h3>
                     <ul class="mt-4 space-y-4">
-                        <li><a href="#" onclick="showPrivacyPolicy(); return false;" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.privacy">Confidentialité</a></li>
-                        <li><a href="#" onclick="showTermsOfService(); return false;" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.terms">Conditions d'utilisation</a></li>
-                        <li><a href="#" onclick="showLegalNotices(); return false;" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.legal">Mentions légales</a></li>
-                        <li><a href="#" onclick="showCookies(); return false;" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.cookies">Cookies</a></li>
+                        <li><a href="#" onclick="event.preventDefault(); showPrivacyPolicy();" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.privacy">Confidentialité</a></li>
+                        <li><a href="#" onclick="event.preventDefault(); showTermsOfService();" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.terms">Conditions d'utilisation</a></li>
+                        <li><a href="#" onclick="event.preventDefault(); showLegalNotices();" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.legal">Mentions légales</a></li>
+                        <li><a href="#" onclick="event.preventDefault(); showCookies();" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.cookies">Cookies</a></li>
                     </ul>
                 </div>
                 <div>
                     <h3 class="text-sm font-semibold text-gray-400 tracking-wider uppercase" data-i18n="footer.contact_title">Contact</h3>
                     <ul class="mt-4 space-y-4">
-                        <li><a href="#" onclick="showSupport(); return false;" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.support">Support</a></li>
+                        <li><a href="#" onclick="event.preventDefault(); showSupport();" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.support">Support</a></li>
                         <li class="flex space-x-6 pt-2">
                             <a href="#" class="text-gray-400 hover:text-white transition-colors">
                                 <span class="sr-only" data-i18n="social.facebook">Facebook</span>

--- a/public/mbti.html
+++ b/public/mbti.html
@@ -1097,16 +1097,16 @@
                 <div>
                     <h3 class="text-sm font-semibold text-gray-400 tracking-wider uppercase" data-i18n="footer.legal_title">Légal</h3>
                     <ul class="mt-4 space-y-4">
-                        <li><a href="#" onclick="showPrivacyPolicy(); return false;" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.privacy">Confidentialité</a></li>
-                        <li><a href="#" onclick="showTermsOfService(); return false;" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.terms">Conditions d'utilisation</a></li>
-                        <li><a href="#" onclick="showLegalNotices(); return false;" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.legal">Mentions légales</a></li>
-                        <li><a href="#" onclick="showLegalNotices(); return false;" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.cookies">Cookies</a></li>
+                        <li><a href="#" onclick="event.preventDefault(); showPrivacyPolicy();" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.privacy">Confidentialité</a></li>
+                        <li><a href="#" onclick="event.preventDefault(); showTermsOfService();" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.terms">Conditions d'utilisation</a></li>
+                        <li><a href="#" onclick="event.preventDefault(); showLegalNotices();" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.legal">Mentions légales</a></li>
+                        <li><a href="#" onclick="event.preventDefault(); showLegalNotices();" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.cookies">Cookies</a></li>
                     </ul>
                 </div>
                 <div>
                     <h3 class="text-sm font-semibold text-gray-400 tracking-wider uppercase" data-i18n="footer.contact_title">Contact</h3>
                     <ul class="mt-4 space-y-4">
-                        <li><a href="#" onclick="showContact(); return false;" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.support">Support</a></li>
+                        <li><a href="#" onclick="event.preventDefault(); showContact();" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.support">Support</a></li>
                         <li class="flex space-x-6 pt-2">
                             <a href="#" class="text-gray-400 hover:text-white transition-colors">
                                 <span class="sr-only">Facebook</span>


### PR DESCRIPTION
## Summary
- prevent default navigation for footer links that open modals
- ensure modal links like privacy policy, terms, and support no longer scroll the page

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a2fc24663c8321b52de86ed82a92cd