### PR TITLE
feat: unify footers and fix modal translations

### DIFF
--- a/public/blog.html
+++ b/public/blog.html
@@ -557,46 +557,46 @@
                     <h3 class="text-sm font-semibold text-gray-400 tracking-wider uppercase" data-i18n="footer.brand_title">Personnalité Comparée</h3>
                     <ul class="mt-4 space-y-4">
                         <li><a href="index.html" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.home">Accueil</a></li>
-                        <li><a href="mbti.html" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.mbti">MBTI</a></li>
-                        <li><a href="enneagramme.html" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.enneagram">Ennéagramme</a></li>
-                        <li><a href="blog.html" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.blog">Blog</a></li>
-        <li><a href="index.html#home-ia" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.ai">IA spécialisée</a></li>
-        <li><a href="index.html#home-faq" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.faq">FAQ</a></li>
+        <li><a href="mbti.html" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.mbti">MBTI</a></li>
+        <li><a href="enneagramme.html" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.enneagram">Ennéagramme</a></li>
+        <li><a href="blog.html" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.blog">Blog</a></li>
+        <li><a href="#home-ia" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.ai">IA spécialisée</a></li>
+        <li><a href="#home-faq" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.faq">FAQ</a></li>
 
                     </ul>
                 </div>
                 <div>
                     <h3 class="text-sm font-semibold text-gray-400 tracking-wider uppercase" data-i18n="footer.tests_title">Tests</h3>
                     <ul class="mt-4 space-y-4">
-                        <li><a href="index.html#home-mbti" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.auto_eval">Auto-évaluation</a></li>
-                        <li><a href="index.html#home-enneagramme" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.evaluate_friend">Évaluer un proche</a></li>
-                        <li><a href="index.html#retourver-profil" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.my_profile">Mon profil</a></li>
+                        <li><a href="#home-mbti" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.auto_eval">Auto-évaluation</a></li>
+                        <li><a href="#home-enneagramme" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.evaluate_friend">Évaluer un proche</a></li>
+                        <li><a href="#retourver-profil" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.my_profile">Mon profil</a></li>
                     </ul>
                 </div>
                 <div>
                     <h3 class="text-sm font-semibold text-gray-400 tracking-wider uppercase" data-i18n="footer.legal_title">Légal</h3>
                     <ul class="mt-4 space-y-4">
-                        <li><a href="#" onclick="event.preventDefault(); showPrivacyPolicy();" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.privacy">Confidentialité</a></li>
-                        <li><a href="#" onclick="event.preventDefault(); showTermsOfService();" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.terms">Conditions d'utilisation</a></li>
-                        <li><a href="#" onclick="event.preventDefault(); showLegalNotices();" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.legal">Mentions légales</a></li>
-                        <li><a href="#" onclick="event.preventDefault(); showLegalNotices();" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.cookies">Cookies</a></li>
+                        <li><a href="#" id="privacy-link" onclick="event.preventDefault(); showPrivacyPolicy();" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.privacy">Confidentialité</a></li>
+                        <li><a href="#" id="terms-link" onclick="event.preventDefault(); showTermsOfService();" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.terms">Conditions d'utilisation</a></li>
+                        <li><a href="#" id="legal-link" onclick="event.preventDefault(); showLegalNotices();" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.legal">Mentions légales</a></li>
+                        <li><a href="#" id="cookies-link" onclick="event.preventDefault(); showCookies();" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.cookies">Cookies</a></li>
                     </ul>
                 </div>
                 <div>
                     <h3 class="text-sm font-semibold text-gray-400 tracking-wider uppercase" data-i18n="footer.contact_title">Contact</h3>
                     <ul class="mt-4 space-y-4">
-                        <li><a href="#" onclick="event.preventDefault(); showContact();" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.support">Support</a></li>
+                        <li><a href="#" id="support-link" onclick="event.preventDefault(); showSupport();" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.support">Support</a></li>
                         <li class="flex space-x-6 pt-2">
                             <a href="#" class="text-gray-400 hover:text-white transition-colors">
-                                <span class="sr-only">Facebook</span>
+                                <span class="sr-only" data-i18n="social.facebook">Facebook</span>
                                 <i class="fab fa-facebook-f"></i>
                             </a>
                             <a href="#" class="text-gray-400 hover:text-white transition-colors">
-                                <span class="sr-only">Instagram</span>
+                                <span class="sr-only" data-i18n="social.instagram">Instagram</span>
                                 <i class="fab fa-instagram"></i>
                             </a>
                             <a href="#" class="text-gray-400 hover:text-white transition-colors">
-                                <span class="sr-only">TikTok</span>
+                                <span class="sr-only" data-i18n="social.tiktok">TikTok</span>
                                 <i class="fab fa-tiktok"></i>
                             </a>
                         </li>
