### PR TITLE
fix: adjust MBTI references in SEO meta tags

### DIFF
--- a/public/blog-mbti-4-dimensions.html
+++ b/public/blog-mbti-4-dimensions.html
@@ -8,7 +8,7 @@
   <!-- Supabase JS -->
 
   <!-- SEO Meta Tags -->
-  <meta name="description" content="Comprendre simplement les quatre axes du MBTI.">
+  <meta name="description" content="Comprendre simplement les quatre axes du modèle inspiré du MBTI.">
   <meta name="keywords" content="test personnalité, MBTI, ennéagramme, psychologie, 16 types, auto-évaluation, gratuit">
   <meta name="author" content="Personnalité Comparée">
   <meta name="robots" content="index, follow">

--- a/public/blog.html
+++ b/public/blog.html
@@ -8,7 +8,7 @@
   <!-- Supabase JS -->
 
   <!-- SEO Meta Tags -->
-  <meta name="description" content="Articles sur le MBTI et l'Ennéagramme pour mieux comprendre votre personnalité.">
+  <meta name="description" content="Articles sur le modèle dérivé du MBTI et l'Ennéagramme pour mieux comprendre votre personnalité.">
   <meta name="keywords" content="test personnalité, MBTI, ennéagramme, psychologie, 16 types, auto-évaluation, gratuit">
   <meta name="author" content="Personnalité Comparée">
   <meta name="robots" content="index, follow">

--- a/public/index.html
+++ b/public/index.html
@@ -8,7 +8,7 @@
   <!-- Supabase JS -->
 
   <!-- SEO Meta Tags -->
-  <meta name="description" content="Découvrez votre vraie personnalité avec notre test dérivé MBTI et Ennéagramme gratuit. Analyse objective combinant votre auto-évaluation et l'avis de vos proches.">
+  <meta name="description" content="Découvrez votre vraie personnalité avec notre test dérivé MBTI et Ennéagramme gratuit. Analyse objective combinant auto-évaluation et validation par vos proches.">
   <meta name="keywords" content="test personnalité, modèle dérivé MBTI, ennéagramme, psychologie, 16 types, auto-évaluation, gratuit">
   <meta name="author" content="Personnalité Comparée">
   <meta name="robots" content="index, follow">

--- a/public/lang.js
+++ b/public/lang.js
@@ -1104,7 +1104,7 @@ const translations = {
     "shareCodeAlert": "Voici ton code à donner à 3 proches : "
   },
   en: {
-    siteTitle: "Compared Personality | Free MBTI & Enneagram Test",
+    siteTitle: "Compared Personality | Free MBTI-inspired & Enneagram Test",
     heroTitle: "What if you <br><span class=\"text-blue-600 font-medium\"><strong>really</strong></span> knew yourself?",
     heroSubtitle: "The first platform combining <span class=\"font-medium text-slate-800\">MBTI®-inspired test</span> & <span class=\"font-medium text-slate-800\">Enneagram</span>, feedback from relatives, and <span class=\"font-medium text-slate-800\">specialized AI</span> to answer all your questions.",
     indicatorMBTI: "16 MBTI profiles",


### PR DESCRIPTION
## Summary
- soften MBTI usage in SEO by revising meta descriptions across blog and index pages
- update English site title translation to use "MBTI-inspired"

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a3d8519ce88321a3d74a33e6bbcc20