### PR TITLE
Add modal handlers for footer links

### DIFF
--- a/public/nav.js
+++ b/public/nav.js
@@ -94,5 +94,45 @@
         }
       });
     });
+
+    const privacyLink = document.getElementById('privacy-link');
+    if (privacyLink) {
+      privacyLink.addEventListener('click', function(e) {
+        e.preventDefault();
+        showPrivacyPolicy();
+      });
+    }
+
+    const termsLink = document.getElementById('terms-link');
+    if (termsLink) {
+      termsLink.addEventListener('click', function(e) {
+        e.preventDefault();
+        showTermsOfUse();
+      });
+    }
+
+    const legalLink = document.getElementById('legal-link');
+    if (legalLink) {
+      legalLink.addEventListener('click', function(e) {
+        e.preventDefault();
+        showLegalNotices();
+      });
+    }
+
+    const cookiesLink = document.getElementById('cookies-link');
+    if (cookiesLink) {
+      cookiesLink.addEventListener('click', function(e) {
+        e.preventDefault();
+        showCookiesPolicy();
+      });
+    }
+
+    const supportLink = document.getElementById('support-link');
+    if (supportLink) {
+      supportLink.addEventListener('click', function(e) {
+        e.preventDefault();
+        showContactSupport();
+      });
+    }
   });
 })();


### PR DESCRIPTION
## Summary
- attach click listeners to footer LEGAL and CONTACT links
- open the appropriate modal while preventing default anchor navigation

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a2fe6a6e308321994b11179b5a6aba