### PR TITLE
style: restore hero subtitle formatting

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -565,7 +565,7 @@
             
             <!-- Sous-titre épuré -->
    <p data-i18n="heroSubtitle" class="max-w-2xl mx-auto text-lg md:text-xl text-slate-600 leading-relaxed mb-12 font-light">
-    La première plateforme qui combine test dérivé MBTI & Ennéagramme, validation par l’entourage et IA spécialisée pour répondre à toutes vos questions.
+    La première plateforme qui combine <span class="font-medium text-slate-800">test dérivé MBTI</span> & <span class="font-medium text-slate-800">Ennéagramme</span>, validation par l’entourage et <span class="font-medium text-slate-800">IA spécialisée</span> pour répondre à toutes vos questions.
    </p>
             
             <!-- Boutons premium -->

--- a/public/lang.js
+++ b/public/lang.js
@@ -2,7 +2,7 @@ const translations = {
   fr: {
     siteTitle: "Personnalité Comparée | Test MBTI & Ennéagramme Gratuit",
     heroTitle: "Et si vous vous connaissiez<br><span class=\"text-blue-600 font-medium\"><strong>vraiment</strong></span> ?",
-    heroSubtitle: "La première plateforme qui combine test dérivé MBTI & Ennéagramme, validation par l’entourage et IA spécialisée pour répondre à toutes vos questions.",
+    heroSubtitle: "La première plateforme qui combine <span class=\"font-medium text-slate-800\">test dérivé MBTI</span> & <span class=\"font-medium text-slate-800\">Ennéagramme</span>, validation par l’entourage et <span class=\"font-medium text-slate-800\">IA spécialisée</span> pour répondre à toutes vos questions.",
     indicatorMBTI: "16 profils MBTI",
     indicatorEnneagram: "9 types Ennéagramme",
     indicatorValidation: "Validation par les proches",
@@ -1106,7 +1106,7 @@ const translations = {
   en: {
     siteTitle: "Compared Personality | Free MBTI & Enneagram Test",
     heroTitle: "What if you <br><span class=\"text-blue-600 font-medium\"><strong>really</strong></span> knew yourself?",
-    heroSubtitle: "The first platform combining MBTI-inspired & Enneagram test, feedback from relatives, and specialized AI to answer all your questions.",
+    heroSubtitle: "The first platform combining <span class=\"font-medium text-slate-800\">MBTI-inspired test</span> & <span class=\"font-medium text-slate-800\">Enneagram</span>, feedback from relatives, and <span class=\"font-medium text-slate-800\">specialized AI</span> to answer all your questions.",
     indicatorMBTI: "16 MBTI profiles",
     indicatorEnneagram: "9 Enneagram types",
     indicatorValidation: "Validation by relatives",


### PR DESCRIPTION
## Summary
- Reinstate emphasis spans for key terms in home page subtitle
- Align French and English translations for hero subtitle

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a3ca1cf7fc8321bdbe9efb1c423df2