### PR TITLE
Uniformize headers and legal modals across pages

### DIFF
--- a/public/blog.html
+++ b/public/blog.html
@@ -399,16 +399,16 @@
                 <img src="logo pc 3.png" alt="Personnalité Comparée logo" class="w-10 h-10 rounded-full object-cover"><span id="brand-home" class="ml-3 text-[1.05rem] sm:text-xl font-bold text-black" data-i18n="brand.name">Personnalité Comparée</span>
             </div>
             <div class="language-switcher ml-4 flex gap-0 text-sm font-bold">
-                <button onclick="switchLang('fr')" data-i18n="lang.fr">FR</button><span> | </span><button onclick="switchLang('en')" data-i18n="lang.en">EN</button>
+                <button onclick="switchLang('fr'); updatePlaceholders();" data-i18n="lang.fr">FR</button><span> | </span><button onclick="switchLang('en'); updatePlaceholders();" data-i18n="lang.en">EN</button>
             </div>
         </div>
         <nav class="desktop-nav hidden md:ml-6 md:flex md:items-center md:space-x-8">
-            <div id="home-menu-container" class="relative group">
+            <div id="home-menu-container" class="relative">
                 <a id="home-menu-button" href="index.html" class="inline-flex items-center gap-2 text-gray-900 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
                     <span data-i18n="menu.home">Accueil</span>
                     <svg class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
                 </a>
-                <div id="home-menu" class="invisible opacity-0 group-hover:visible group-hover:opacity-100 transition absolute left-0 mt-2 w-64 rounded-xl shadow-lg bg-white ring-1 ring-black/5 z-50">
+                <div id="home-menu" class="invisible opacity-0 transition absolute left-0 mt-2 w-64 rounded-xl shadow-lg bg-white ring-1 ring-black/5 z-50">
                     <ul class="py-2 text-sm">
                         <li><a href="index.html#home-how" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100" data-i18n="menu.home.how">Comment ça marche</a></li>
                         <li><a href="index.html#home-mbti" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100" data-i18n="menu.home.auto_eval">Auto-évaluation</a></li>
@@ -421,12 +421,12 @@
                     </ul>
                 </div>
             </div>
-            <div id="mbti-menu-container" class="relative group">
+            <div id="mbti-menu-container" class="relative">
                 <a id="mbti-menu-button" href="mbti.html" class="inline-flex items-center gap-2 text-gray-500 hover:text-gray-700 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
                     <span data-i18n="menu.mbti">MBTI</span>
                     <svg class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
                 </a>
-                <div id="mbti-menu" class="invisible opacity-0 group-hover:visible group-hover:opacity-100 transition absolute left-0 mt-2 w-64 rounded-xl shadow-lg bg-white ring-1 ring-black/5 z-50">
+                <div id="mbti-menu" class="invisible opacity-0 transition absolute left-0 mt-2 w-64 rounded-xl shadow-lg bg-white ring-1 ring-black/5 z-50">
                     <ul class="py-2 text-sm">
                         <li><a href="mbti.html#mbti-hero" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100" data-i18n="menu.mbti.understand">Comprendre le MBTI</a></li>
                         <li><a href="mbti.html#mbti-history" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100" data-i18n="menu.mbti.history">Un peu d'histoire</a></li>
@@ -435,12 +435,12 @@
                     </ul>
                 </div>
             </div>
-            <div id="ennea-menu-container" class="relative group">
+            <div id="ennea-menu-container" class="relative">
                 <a id="ennea-menu-button" href="enneagramme.html" class="inline-flex items-center gap-2 text-gray-500 hover:text-gray-700 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
                     <span data-i18n="menu.enneagram">Ennéagramme</span>
                     <svg class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
                 </a>
-                <div id="ennea-menu" class="invisible opacity-0 group-hover:visible group-hover:opacity-100 transition absolute left-0 mt-2 w-64 rounded-xl shadow-lg bg-white ring-1 ring-black/5 z-50">
+                <div id="ennea-menu" class="invisible opacity-0 transition absolute left-0 mt-2 w-64 rounded-xl shadow-lg bg-white ring-1 ring-black/5 z-50">
                     <ul class="py-2 text-sm">
                         <li><a href="enneagramme.html#ennea-hero" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100" data-i18n="menu.enneagram.understand">Comprendre l’Ennéagramme</a></li>
                         <li><a href="enneagramme.html#ennea-history" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100" data-i18n="menu.enneagram.history">Un peu d'histoire</a></li>