@@ -2450,66 +2450,112 @@ function displayResults(results) {
 
         // Fonctions pour les pages légales et contact
 function showPrivacyPolicy() {
+  const lang = localStorage.getItem('lang') || 'fr';
+  const date = new Date().toLocaleDateString(lang === 'fr' ? 'fr-FR' : 'en-US');
   const content = `
     <div class="space-y-4">
-      <h3 class="text-lg font-semibold text-gray-900">Politique de Confidentialité</h3>
-      <p class="text-gray-700">Dernière mise à jour : ${new Date().toLocaleDateString('fr-FR')}</p>
+      <h3 class="text-lg font-semibold text-gray-900" data-i18n="footer.legal.privacy.title">Politique de Confidentialité</h3>
+      <p class="text-gray-700"><span data-i18n="footer.legal.privacy.update">Dernière mise à jour :</span> ${date}</p>
 
-      <h4 class="font-semibold text-gray-900">1. Données collectées</h4>
-      <p class="text-gray-700">Nous collectons uniquement les réponses fournies lors&nbsp;:</p>
+      <h4 class="font-semibold text-gray-900" data-i18n="footer.legal.privacy.collected.title">1. Données collectées</h4>
+      <p class="text-gray-700" data-i18n="footer.legal.privacy.collected.desc">Nous collectons uniquement les réponses fournies lors&nbsp;:</p>
       <ul class="list-disc pl-6 text-gray-700">
-        <li>de vos auto-évaluations ;</li>
-        <li>des évaluations réalisées par vos proches.</li>
+        <li data-i18n="footer.legal.privacy.collected.item1">de vos auto-évaluations ;</li>
+        <li data-i18n="footer.legal.privacy.collected.item2">des évaluations réalisées par vos proches.</li>
       </ul>
-      <p class="text-gray-700">Aucune autre donnée personnelle (nom, e-mail, localisation, etc.) n’est demandée ni enregistrée.</p>
+      <p class="text-gray-700" data-i18n="footer.legal.privacy.collected.note">Aucune autre donnée personnelle (nom, e-mail, localisation, etc.) n’est demandée ni enregistrée.</p>
 
-      <h4 class="font-semibold text-gray-900">2. Finalité de la collecte</h4>
+      <h4 class="font-semibold text-gray-900" data-i18n="footer.legal.privacy.purpose.title">2. Finalité de la collecte</h4>
       <ul class="list-disc pl-6 text-gray-700">
-        <li>Calculer et afficher votre profil de personnalité ;</li>
-        <li>Générer les résultats finaux à partir des évaluations reçues.</li>
+        <li data-i18n="footer.legal.privacy.purpose.item1">Calculer et afficher votre profil de personnalité ;</li>
+        <li data-i18n="footer.legal.privacy.purpose.item2">Générer les résultats finaux à partir des évaluations reçues.</li>
       </ul>
 
-      <h4 class="font-semibold text-gray-900">3. Stockage des données</h4>
-      <p class="text-gray-700">Vos réponses sont stockées de manière sécurisée dans notre base de données <strong>Supabase</strong>. Elles ne sont pas enregistrées ailleurs.</p>
+      <h4 class="font-semibold text-gray-900" data-i18n="footer.legal.privacy.storage.title">3. Stockage des données</h4>
+      <p class="text-gray-700" data-i18n="footer.legal.privacy.storage.text">Vos réponses sont stockées de manière sécurisée dans notre base de données <strong>Supabase</strong>. Elles ne sont pas enregistrées ailleurs.</p>
 
-      <h4 class="font-semibold text-gray-900">4. Partage des données</h4>
-      <p class="text-gray-700">Nous ne vendons, n’échangeons et ne partageons <strong>aucune</strong> donnée avec des tiers. Seules les personnes disposant de votre code unique peuvent consulter vos résultats.</p>
+      <h4 class="font-semibold text-gray-900" data-i18n="footer.legal.privacy.sharing.title">4. Partage des données</h4>
+      <p class="text-gray-700" data-i18n="footer.legal.privacy.sharing.text">Nous ne vendons, n’échangeons et ne partageons <strong>aucune</strong> donnée avec des tiers. Seules les personnes disposant de votre code unique peuvent consulter vos résultats.</p>
 
-      <h4 class="font-semibold text-gray-900">5. Sécurité</h4>
-      <p class="text-gray-700">Supabase applique des mesures de sécurité standards (chiffrement en transit, contrôles d’accès). Nous limitons l’accès aux données aux seules finalités décrites ci-dessus.</p>
+      <h4 class="font-semibold text-gray-900" data-i18n="footer.legal.privacy.security.title">5. Sécurité</h4>
+      <p class="text-gray-700" data-i18n="footer.legal.privacy.security.text">Supabase applique des mesures de sécurité standards (chiffrement en transit, contrôles d’accès). Nous limitons l’accès aux données aux seules finalités décrites ci-dessus.</p>
 
-      <h4 class="font-semibold text-gray-900">6. Durée de conservation</h4>
-      <p class="text-gray-700">Les réponses sont conservées tant que votre code unique reste valide dans notre base. Vous pouvez demander leur suppression à tout moment.</p>
+      <h4 class="font-semibold text-gray-900" data-i18n="footer.legal.privacy.retention.title">6. Durée de conservation</h4>
+      <p class="text-gray-700" data-i18n="footer.legal.privacy.retention.text">Les réponses sont conservées tant que votre code unique reste valide dans notre base. Vous pouvez demander leur suppression à tout moment.</p>
 
-      <h4 class="font-semibold text-gray-900">7. Vos droits</h4>
+      <h4 class="font-semibold text-gray-900" data-i18n="footer.legal.privacy.rights.title">7. Vos droits</h4>
       <ul class="list-disc pl-6 text-gray-700">
-        <li>Demander une copie de vos données ;</li>
-        <li>Demander la suppression définitive de vos données.</li>
+        <li data-i18n="footer.legal.privacy.rights.item1">Demander une copie de vos données ;</li>
+        <li data-i18n="footer.legal.privacy.rights.item2">Demander la suppression définitive de vos données.</li>
       </ul>
-      <p class="text-gray-700">Pour exercer ces droits, contactez-nous via la section <strong>Support</strong> du site.</p>
+      <p class="text-gray-700" data-i18n="footer.legal.privacy.rights.contact">Pour exercer ces droits, contactez-nous via la section <strong>Support</strong> du site.</p>
     </div>
   `;
-  showModal('Politique de Confidentialité', content);
+  showModal('<span data-i18n="footer.legal.privacy.title">Politique de Confidentialité</span>', content);
 }
 
-        function showTermsOfService() {
-            const content = `
-                <div class="space-y-4">
-                    <h3 class="text-lg font-semibold text-gray-900">Conditions d'Utilisation</h3>
-                    <p class="text-gray-700">Dernière mise à jour : ${new Date().toLocaleDateString('fr-FR')}</p>
-                    
-                    <h4 class="font-semibold text-gray-900">Utilisation du service</h4>
-                    <p class="text-gray-700">Ce service est fourni gratuitement à des fins éducatives et de développement personnel. Il ne remplace pas un conseil professionnel en psychologie.</p>
-                    
-                    <h4 class="font-semibold text-gray-900">Précision des résultats</h4>
-                    <p class="text-gray-700">Les résultats sont basés sur des modèles psychologiques reconnus mais ne constituent pas un diagnostic médical ou psychologique.</p>
-                    
-                    <h4 class="font-semibold text-gray-900">Responsabilité</h4>
-                    <p class="text-gray-700">L'utilisation de ce service se fait sous votre propre responsabilité. Nous ne sommes pas responsables des décisions prises sur la base des résultats.</p>
-                </div>
-            `;
-            showModal('Conditions d\'Utilisation', content);
-        }
+function showTermsOfService() {
+  const lang = localStorage.getItem('lang') || 'fr';
+  const date = new Date().toLocaleDateString(lang === 'fr' ? 'fr-FR' : 'en-US');
+  const content = `
+    <div class="space-y-4">
+      <h3 class="text-lg font-semibold text-gray-900" data-i18n="footer.legal.terms.title">Conditions d'Utilisation</h3>
+      <p class="text-gray-700"><span data-i18n="footer.legal.terms.update">Dernière mise à jour :</span> ${date}</p>
+
+      <h4 class="font-semibold text-gray-900" data-i18n="footer.legal.terms.use.title">Utilisation du service</h4>
+      <p class="text-gray-700" data-i18n="footer.legal.terms.use.text">Ce service est fourni gratuitement à des fins éducatives et de développement personnel. Il ne remplace pas un conseil professionnel en psychologie.</p>
+
+      <h4 class="font-semibold text-gray-900" data-i18n="footer.legal.terms.accuracy.title">Précision des résultats</h4>
+      <p class="text-gray-700" data-i18n="footer.legal.terms.accuracy.text">Les résultats sont basés sur des modèles psychologiques reconnus mais ne constituent pas un diagnostic médical ou psychologique.</p>
+
+      <h4 class="font-semibold text-gray-900" data-i18n="footer.legal.terms.liability.title">Responsabilité</h4>
+      <p class="text-gray-700" data-i18n="footer.legal.terms.liability.text">L'utilisation de ce service se fait sous votre propre responsabilité. Nous ne sommes pas responsables des décisions prises sur la base des résultats.</p>
+    </div>
+  `;
+  showModal('<span data-i18n="footer.legal.terms.title">Conditions d\\'Utilisation</span>', content);
+}
+
+function showCookies() {
+  const content = `
+    <div class="space-y-4">
+      <h3 class="text-lg font-semibold text-gray-900" data-i18n="footer.legal.cookies.title">Cookies et stockage local</h3>
+      <p class="text-gray-700" data-i18n="footer.legal.cookies.text">
+        Ce site n’utilise pas de cookies de suivi.<br>
+        Seules certaines données nécessaires au fonctionnement (comme la progression dans le test ou le code d’accès aux résultats) sont stockées localement dans le navigateur ou dans notre base de données Supabase.
+      </p>
+    </div>
+  `;
+  showModal('<span data-i18n="footer.legal.cookies.title">Cookies et stockage local</span>', content);
+}
+
+function showSupport() {
+  const content = `
+    <div class="space-y-4">
+      <h3 class="text-lg font-semibold text-gray-900" data-i18n="footer.contact.support.title">Support</h3>
+
+      <div class="bg-blue-50 p-4 rounded-lg">
+        <h4 class="font-semibold text-blue-900" data-i18n="footer.contact.support.email.title">Email</h4>
+        <p class="text-blue-700" data-i18n="footer.contact.support.email.text"></p>
+      </div>
+
+      <div class="bg-blue-50 p-4 rounded-lg">
+        <h4 class="font-semibold text-blue-900" data-i18n="footer.contact.support.tech.title">Support technique</h4>
+        <p class="text-blue-700" data-i18n="footer.contact.support.tech.text">Pour toute question technique ou problème avec le test, n'hésitez pas à nous écrire en détaillant votre problème.</p>
+      </div>
+
+      <div class="bg-green-50 p-4 rounded-lg">
+        <h4 class="font-semibold text-green-900" data-i18n="footer.contact.support.suggestions.title">Suggestions</h4>
+        <p class="text-green-700" data-i18n="footer.contact.support.suggestions.text">Vos suggestions d'amélioration sont les bienvenues ! Aidez-nous à améliorer l'expérience utilisateur.</p>
+      </div>
+
+      <div class="bg-yellow-50 p-4 rounded-lg">
+        <h4 class="font-semibold text-yellow-900" data-i18n="footer.contact.support.time.title">Temps de réponse</h4>
+        <p class="text-yellow-700" data-i18n="footer.contact.support.time.text">Nous nous efforçons de répondre à tous les messages dans les 48 heures.</p>
+      </div>
+    </div>
+  `;
+  showModal('<span data-i18n="footer.contact.support.title">Support</span>', content);
+}
 
        function showLegalNotices() {
   const content = `

--- a/public/enneagramme.html
+++ b/public/enneagramme.html
@@ -981,35 +981,35 @@
                     <h3 class="text-sm font-semibold text-gray-400 tracking-wider uppercase" data-i18n="footer.brand_title">Personnalité Comparée</h3>
                     <ul class="mt-4 space-y-4">
                         <li><a href="index.html" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.home">Accueil</a></li>
-                        <li><a href="mbti.html" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.mbti">MBTI</a></li>
-                        <li><a href="enneagramme.html" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.enneagram">Ennéagramme</a></li>
-                        <li><a href="blog.html" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.blog">Blog</a></li>
-        <li><a href="index.html#home-ia" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.ai">IA spécialisée</a></li>
-        <li><a href="index.html#home-faq" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.faq">FAQ</a></li>
+        <li><a href="mbti.html" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.mbti">MBTI</a></li>
+        <li><a href="enneagramme.html" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.enneagram">Ennéagramme</a></li>
+        <li><a href="blog.html" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.blog">Blog</a></li>
+        <li><a href="#home-ia" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.ai">IA spécialisée</a></li>
+        <li><a href="#home-faq" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.faq">FAQ</a></li>
 
                     </ul>
                 </div>
                 <div>
                     <h3 class="text-sm font-semibold text-gray-400 tracking-wider uppercase" data-i18n="footer.tests_title">Tests</h3>
                     <ul class="mt-4 space-y-4">
-                        <li><a href="index.html#home-mbti" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.auto_eval">Auto-évaluation</a></li>
-                        <li><a href="index.html#home-enneagramme" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.evaluate_friend">Évaluer un proche</a></li>
-                        <li><a href="index.html#retourver-profil" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.my_profile">Mon profil</a></li>
+                        <li><a href="#home-mbti" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.auto_eval">Auto-évaluation</a></li>
+                        <li><a href="#home-enneagramme" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.evaluate_friend">Évaluer un proche</a></li>
+                        <li><a href="#retourver-profil" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.my_profile">Mon profil</a></li>
                     </ul>
                 </div>
                 <div>
                     <h3 class="text-sm font-semibold text-gray-400 tracking-wider uppercase" data-i18n="footer.legal_title">Légal</h3>
                     <ul class="mt-4 space-y-4">
-                        <li><a href="#" onclick="event.preventDefault(); showPrivacyPolicy();" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.privacy">Confidentialité</a></li>
-                        <li><a href="#" onclick="event.preventDefault(); showTermsOfService();" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.terms">Conditions d'utilisation</a></li>
-                        <li><a href="#" onclick="event.preventDefault(); showLegalNotices();" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.legal">Mentions légales</a></li>
-                        <li><a href="#" onclick="event.preventDefault(); showLegalNotices();" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.cookies">Cookies</a></li>
+                        <li><a href="#" id="privacy-link" onclick="event.preventDefault(); showPrivacyPolicy();" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.privacy">Confidentialité</a></li>
+                        <li><a href="#" id="terms-link" onclick="event.preventDefault(); showTermsOfService();" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.terms">Conditions d'utilisation</a></li>
+                        <li><a href="#" id="legal-link" onclick="event.preventDefault(); showLegalNotices();" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.legal">Mentions légales</a></li>
+                        <li><a href="#" id="cookies-link" onclick="event.preventDefault(); showCookies();" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.cookies">Cookies</a></li>
                     </ul>
                 </div>
                 <div>
                     <h3 class="text-sm font-semibold text-gray-400 tracking-wider uppercase" data-i18n="footer.contact_title">Contact</h3>
                     <ul class="mt-4 space-y-4">
-                        <li><a href="#" onclick="event.preventDefault(); showContact();" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.support">Support</a></li>
+                        <li><a href="#" id="support-link" onclick="event.preventDefault(); showSupport();" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.support">Support</a></li>
                         <li class="flex space-x-6 pt-2">
                             <a href="#" class="text-gray-400 hover:text-white transition-colors">
                                 <span class="sr-only" data-i18n="social.facebook">Facebook</span>
@@ -2880,66 +2880,112 @@ function displayResults(results) {
 
         // Fonctions pour les pages légales et contact
 function showPrivacyPolicy() {
+  const lang = localStorage.getItem('lang') || 'fr';
+  const date = new Date().toLocaleDateString(lang === 'fr' ? 'fr-FR' : 'en-US');
   const content = `
     <div class="space-y-4">
-      <h3 class="text-lg font-semibold text-gray-900">Politique de Confidentialité</h3>
-      <p class="text-gray-700">Dernière mise à jour : ${new Date().toLocaleDateString('fr-FR')}</p>
+      <h3 class="text-lg font-semibold text-gray-900" data-i18n="footer.legal.privacy.title">Politique de Confidentialité</h3>
+      <p class="text-gray-700"><span data-i18n="footer.legal.privacy.update">Dernière mise à jour :</span> ${date}</p>
 
-      <h4 class="font-semibold text-gray-900">1. Données collectées</h4>
-      <p class="text-gray-700">Nous collectons uniquement les réponses fournies lors&nbsp;:</p>
+      <h4 class="font-semibold text-gray-900" data-i18n="footer.legal.privacy.collected.title">1. Données collectées</h4>
+      <p class="text-gray-700" data-i18n="footer.legal.privacy.collected.desc">Nous collectons uniquement les réponses fournies lors&nbsp;:</p>
       <ul class="list-disc pl-6 text-gray-700">
-        <li>de vos auto-évaluations ;</li>
-        <li>des évaluations réalisées par vos proches.</li>
+        <li data-i18n="footer.legal.privacy.collected.item1">de vos auto-évaluations ;</li>
+        <li data-i18n="footer.legal.privacy.collected.item2">des évaluations réalisées par vos proches.</li>
       </ul>
-      <p class="text-gray-700">Aucune autre donnée personnelle (nom, e-mail, localisation, etc.) n’est demandée ni enregistrée.</p>
+      <p class="text-gray-700" data-i18n="footer.legal.privacy.collected.note">Aucune autre donnée personnelle (nom, e-mail, localisation, etc.) n’est demandée ni enregistrée.</p>
 
-      <h4 class="font-semibold text-gray-900">2. Finalité de la collecte</h4>
+      <h4 class="font-semibold text-gray-900" data-i18n="footer.legal.privacy.purpose.title">2. Finalité de la collecte</h4>
       <ul class="list-disc pl-6 text-gray-700">
-        <li>Calculer et afficher votre profil de personnalité ;</li>
-        <li>Générer les résultats finaux à partir des évaluations reçues.</li>
+        <li data-i18n="footer.legal.privacy.purpose.item1">Calculer et afficher votre profil de personnalité ;</li>
+        <li data-i18n="footer.legal.privacy.purpose.item2">Générer les résultats finaux à partir des évaluations reçues.</li>
       </ul>
 
-      <h4 class="font-semibold text-gray-900">3. Stockage des données</h4>
-      <p class="text-gray-700">Vos réponses sont stockées de manière sécurisée dans notre base de données <strong>Supabase</strong>. Elles ne sont pas enregistrées ailleurs.</p>
+      <h4 class="font-semibold text-gray-900" data-i18n="footer.legal.privacy.storage.title">3. Stockage des données</h4>
+      <p class="text-gray-700" data-i18n="footer.legal.privacy.storage.text">Vos réponses sont stockées de manière sécurisée dans notre base de données <strong>Supabase</strong>. Elles ne sont pas enregistrées ailleurs.</p>
 
-      <h4 class="font-semibold text-gray-900">4. Partage des données</h4>
-      <p class="text-gray-700">Nous ne vendons, n’échangeons et ne partageons <strong>aucune</strong> donnée avec des tiers. Seules les personnes disposant de votre code unique peuvent consulter vos résultats.</p>
+      <h4 class="font-semibold text-gray-900" data-i18n="footer.legal.privacy.sharing.title">4. Partage des données</h4>
+      <p class="text-gray-700" data-i18n="footer.legal.privacy.sharing.text">Nous ne vendons, n’échangeons et ne partageons <strong>aucune</strong> donnée avec des tiers. Seules les personnes disposant de votre code unique peuvent consulter vos résultats.</p>
 
-      <h4 class="font-semibold text-gray-900">5. Sécurité</h4>
-      <p class="text-gray-700">Supabase applique des mesures de sécurité standards (chiffrement en transit, contrôles d’accès). Nous limitons l’accès aux données aux seules finalités décrites ci-dessus.</p>
+      <h4 class="font-semibold text-gray-900" data-i18n="footer.legal.privacy.security.title">5. Sécurité</h4>
+      <p class="text-gray-700" data-i18n="footer.legal.privacy.security.text">Supabase applique des mesures de sécurité standards (chiffrement en transit, contrôles d’accès). Nous limitons l’accès aux données aux seules finalités décrites ci-dessus.</p>
 
-      <h4 class="font-semibold text-gray-900">6. Durée de conservation</h4>
-      <p class="text-gray-700">Les réponses sont conservées tant que votre code unique reste valide dans notre base. Vous pouvez demander leur suppression à tout moment.</p>
+      <h4 class="font-semibold text-gray-900" data-i18n="footer.legal.privacy.retention.title">6. Durée de conservation</h4>
+      <p class="text-gray-700" data-i18n="footer.legal.privacy.retention.text">Les réponses sont conservées tant que votre code unique reste valide dans notre base. Vous pouvez demander leur suppression à tout moment.</p>
 
-      <h4 class="font-semibold text-gray-900">7. Vos droits</h4>
+      <h4 class="font-semibold text-gray-900" data-i18n="footer.legal.privacy.rights.title">7. Vos droits</h4>
       <ul class="list-disc pl-6 text-gray-700">
-        <li>Demander une copie de vos données ;</li>
-        <li>Demander la suppression définitive de vos données.</li>
+        <li data-i18n="footer.legal.privacy.rights.item1">Demander une copie de vos données ;</li>
+        <li data-i18n="footer.legal.privacy.rights.item2">Demander la suppression définitive de vos données.</li>
       </ul>
-      <p class="text-gray-700">Pour exercer ces droits, contactez-nous via la section <strong>Support</strong> du site.</p>
+      <p class="text-gray-700" data-i18n="footer.legal.privacy.rights.contact">Pour exercer ces droits, contactez-nous via la section <strong>Support</strong> du site.</p>
     </div>
   `;
-  showModal('Politique de Confidentialité', content);
+  showModal('<span data-i18n="footer.legal.privacy.title">Politique de Confidentialité</span>', content);
 }
 
-        function showTermsOfService() {
-            const content = `
-                <div class="space-y-4">
-                    <h3 class="text-lg font-semibold text-gray-900">Conditions d'Utilisation</h3>
-                    <p class="text-gray-700">Dernière mise à jour : ${new Date().toLocaleDateString('fr-FR')}</p>
-                    
-                    <h4 class="font-semibold text-gray-900">Utilisation du service</h4>
-                    <p class="text-gray-700">Ce service est fourni gratuitement à des fins éducatives et de développement personnel. Il ne remplace pas un conseil professionnel en psychologie.</p>
-                    
-                    <h4 class="font-semibold text-gray-900">Précision des résultats</h4>
-                    <p class="text-gray-700">Les résultats sont basés sur des modèles psychologiques reconnus mais ne constituent pas un diagnostic médical ou psychologique.</p>
-                    
-                    <h4 class="font-semibold text-gray-900">Responsabilité</h4>
-                    <p class="text-gray-700">L'utilisation de ce service se fait sous votre propre responsabilité. Nous ne sommes pas responsables des décisions prises sur la base des résultats.</p>
-                </div>
-            `;
-            showModal('Conditions d\'Utilisation', content);
-        }
+function showTermsOfService() {
+  const lang = localStorage.getItem('lang') || 'fr';
+  const date = new Date().toLocaleDateString(lang === 'fr' ? 'fr-FR' : 'en-US');
+  const content = `
+    <div class="space-y-4">
+      <h3 class="text-lg font-semibold text-gray-900" data-i18n="footer.legal.terms.title">Conditions d'Utilisation</h3>
+      <p class="text-gray-700"><span data-i18n="footer.legal.terms.update">Dernière mise à jour :</span> ${date}</p>
+
+      <h4 class="font-semibold text-gray-900" data-i18n="footer.legal.terms.use.title">Utilisation du service</h4>
+      <p class="text-gray-700" data-i18n="footer.legal.terms.use.text">Ce service est fourni gratuitement à des fins éducatives et de développement personnel. Il ne remplace pas un conseil professionnel en psychologie.</p>
+
+      <h4 class="font-semibold text-gray-900" data-i18n="footer.legal.terms.accuracy.title">Précision des résultats</h4>
+      <p class="text-gray-700" data-i18n="footer.legal.terms.accuracy.text">Les résultats sont basés sur des modèles psychologiques reconnus mais ne constituent pas un diagnostic médical ou psychologique.</p>
+
+      <h4 class="font-semibold text-gray-900" data-i18n="footer.legal.terms.liability.title">Responsabilité</h4>
+      <p class="text-gray-700" data-i18n="footer.legal.terms.liability.text">L'utilisation de ce service se fait sous votre propre responsabilité. Nous ne sommes pas responsables des décisions prises sur la base des résultats.</p>
+    </div>
+  `;
+  showModal('<span data-i18n="footer.legal.terms.title">Conditions d\\'Utilisation</span>', content);
+}
+
+function showCookies() {
+  const content = `
+    <div class="space-y-4">
+      <h3 class="text-lg font-semibold text-gray-900" data-i18n="footer.legal.cookies.title">Cookies et stockage local</h3>
+      <p class="text-gray-700" data-i18n="footer.legal.cookies.text">
+        Ce site n’utilise pas de cookies de suivi.<br>
+        Seules certaines données nécessaires au fonctionnement (comme la progression dans le test ou le code d’accès aux résultats) sont stockées localement dans le navigateur ou dans notre base de données Supabase.
+      </p>
+    </div>
+  `;
+  showModal('<span data-i18n="footer.legal.cookies.title">Cookies et stockage local</span>', content);
+}
+
+function showSupport() {
+  const content = `
+    <div class="space-y-4">
+      <h3 class="text-lg font-semibold text-gray-900" data-i18n="footer.contact.support.title">Support</h3>
+
+      <div class="bg-blue-50 p-4 rounded-lg">
+        <h4 class="font-semibold text-blue-900" data-i18n="footer.contact.support.email.title">Email</h4>
+        <p class="text-blue-700" data-i18n="footer.contact.support.email.text"></p>
+      </div>
+
+      <div class="bg-blue-50 p-4 rounded-lg">
+        <h4 class="font-semibold text-blue-900" data-i18n="footer.contact.support.tech.title">Support technique</h4>
+        <p class="text-blue-700" data-i18n="footer.contact.support.tech.text">Pour toute question technique ou problème avec le test, n'hésitez pas à nous écrire en détaillant votre problème.</p>
+      </div>
+
+      <div class="bg-green-50 p-4 rounded-lg">
+        <h4 class="font-semibold text-green-900" data-i18n="footer.contact.support.suggestions.title">Suggestions</h4>
+        <p class="text-green-700" data-i18n="footer.contact.support.suggestions.text">Vos suggestions d'amélioration sont les bienvenues ! Aidez-nous à améliorer l'expérience utilisateur.</p>
+      </div>
+
+      <div class="bg-yellow-50 p-4 rounded-lg">
+        <h4 class="font-semibold text-yellow-900" data-i18n="footer.contact.support.time.title">Temps de réponse</h4>
+        <p class="text-yellow-700" data-i18n="footer.contact.support.time.text">Nous nous efforçons de répondre à tous les messages dans les 48 heures.</p>
+      </div>
+    </div>
+  `;
+  showModal('<span data-i18n="footer.contact.support.title">Support</span>', content);
+}
 
        function showLegalNotices() {
   const content = `

--- a/public/mbti.html
+++ b/public/mbti.html
@@ -1078,46 +1078,46 @@
                     <h3 class="text-sm font-semibold text-gray-400 tracking-wider uppercase" data-i18n="footer.brand_title">Personnalité Comparée</h3>
                     <ul class="mt-4 space-y-4">
                         <li><a href="index.html" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.home">Accueil</a></li>
-                        <li><a href="mbti.html" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.mbti">MBTI</a></li>
-                        <li><a href="enneagramme.html" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.enneagram">Ennéagramme</a></li>
-                        <li><a href="blog.html" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.blog">Blog</a></li>
-                        <li><a href="index.html#home-ia" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.ai">IA spécialisée</a></li>
-                        <li><a href="index.html#home-faq" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.faq">FAQ</a></li>
+        <li><a href="mbti.html" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.mbti">MBTI</a></li>
+        <li><a href="enneagramme.html" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.enneagram">Ennéagramme</a></li>
+        <li><a href="blog.html" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.blog">Blog</a></li>
+        <li><a href="#home-ia" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.ai">IA spécialisée</a></li>
+        <li><a href="#home-faq" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.faq">FAQ</a></li>
 
                     </ul>
                 </div>
                 <div>
                     <h3 class="text-sm font-semibold text-gray-400 tracking-wider uppercase" data-i18n="footer.tests_title">Tests</h3>
                     <ul class="mt-4 space-y-4">
-                        <li><a href="index.html#home-mbti" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.auto_eval">Auto-évaluation</a></li>
-                        <li><a href="index.html#home-enneagramme" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.evaluate_friend">Évaluer un proche</a></li>
-                        <li><a href="index.html#retourver-profil" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.my_profile">Mon profil</a></li>
+                        <li><a href="#home-mbti" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.auto_eval">Auto-évaluation</a></li>
+                        <li><a href="#home-enneagramme" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.evaluate_friend">Évaluer un proche</a></li>
+                        <li><a href="#retourver-profil" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.my_profile">Mon profil</a></li>
                     </ul>
                 </div>
                 <div>
                     <h3 class="text-sm font-semibold text-gray-400 tracking-wider uppercase" data-i18n="footer.legal_title">Légal</h3>
                     <ul class="mt-4 space-y-4">
-                        <li><a href="#" onclick="event.preventDefault(); showPrivacyPolicy();" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.privacy">Confidentialité</a></li>
-                        <li><a href="#" onclick="event.preventDefault(); showTermsOfService();" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.terms">Conditions d'utilisation</a></li>
-                        <li><a href="#" onclick="event.preventDefault(); showLegalNotices();" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.legal">Mentions légales</a></li>
-                        <li><a href="#" onclick="event.preventDefault(); showLegalNotices();" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.cookies">Cookies</a></li>
+                        <li><a href="#" id="privacy-link" onclick="event.preventDefault(); showPrivacyPolicy();" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.privacy">Confidentialité</a></li>
+                        <li><a href="#" id="terms-link" onclick="event.preventDefault(); showTermsOfService();" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.terms">Conditions d'utilisation</a></li>
+                        <li><a href="#" id="legal-link" onclick="event.preventDefault(); showLegalNotices();" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.legal">Mentions légales</a></li>
+                        <li><a href="#" id="cookies-link" onclick="event.preventDefault(); showCookies();" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.cookies">Cookies</a></li>
                     </ul>
                 </div>
                 <div>
                     <h3 class="text-sm font-semibold text-gray-400 tracking-wider uppercase" data-i18n="footer.contact_title">Contact</h3>
                     <ul class="mt-4 space-y-4">
-                        <li><a href="#" onclick="event.preventDefault(); showContact();" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.support">Support</a></li>
+                        <li><a href="#" id="support-link" onclick="event.preventDefault(); showSupport();" class="text-base text-gray-300 hover:text-white transition-colors" data-i18n="footer.support">Support</a></li>
                         <li class="flex space-x-6 pt-2">
                             <a href="#" class="text-gray-400 hover:text-white transition-colors">
-                                <span class="sr-only">Facebook</span>
+                                <span class="sr-only" data-i18n="social.facebook">Facebook</span>
                                 <i class="fab fa-facebook-f"></i>
                             </a>
                             <a href="#" class="text-gray-400 hover:text-white transition-colors">
-                                <span class="sr-only">Instagram</span>
+                                <span class="sr-only" data-i18n="social.instagram">Instagram</span>
                                 <i class="fab fa-instagram"></i>
                             </a>
                             <a href="#" class="text-gray-400 hover:text-white transition-colors">
-                                <span class="sr-only">TikTok</span>
+                                <span class="sr-only" data-i18n="social.tiktok">TikTok</span>
                                 <i class="fab fa-tiktok"></i>
                             </a>
                         </li>
@@ -2974,68 +2974,114 @@ function displayResults(results) {
 
         // Fonctions pour les pages légales et contact
 function showPrivacyPolicy() {
+  const lang = localStorage.getItem('lang') || 'fr';
+  const date = new Date().toLocaleDateString(lang === 'fr' ? 'fr-FR' : 'en-US');
   const content = `
     <div class="space-y-4">
-      <h3 class="text-lg font-semibold text-gray-900">Politique de Confidentialité</h3>
-      <p class="text-gray-700">Dernière mise à jour : ${new Date().toLocaleDateString('fr-FR')}</p>
+      <h3 class="text-lg font-semibold text-gray-900" data-i18n="footer.legal.privacy.title">Politique de Confidentialité</h3>
+      <p class="text-gray-700"><span data-i18n="footer.legal.privacy.update">Dernière mise à jour :</span> ${date}</p>
 
-      <h4 class="font-semibold text-gray-900">1. Données collectées</h4>
-      <p class="text-gray-700">Nous collectons uniquement les réponses fournies lors&nbsp;:</p>
+      <h4 class="font-semibold text-gray-900" data-i18n="footer.legal.privacy.collected.title">1. Données collectées</h4>
+      <p class="text-gray-700" data-i18n="footer.legal.privacy.collected.desc">Nous collectons uniquement les réponses fournies lors&nbsp;:</p>
       <ul class="list-disc pl-6 text-gray-700">
-        <li>de vos auto-évaluations ;</li>
-        <li>des évaluations réalisées par vos proches.</li>
+        <li data-i18n="footer.legal.privacy.collected.item1">de vos auto-évaluations ;</li>
+        <li data-i18n="footer.legal.privacy.collected.item2">des évaluations réalisées par vos proches.</li>
       </ul>
-      <p class="text-gray-700">Aucune autre donnée personnelle (nom, e-mail, localisation, etc.) n’est demandée ni enregistrée.</p>
+      <p class="text-gray-700" data-i18n="footer.legal.privacy.collected.note">Aucune autre donnée personnelle (nom, e-mail, localisation, etc.) n’est demandée ni enregistrée.</p>
 
-      <h4 class="font-semibold text-gray-900">2. Finalité de la collecte</h4>
+      <h4 class="font-semibold text-gray-900" data-i18n="footer.legal.privacy.purpose.title">2. Finalité de la collecte</h4>
       <ul class="list-disc pl-6 text-gray-700">
-        <li>Calculer et afficher votre profil de personnalité ;</li>
-        <li>Générer les résultats finaux à partir des évaluations reçues.</li>
+        <li data-i18n="footer.legal.privacy.purpose.item1">Calculer et afficher votre profil de personnalité ;</li>
+        <li data-i18n="footer.legal.privacy.purpose.item2">Générer les résultats finaux à partir des évaluations reçues.</li>
       </ul>
 
-      <h4 class="font-semibold text-gray-900">3. Stockage des données</h4>
-      <p class="text-gray-700">Vos réponses sont stockées de manière sécurisée dans notre base de données <strong>Supabase</strong>. Elles ne sont pas enregistrées ailleurs.</p>
+      <h4 class="font-semibold text-gray-900" data-i18n="footer.legal.privacy.storage.title">3. Stockage des données</h4>
+      <p class="text-gray-700" data-i18n="footer.legal.privacy.storage.text">Vos réponses sont stockées de manière sécurisée dans notre base de données <strong>Supabase</strong>. Elles ne sont pas enregistrées ailleurs.</p>
 
-      <h4 class="font-semibold text-gray-900">4. Partage des données</h4>
-      <p class="text-gray-700">Nous ne vendons, n’échangeons et ne partageons <strong>aucune</strong> donnée avec des tiers. Seules les personnes disposant de votre code unique peuvent consulter vos résultats.</p>
+      <h4 class="font-semibold text-gray-900" data-i18n="footer.legal.privacy.sharing.title">4. Partage des données</h4>
+      <p class="text-gray-700" data-i18n="footer.legal.privacy.sharing.text">Nous ne vendons, n’échangeons et ne partageons <strong>aucune</strong> donnée avec des tiers. Seules les personnes disposant de votre code unique peuvent consulter vos résultats.</p>
 
-      <h4 class="font-semibold text-gray-900">5. Sécurité</h4>
-      <p class="text-gray-700">Supabase applique des mesures de sécurité standards (chiffrement en transit, contrôles d’accès). Nous limitons l’accès aux données aux seules finalités décrites ci-dessus.</p>
+      <h4 class="font-semibold text-gray-900" data-i18n="footer.legal.privacy.security.title">5. Sécurité</h4>
+      <p class="text-gray-700" data-i18n="footer.legal.privacy.security.text">Supabase applique des mesures de sécurité standards (chiffrement en transit, contrôles d’accès). Nous limitons l’accès aux données aux seules finalités décrites ci-dessus.</p>
 
-      <h4 class="font-semibold text-gray-900">6. Durée de conservation</h4>
-      <p class="text-gray-700">Les réponses sont conservées tant que votre code unique reste valide dans notre base. Vous pouvez demander leur suppression à tout moment.</p>
+      <h4 class="font-semibold text-gray-900" data-i18n="footer.legal.privacy.retention.title">6. Durée de conservation</h4>
+      <p class="text-gray-700" data-i18n="footer.legal.privacy.retention.text">Les réponses sont conservées tant que votre code unique reste valide dans notre base. Vous pouvez demander leur suppression à tout moment.</p>
 
-      <h4 class="font-semibold text-gray-900">7. Vos droits</h4>
+      <h4 class="font-semibold text-gray-900" data-i18n="footer.legal.privacy.rights.title">7. Vos droits</h4>
       <ul class="list-disc pl-6 text-gray-700">
-        <li>Demander une copie de vos données ;</li>
-        <li>Demander la suppression définitive de vos données.</li>
+        <li data-i18n="footer.legal.privacy.rights.item1">Demander une copie de vos données ;</li>
+        <li data-i18n="footer.legal.privacy.rights.item2">Demander la suppression définitive de vos données.</li>
       </ul>
-      <p class="text-gray-700">Pour exercer ces droits, contactez-nous via la section <strong>Support</strong> du site.</p>
+      <p class="text-gray-700" data-i18n="footer.legal.privacy.rights.contact">Pour exercer ces droits, contactez-nous via la section <strong>Support</strong> du site.</p>
     </div>
   `;
-  showModal('Politique de Confidentialité', content);
+  showModal('<span data-i18n="footer.legal.privacy.title">Politique de Confidentialité</span>', content);
 }
 
-        function showTermsOfService() {
-            const content = `
-                <div class="space-y-4">
-                    <h3 class="text-lg font-semibold text-gray-900">Conditions d'Utilisation</h3>
-                    <p class="text-gray-700">Dernière mise à jour : ${new Date().toLocaleDateString('fr-FR')}</p>
-                    
-                    <h4 class="font-semibold text-gray-900">Utilisation du service</h4>
-                    <p class="text-gray-700">Ce service est fourni gratuitement à des fins éducatives et de développement personnel. Il ne remplace pas un conseil professionnel en psychologie.</p>
-                    
-                    <h4 class="font-semibold text-gray-900">Précision des résultats</h4>
-                    <p class="text-gray-700">Les résultats sont basés sur des modèles psychologiques reconnus mais ne constituent pas un diagnostic médical ou psychologique.</p>
-                    
-                    <h4 class="font-semibold text-gray-900">Responsabilité</h4>
-                    <p class="text-gray-700">L'utilisation de ce service se fait sous votre propre responsabilité. Nous ne sommes pas responsables des décisions prises sur la base des résultats.</p>
-                </div>
-            `;
-            showModal('Conditions d\'Utilisation', content);
-        }
+function showTermsOfService() {
+  const lang = localStorage.getItem('lang') || 'fr';
+  const date = new Date().toLocaleDateString(lang === 'fr' ? 'fr-FR' : 'en-US');
+  const content = `
+    <div class="space-y-4">
+      <h3 class="text-lg font-semibold text-gray-900" data-i18n="footer.legal.terms.title">Conditions d'Utilisation</h3>
+      <p class="text-gray-700"><span data-i18n="footer.legal.terms.update">Dernière mise à jour :</span> ${date}</p>
 
-       function showLegalNotices() {
+      <h4 class="font-semibold text-gray-900" data-i18n="footer.legal.terms.use.title">Utilisation du service</h4>
+      <p class="text-gray-700" data-i18n="footer.legal.terms.use.text">Ce service est fourni gratuitement à des fins éducatives et de développement personnel. Il ne remplace pas un conseil professionnel en psychologie.</p>
+
+      <h4 class="font-semibold text-gray-900" data-i18n="footer.legal.terms.accuracy.title">Précision des résultats</h4>
+      <p class="text-gray-700" data-i18n="footer.legal.terms.accuracy.text">Les résultats sont basés sur des modèles psychologiques reconnus mais ne constituent pas un diagnostic médical ou psychologique.</p>
+
+      <h4 class="font-semibold text-gray-900" data-i18n="footer.legal.terms.liability.title">Responsabilité</h4>
+      <p class="text-gray-700" data-i18n="footer.legal.terms.liability.text">L'utilisation de ce service se fait sous votre propre responsabilité. Nous ne sommes pas responsables des décisions prises sur la base des résultats.</p>
+    </div>
+  `;
+  showModal('<span data-i18n="footer.legal.terms.title">Conditions d\\'Utilisation</span>', content);
+}
+
+function showCookies() {
+  const content = `
+    <div class="space-y-4">
+      <h3 class="text-lg font-semibold text-gray-900" data-i18n="footer.legal.cookies.title">Cookies et stockage local</h3>
+      <p class="text-gray-700" data-i18n="footer.legal.cookies.text">
+        Ce site n’utilise pas de cookies de suivi.<br>
+        Seules certaines données nécessaires au fonctionnement (comme la progression dans le test ou le code d’accès aux résultats) sont stockées localement dans le navigateur ou dans notre base de données Supabase.
+      </p>
+    </div>
+  `;
+  showModal('<span data-i18n="footer.legal.cookies.title">Cookies et stockage local</span>', content);
+}
+
+function showSupport() {
+  const content = `
+    <div class="space-y-4">
+      <h3 class="text-lg font-semibold text-gray-900" data-i18n="footer.contact.support.title">Support</h3>
+
+      <div class="bg-blue-50 p-4 rounded-lg">
+        <h4 class="font-semibold text-blue-900" data-i18n="footer.contact.support.email.title">Email</h4>
+        <p class="text-blue-700" data-i18n="footer.contact.support.email.text"></p>
+      </div>
+
+      <div class="bg-blue-50 p-4 rounded-lg">
+        <h4 class="font-semibold text-blue-900" data-i18n="footer.contact.support.tech.title">Support technique</h4>
+        <p class="text-blue-700" data-i18n="footer.contact.support.tech.text">Pour toute question technique ou problème avec le test, n'hésitez pas à nous écrire en détaillant votre problème.</p>
+      </div>
+
+      <div class="bg-green-50 p-4 rounded-lg">
+        <h4 class="font-semibold text-green-900" data-i18n="footer.contact.support.suggestions.title">Suggestions</h4>
+        <p class="text-green-700" data-i18n="footer.contact.support.suggestions.text">Vos suggestions d'amélioration sont les bienvenues ! Aidez-nous à améliorer l'expérience utilisateur.</p>
+      </div>
+
+      <div class="bg-yellow-50 p-4 rounded-lg">
+        <h4 class="font-semibold text-yellow-900" data-i18n="footer.contact.support.time.title">Temps de réponse</h4>
+        <p class="text-yellow-700" data-i18n="footer.contact.support.time.text">Nous nous efforçons de répondre à tous les messages dans les 48 heures.</p>
+      </div>
+    </div>
+  `;
+  showModal('<span data-i18n="footer.contact.support.title">Support</span>', content);
+}
+
+function showLegalNotices() {
   const content = `
     <div class="space-y-4">
       <h3 class="text-lg font-semibold text-gray-900" data-i18n="footer.legal.mentions.title">Mentions Légales</h3>


### PR DESCRIPTION
## Summary
- replace footers in MBTI, Enneagram and Blog pages with unified version from index
- fix Privacy Policy and Terms modals to translate based on selected language
- add cookies and support modal handlers for consistent footer links

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a308c9d3cc832192afde5946794087