### PR TITLE
fix: expose questions data in browser

### DIFF
--- a/public/questions-v2.js
+++ b/public/questions-v2.js
@@ -639,6 +639,12 @@ const EXTERNAL_QUESTIONS = [
   }
 ];
 
-if (typeof module !== 'undefined') {
+// Expose the questions arrays in both browser and Node environments
+if (typeof window !== 'undefined') {
+  window.AUTO_QUESTIONS = AUTO_QUESTIONS;
+  window.EXTERNAL_QUESTIONS = EXTERNAL_QUESTIONS;
+}
+
+if (typeof module !== 'undefined' && module.exports) {
   module.exports = { AUTO_QUESTIONS, EXTERNAL_QUESTIONS };
 }


### PR DESCRIPTION
## Summary
- expose AUTO_QUESTIONS and EXTERNAL_QUESTIONS on `window` for browser usage
- guard CommonJS export to avoid runtime errors

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a2ffa2489c8321bcbaefb9c21b1084