@@ -458,7 +458,7 @@
         </nav>
         <div class="-mr-2 flex items-center md:hidden">
             <button type="button" id="mobile-menu-button" class="inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500" aria-controls="mobile-menu" aria-expanded="false">
-                <span class="sr-only">Ouvrir le menu principal</span>
+                <span class="sr-only" data-i18n="nav.open_main">Ouvrir le menu principal</span>
                 <i class="fas fa-bars" id="menu-icon"></i>
             </button>
         </div>

--- a/public/common.js
+++ b/public/common.js
@@ -165,10 +165,20 @@ function showEnneagramDetails(type){
 function showPrivacyPolicy(){
   const content = `<p class="text-gray-700">Nous collectons uniquement les réponses nécessaires au fonctionnement du site. Aucune donnée personnelle n'est partagée.</p>`;
   showModal('Politique de Confidentialité', content);
+  if (window.i18n && typeof window.i18n.translate === 'function') {
+    window.i18n.translate();
+  } else if (typeof applyTranslations === 'function') {
+    applyTranslations();
+  }
 }
 function showTermsOfService(){
   const content = `<p class="text-gray-700">L'utilisation du site est soumise à votre acceptation de nos conditions d'utilisation.</p>`;
   showModal("Conditions d'utilisation", content);
+  if (window.i18n && typeof window.i18n.translate === 'function') {
+    window.i18n.translate();
+  } else if (typeof applyTranslations === 'function') {
+    applyTranslations();
+  }
 }
 function showLegalNotices(){
   const content = `

--- a/public/enneagramme.html
+++ b/public/enneagramme.html
@@ -399,16 +399,16 @@
                 <img src="logo pc 3.png" alt="Personnalité Comparée logo" class="w-10 h-10 rounded-full object-cover"><span id="brand-home" class="ml-3 text-[1.05rem] sm:text-xl font-bold text-black" data-i18n="brand.name">Personnalité Comparée</span>
             </div>
             <div class="language-switcher ml-4 flex gap-0 text-sm font-bold">
-                <button onclick="switchLang('fr')" data-i18n="lang.fr">FR</button><span> | </span><button onclick="switchLang('en')" data-i18n="lang.en">EN</button>
+                <button onclick="switchLang('fr'); updatePlaceholders();" data-i18n="lang.fr">FR</button><span> | </span><button onclick="switchLang('en'); updatePlaceholders();" data-i18n="lang.en">EN</button>
             </div>
         </div>
         <nav class="desktop-nav hidden md:ml-6 md:flex md:items-center md:space-x-8">
-            <div id="home-menu-container" class="relative group">
+            <div id="home-menu-container" class="relative">
                 <a id="home-menu-button" href="index.html" class="inline-flex items-center gap-2 text-gray-900 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
                     <span data-i18n="menu.home">Accueil</span>
                     <svg class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
                 </a>
-                <div id="home-menu" class="invisible opacity-0 group-hover:visible group-hover:opacity-100 transition absolute left-0 mt-2 w-64 rounded-xl shadow-lg bg-white ring-1 ring-black/5 z-50">
+                <div id="home-menu" class="invisible opacity-0 transition absolute left-0 mt-2 w-64 rounded-xl shadow-lg bg-white ring-1 ring-black/5 z-50">
                     <ul class="py-2 text-sm">
                         <li><a href="index.html#home-how" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100" data-i18n="menu.home.how">Comment ça marche</a></li>
                         <li><a href="index.html#home-mbti" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100" data-i18n="menu.home.auto_eval">Auto-évaluation</a></li>
@@ -421,12 +421,12 @@
                     </ul>
                 </div>
             </div>
-            <div id="mbti-menu-container" class="relative group">
+            <div id="mbti-menu-container" class="relative">
                 <a id="mbti-menu-button" href="mbti.html" class="inline-flex items-center gap-2 text-gray-500 hover:text-gray-700 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
                     <span data-i18n="menu.mbti">MBTI</span>
                     <svg class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
                 </a>
-                <div id="mbti-menu" class="invisible opacity-0 group-hover:visible group-hover:opacity-100 transition absolute left-0 mt-2 w-64 rounded-xl shadow-lg bg-white ring-1 ring-black/5 z-50">
+                <div id="mbti-menu" class="invisible opacity-0 transition absolute left-0 mt-2 w-64 rounded-xl shadow-lg bg-white ring-1 ring-black/5 z-50">
                     <ul class="py-2 text-sm">
                         <li><a href="mbti.html#mbti-hero" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100" data-i18n="menu.mbti.understand">Comprendre le MBTI</a></li>
                         <li><a href="mbti.html#mbti-history" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100" data-i18n="menu.mbti.history">Un peu d'histoire</a></li>
@@ -435,12 +435,12 @@
                     </ul>
                 </div>
             </div>
-            <div id="ennea-menu-container" class="relative group">
+            <div id="ennea-menu-container" class="relative">
                 <a id="ennea-menu-button" href="enneagramme.html" class="inline-flex items-center gap-2 text-gray-500 hover:text-gray-700 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
                     <span data-i18n="menu.enneagram">Ennéagramme</span>
                     <svg class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
                 </a>
-                <div id="ennea-menu" class="invisible opacity-0 group-hover:visible group-hover:opacity-100 transition absolute left-0 mt-2 w-64 rounded-xl shadow-lg bg-white ring-1 ring-black/5 z-50">
+                <div id="ennea-menu" class="invisible opacity-0 transition absolute left-0 mt-2 w-64 rounded-xl shadow-lg bg-white ring-1 ring-black/5 z-50">
                     <ul class="py-2 text-sm">
                         <li><a href="enneagramme.html#ennea-hero" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100" data-i18n="menu.enneagram.understand">Comprendre l’Ennéagramme</a></li>
                         <li><a href="enneagramme.html#ennea-history" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100" data-i18n="menu.enneagram.history">Un peu d'histoire</a></li>
@@ -452,7 +452,9 @@
             <a href="index.html#home-ia" class="text-gray-500 hover:text-gray-700 inline-flex items-center px-1 pt-1 text-sm font-medium" data-i18n="menu.ai">IA spécialisée</a>
             <a href="blog.html" class="text-gray-500 hover:text-gray-700 inline-flex items-center px-1 pt-1 text-sm font-medium" data-i18n="menu.blog">Blog</a>
             <a href="index.html#home-faq" class="text-gray-500 hover:text-gray-700 inline-flex items-center px-1 pt-1 text-sm font-medium" data-i18n="menu.faq">FAQ</a>
-            <button id="profile-btn-desktop" onclick="openProfileModal()" class="ml-4 inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-black hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black" data-i18n="menu.profile">Mon profil</button>
+            <button id="profile-btn-desktop" onclick="openProfileModal()" class="ml-4 inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-black hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black" data-i18n="menu.profile">
+                Mon profil
+            </button>
         </nav>
         <div class="-mr-2 flex items-center md:hidden">
             <button type="button" id="mobile-menu-button" class="inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500" aria-controls="mobile-menu" aria-expanded="false">

--- a/public/mbti.html
+++ b/public/mbti.html
@@ -399,16 +399,16 @@
                 <img src="logo pc 3.png" alt="Personnalité Comparée logo" class="w-10 h-10 rounded-full object-cover"><span id="brand-home" class="ml-3 text-[1.05rem] sm:text-xl font-bold text-black" data-i18n="brand.name">Personnalité Comparée</span>
             </div>
             <div class="language-switcher ml-4 flex gap-0 text-sm font-bold">
-                <button onclick="switchLang('fr')" data-i18n="lang.fr">FR</button><span> | </span><button onclick="switchLang('en')" data-i18n="lang.en">EN</button>
+                <button onclick="switchLang('fr'); updatePlaceholders();" data-i18n="lang.fr">FR</button><span> | </span><button onclick="switchLang('en'); updatePlaceholders();" data-i18n="lang.en">EN</button>
             </div>
         </div>
         <nav class="desktop-nav hidden md:ml-6 md:flex md:items-center md:space-x-8">
-            <div id="home-menu-container" class="relative group">
+            <div id="home-menu-container" class="relative">
                 <a id="home-menu-button" href="index.html" class="inline-flex items-center gap-2 text-gray-900 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
                     <span data-i18n="menu.home">Accueil</span>
                     <svg class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
                 </a>
-                <div id="home-menu" class="invisible opacity-0 group-hover:visible group-hover:opacity-100 transition absolute left-0 mt-2 w-64 rounded-xl shadow-lg bg-white ring-1 ring-black/5 z-50">
+                <div id="home-menu" class="invisible opacity-0 transition absolute left-0 mt-2 w-64 rounded-xl shadow-lg bg-white ring-1 ring-black/5 z-50">
                     <ul class="py-2 text-sm">
                         <li><a href="index.html#home-how" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100" data-i18n="menu.home.how">Comment ça marche</a></li>
                         <li><a href="index.html#home-mbti" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100" data-i18n="menu.home.auto_eval">Auto-évaluation</a></li>
@@ -421,12 +421,12 @@
                     </ul>
                 </div>
             </div>
-            <div id="mbti-menu-container" class="relative group">
+            <div id="mbti-menu-container" class="relative">
                 <a id="mbti-menu-button" href="mbti.html" class="inline-flex items-center gap-2 text-gray-500 hover:text-gray-700 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
                     <span data-i18n="menu.mbti">MBTI</span>
                     <svg class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
                 </a>
-                <div id="mbti-menu" class="invisible opacity-0 group-hover:visible group-hover:opacity-100 transition absolute left-0 mt-2 w-64 rounded-xl shadow-lg bg-white ring-1 ring-black/5 z-50">
+                <div id="mbti-menu" class="invisible opacity-0 transition absolute left-0 mt-2 w-64 rounded-xl shadow-lg bg-white ring-1 ring-black/5 z-50">
                     <ul class="py-2 text-sm">
                         <li><a href="mbti.html#mbti-hero" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100" data-i18n="menu.mbti.understand">Comprendre le MBTI</a></li>
                         <li><a href="mbti.html#mbti-history" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100" data-i18n="menu.mbti.history">Un peu d'histoire</a></li>
@@ -435,12 +435,12 @@
                     </ul>
                 </div>
             </div>
-            <div id="ennea-menu-container" class="relative group">
+            <div id="ennea-menu-container" class="relative">
                 <a id="ennea-menu-button" href="enneagramme.html" class="inline-flex items-center gap-2 text-gray-500 hover:text-gray-700 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
                     <span data-i18n="menu.enneagram">Ennéagramme</span>
                     <svg class="h-4 w-4 transition-transform" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
                 </a>
-                <div id="ennea-menu" class="invisible opacity-0 group-hover:visible group-hover:opacity-100 transition absolute left-0 mt-2 w-64 rounded-xl shadow-lg bg-white ring-1 ring-black/5 z-50">
+                <div id="ennea-menu" class="invisible opacity-0 transition absolute left-0 mt-2 w-64 rounded-xl shadow-lg bg-white ring-1 ring-black/5 z-50">
                     <ul class="py-2 text-sm">
                         <li><a href="enneagramme.html#ennea-hero" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100" data-i18n="menu.enneagram.understand">Comprendre l’Ennéagramme</a></li>
                         <li><a href="enneagramme.html#ennea-history" class="dropdown-item block px-4 py-2 text-gray-700 hover:bg-gray-100" data-i18n="menu.enneagram.history">Un peu d'histoire</a></li>
@@ -458,7 +458,7 @@
         </nav>
         <div class="-mr-2 flex items-center md:hidden">
             <button type="button" id="mobile-menu-button" class="inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500" aria-controls="mobile-menu" aria-expanded="false">
-                <span class="sr-only">Ouvrir le menu principal</span>
+                <span class="sr-only" data-i18n="nav.open_main">Ouvrir le menu principal</span>
                 <i class="fas fa-bars" id="menu-icon"></i>
             </button>
         </div>


### PR DESCRIPTION
## Summary
- Match MBTI, Ennéagramme and Blog headers/footers with the homepage for consistent navigation and legal links
- Ensure privacy and terms modals trigger translation after injection for proper mobile language support

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a31154ff908321880554162df0f1ce