### PR TITLE
fix(i18n): translate profile modal content in mbti, enneagramme, blog

### DIFF
--- a/public/blog.html
+++ b/public/blog.html
@@ -3775,7 +3775,7 @@ function showSupport() {
     <div id="profile-modal" class="modal">
         <div class="modal-content">
             <div class="modal-header">
-                <h2 class="text-xl font-bold text-gray-900">Mon Espace Personnel</h2>
+                <h2 class="text-xl font-bold text-gray-900" data-i18n="profileModal.title">Mon Espace Personnel</h2>
                 <span class="close" onclick="closeProfileModal()">&times;</span>
             </div>
             <div class="modal-body">
@@ -3785,19 +3785,19 @@ function showSupport() {
                         <div class="mx-auto flex items-center justify-center h-12 w-12 rounded-full bg-blue-100 mb-4">
                             <i class="fas fa-key text-blue-600 text-xl"></i>
                         </div>
-                        <h3 class="text-lg font-medium text-gray-900 mb-2">Accédez à votre profil</h3>
-                        <p class="text-sm text-gray-500">Entrez votre code unique pour consulter vos résultats</p>
+                        <h3 class="text-lg font-medium text-gray-900 mb-2" data-i18n="profileModal.step1.title">Accédez à votre profil</h3>
+                        <p class="text-sm text-gray-500" data-i18n="profileModal.step1.desc">Entrez votre code unique pour consulter vos résultats</p>
                     </div>
                     
                     <div class="space-y-4">
                         <div>
-                            <label for="profile-code" class="block text-sm font-medium text-gray-700 mb-2">Code unique</label>
-                            <input type="text" id="profile-code" placeholder="Entrez votre code (ex: ABC123)" 
-                                   class="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 text-center text-lg font-mono tracking-wider uppercase">
+                            <label for="profile-code" class="block text-sm font-medium text-gray-700 mb-2" data-i18n="profileModal.codeLabel">Code unique</label>
+                            <input type="text" id="profile-code" placeholder="Entrez votre code (ex: ABC123)"
+                                   class="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 text-center text-lg font-mono tracking-wider uppercase" data-i18n-placeholder="profileModal.codePlaceholder">
                         </div>
                         <button onclick="checkProfileCode()" class="w-full inline-flex items-center justify-center px-4 py-2 border border-transparent text-base font-medium rounded-md text-white bg-black hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black">
                             <i class="fas fa-sign-in-alt mr-2"></i>
-                            Accéder à mon profil
+                            <span data-i18n="profileModal.accessButton">Accéder à mon profil</span>
                         </button>
                     </div>
                 </div>
@@ -3808,22 +3808,22 @@ function showSupport() {
                         <div class="mx-auto flex items-center justify-center h-12 w-12 rounded-full bg-blue-100 mb-4">
                             <i class="fas fa-user-circle text-blue-600 text-xl"></i>
                         </div>
-                        <h3 class="text-lg font-medium text-gray-900 mb-2">Profil de <span id="profile-name"></span></h3>
-                        <p class="text-sm text-gray-500">Code: <span id="display-code" class="font-mono font-bold"></span></p>
+                        <h3 class="text-lg font-medium text-gray-900 mb-2"><span data-i18n="profileModal.step2.title">Profil de</span> <span id="profile-name"></span></h3>
+                        <p class="text-sm text-gray-500"><span data-i18n="profileModal.step2.codeLabel">Code:</span> <span id="display-code" class="font-mono font-bold"></span></p>
                     </div>
 
                     <!-- Statut des évaluations -->
                     <div class="bg-gray-50 rounded-lg p-4 mb-6">
-                        <h4 class="font-medium text-gray-900 mb-3">Statut des évaluations</h4>
+                        <h4 class="font-medium text-gray-900 mb-3" data-i18n="profileModal.step2.statusTitle">Statut des évaluations</h4>
                         <div class="space-y-3">
                             <div class="flex items-center justify-between">
-                                <span class="text-sm text-gray-600">Votre auto-évaluation</span>
+                                <span class="text-sm text-gray-600" data-i18n="profileModal.step2.selfEval">Votre auto-évaluation</span>
                                 <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">
-                                    <i class="fas fa-check mr-1"></i> Terminée
+                                    <i class="fas fa-check mr-1"></i> <span data-i18n="profileModal.step2.completed">Terminée</span>
                                 </span>
                             </div>
                             <div class="flex items-center justify-between">
-                                <span class="text-sm text-gray-600">Évaluations des proches</span>
+                                <span class="text-sm text-gray-600" data-i18n="profileModal.step2.relativesEval">Évaluations des proches</span>
                                 <span id="evaluations-status" class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium">
                                     <!-- Sera rempli dynamiquement -->
                                 </span>
@@ -3833,8 +3833,8 @@ function showSupport() {
                         <!-- Barre de progression -->
                         <div class="mt-4">
                             <div class="flex justify-between text-sm text-gray-600 mb-1">
-                                <span>Progression globale</span>
-                                <span id="progress-text">0/4 terminé</span>
+                                <span data-i18n="profileModal.step2.progress">Progression globale</span>
+                                <span id="progress-text" data-i18n="profileModal.step2.progressText">0/4 terminé</span>
                             </div>
                             <div class="w-full bg-gray-200 rounded-full h-2">
                                 <div id="progress-bar" class="bg-blue-600 h-2 rounded-full transition-all duration-500" style="width: 0%"></div>
@@ -3851,11 +3851,11 @@ function showSupport() {
                     <div class="flex space-x-3">
                         <button onclick="shareCode()" class="flex-1 inline-flex items-center justify-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50">
                             <i class="fas fa-share mr-2"></i>
-                            Partager mon code
+                            <span data-i18n="profile.complete.button.share">Partager mon code</span>
                         </button>
                         <button id="view-results-btn" onclick="viewResults()" class="flex-1 inline-flex items-center justify-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-black hover:bg-gray-800" style="display: none;">
                             <i class="fas fa-chart-pie mr-2"></i>
-                            Voir mes résultats
+                            <span data-i18n="profile.complete.button.results">Voir mes résultats</span>
                         </button>
                     </div>
                 </div>
@@ -3866,10 +3866,10 @@ function showSupport() {
                         <div class="mx-auto flex items-center justify-center h-12 w-12 rounded-full bg-red-100 mb-4">
                             <i class="fas fa-exclamation-triangle text-red-600 text-xl"></i>
                         </div>
-                        <h3 class="text-lg font-medium text-gray-900 mb-2">Code introuvable</h3>
-                        <p class="text-sm text-gray-500 mb-4">Le code que vous avez entré n'existe pas ou est incorrect.</p>
+                        <h3 class="text-lg font-medium text-gray-900 mb-2" data-i18n="profileModal.error.title">Code introuvable</h3>
+                        <p class="text-sm text-gray-500 mb-4" data-i18n="profileModal.error.desc">Le code que vous avez entré n'existe pas ou est incorrect.</p>
                         <button onclick="resetProfileModal()" class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-black hover:bg-gray-800">
-                            Réessayer
+                            <span data-i18n="profileModal.error.retry">Réessayer</span>
                         </button>
                     </div>
                 </div>

--- a/public/enneagramme.html
+++ b/public/enneagramme.html
@@ -4222,7 +4222,7 @@ function showSupport() {
     <div id="profile-modal" class="modal">
         <div class="modal-content">
             <div class="modal-header">
-                <h2 class="text-xl font-bold text-gray-900">Mon Espace Personnel</h2>
+                <h2 class="text-xl font-bold text-gray-900" data-i18n="profileModal.title">Mon Espace Personnel</h2>
                 <span class="close" onclick="closeProfileModal()">&times;</span>
             </div>
             <div class="modal-body">
@@ -4232,19 +4232,19 @@ function showSupport() {
                         <div class="mx-auto flex items-center justify-center h-12 w-12 rounded-full bg-blue-100 mb-4">
                             <i class="fas fa-key text-blue-600 text-xl"></i>
                         </div>
-                        <h3 class="text-lg font-medium text-gray-900 mb-2">Accédez à votre profil</h3>
-                        <p class="text-sm text-gray-500">Entrez votre code unique pour consulter vos résultats</p>
+                        <h3 class="text-lg font-medium text-gray-900 mb-2" data-i18n="profileModal.step1.title">Accédez à votre profil</h3>
+                        <p class="text-sm text-gray-500" data-i18n="profileModal.step1.desc">Entrez votre code unique pour consulter vos résultats</p>
                     </div>
                     
                     <div class="space-y-4">
                         <div>
-                            <label for="profile-code" class="block text-sm font-medium text-gray-700 mb-2">Code unique</label>
-                            <input type="text" id="profile-code" placeholder="Entrez votre code (ex: ABC123)" 
-                                   class="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 text-center text-lg font-mono tracking-wider uppercase">
+                            <label for="profile-code" class="block text-sm font-medium text-gray-700 mb-2" data-i18n="profileModal.codeLabel">Code unique</label>
+                            <input type="text" id="profile-code" placeholder="Entrez votre code (ex: ABC123)"
+                                   class="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 text-center text-lg font-mono tracking-wider uppercase" data-i18n-placeholder="profileModal.codePlaceholder">
                         </div>
                         <button onclick="checkProfileCode()" class="w-full inline-flex items-center justify-center px-4 py-2 border border-transparent text-base font-medium rounded-md text-white bg-black hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black">
                             <i class="fas fa-sign-in-alt mr-2"></i>
-                            Accéder à mon profil
+                            <span data-i18n="profileModal.accessButton">Accéder à mon profil</span>
                         </button>
                     </div>
                 </div>
@@ -4255,22 +4255,22 @@ function showSupport() {
                         <div class="mx-auto flex items-center justify-center h-12 w-12 rounded-full bg-blue-100 mb-4">
                             <i class="fas fa-user-circle text-blue-600 text-xl"></i>
                         </div>
-                        <h3 class="text-lg font-medium text-gray-900 mb-2">Profil de <span id="profile-name"></span></h3>
-                        <p class="text-sm text-gray-500">Code: <span id="display-code" class="font-mono font-bold"></span></p>
+                        <h3 class="text-lg font-medium text-gray-900 mb-2"><span data-i18n="profileModal.step2.title">Profil de</span> <span id="profile-name"></span></h3>
+                        <p class="text-sm text-gray-500"><span data-i18n="profileModal.step2.codeLabel">Code:</span> <span id="display-code" class="font-mono font-bold"></span></p>
                     </div>
 
                     <!-- Statut des évaluations -->
                     <div class="bg-gray-50 rounded-lg p-4 mb-6">
-                        <h4 class="font-medium text-gray-900 mb-3">Statut des évaluations</h4>
+                        <h4 class="font-medium text-gray-900 mb-3" data-i18n="profileModal.step2.statusTitle">Statut des évaluations</h4>
                         <div class="space-y-3">
                             <div class="flex items-center justify-between">
-                                <span class="text-sm text-gray-600">Votre auto-évaluation</span>
+                                <span class="text-sm text-gray-600" data-i18n="profileModal.step2.selfEval">Votre auto-évaluation</span>
                                 <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">
-                                    <i class="fas fa-check mr-1"></i> Terminée
+                                    <i class="fas fa-check mr-1"></i> <span data-i18n="profileModal.step2.completed">Terminée</span>
                                 </span>
                             </div>
                             <div class="flex items-center justify-between">
-                                <span class="text-sm text-gray-600">Évaluations des proches</span>
+                                <span class="text-sm text-gray-600" data-i18n="profileModal.step2.relativesEval">Évaluations des proches</span>
                                 <span id="evaluations-status" class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium">
                                     <!-- Sera rempli dynamiquement -->
                                 </span>
@@ -4280,8 +4280,8 @@ function showSupport() {
                         <!-- Barre de progression -->
                         <div class="mt-4">
                             <div class="flex justify-between text-sm text-gray-600 mb-1">
-                                <span>Progression globale</span>
-                                <span id="progress-text">0/4 terminé</span>
+                                <span data-i18n="profileModal.step2.progress">Progression globale</span>
+                                <span id="progress-text" data-i18n="profileModal.step2.progressText">0/4 terminé</span>
                             </div>
                             <div class="w-full bg-gray-200 rounded-full h-2">
                                 <div id="progress-bar" class="bg-blue-600 h-2 rounded-full transition-all duration-500" style="width: 0%"></div>
@@ -4298,11 +4298,11 @@ function showSupport() {
                     <div class="flex space-x-3">
                         <button onclick="shareCode()" class="flex-1 inline-flex items-center justify-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50">
                             <i class="fas fa-share mr-2"></i>
-                            Partager mon code
+                            <span data-i18n="profile.complete.button.share">Partager mon code</span>
                         </button>
                         <button id="seeResultsBtn" onclick="viewResults()" class="flex-1 inline-flex items-center justify-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-black hover:bg-gray-800">
                             <i class="fas fa-chart-pie mr-2"></i>
-                            Voir mes résultats
+                            <span data-i18n="profile.complete.button.results">Voir mes résultats</span>
                         </button>
                     </div>
                 </div>
@@ -4313,10 +4313,10 @@ function showSupport() {
                         <div class="mx-auto flex items-center justify-center h-12 w-12 rounded-full bg-red-100 mb-4">
                             <i class="fas fa-exclamation-triangle text-red-600 text-xl"></i>
                         </div>
-                        <h3 class="text-lg font-medium text-gray-900 mb-2">Code introuvable</h3>
-                        <p class="text-sm text-gray-500 mb-4">Le code que vous avez entré n'existe pas ou est incorrect.</p>
+                        <h3 class="text-lg font-medium text-gray-900 mb-2" data-i18n="profileModal.error.title">Code introuvable</h3>
+                        <p class="text-sm text-gray-500 mb-4" data-i18n="profileModal.error.desc">Le code que vous avez entré n'existe pas ou est incorrect.</p>
                         <button onclick="resetProfileModal()" class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-black hover:bg-gray-800">
-                            Réessayer
+                            <span data-i18n="profileModal.error.retry">Réessayer</span>
                         </button>
                     </div>
                 </div>

--- a/public/mbti.html
+++ b/public/mbti.html
@@ -4334,7 +4334,7 @@ function showSupport() {
     <div id="profile-modal" class="modal">
         <div class="modal-content">
             <div class="modal-header">
-                <h2 class="text-xl font-bold text-gray-900">Mon Espace Personnel</h2>
+                <h2 class="text-xl font-bold text-gray-900" data-i18n="profileModal.title">Mon Espace Personnel</h2>
                 <span class="close" onclick="closeProfileModal()">&times;</span>
             </div>
             <div class="modal-body">
@@ -4344,19 +4344,19 @@ function showSupport() {
                         <div class="mx-auto flex items-center justify-center h-12 w-12 rounded-full bg-blue-100 mb-4">
                             <i class="fas fa-key text-blue-600 text-xl"></i>
                         </div>
-                        <h3 class="text-lg font-medium text-gray-900 mb-2">Accédez à votre profil</h3>
-                        <p class="text-sm text-gray-500">Entrez votre code unique pour consulter vos résultats</p>
+                        <h3 class="text-lg font-medium text-gray-900 mb-2" data-i18n="profileModal.step1.title">Accédez à votre profil</h3>
+                        <p class="text-sm text-gray-500" data-i18n="profileModal.step1.desc">Entrez votre code unique pour consulter vos résultats</p>
                     </div>
                     
                     <div class="space-y-4">
                         <div>
-                            <label for="profile-code" class="block text-sm font-medium text-gray-700 mb-2">Code unique</label>
-                            <input type="text" id="profile-code" placeholder="Entrez votre code (ex: ABC123)" 
-                                   class="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 text-center text-lg font-mono tracking-wider uppercase">
+                            <label for="profile-code" class="block text-sm font-medium text-gray-700 mb-2" data-i18n="profileModal.codeLabel">Code unique</label>
+                            <input type="text" id="profile-code" placeholder="Entrez votre code (ex: ABC123)"
+                                   class="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 text-center text-lg font-mono tracking-wider uppercase" data-i18n-placeholder="profileModal.codePlaceholder">
                         </div>
                         <button onclick="checkProfileCode()" class="w-full inline-flex items-center justify-center px-4 py-2 border border-transparent text-base font-medium rounded-md text-white bg-black hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black">
                             <i class="fas fa-sign-in-alt mr-2"></i>
-                            Accéder à mon profil
+                            <span data-i18n="profileModal.accessButton">Accéder à mon profil</span>
                         </button>
                     </div>
                 </div>
@@ -4367,22 +4367,22 @@ function showSupport() {
                         <div class="mx-auto flex items-center justify-center h-12 w-12 rounded-full bg-blue-100 mb-4">
                             <i class="fas fa-user-circle text-blue-600 text-xl"></i>
                         </div>
-                        <h3 class="text-lg font-medium text-gray-900 mb-2">Profil de <span id="profile-name"></span></h3>
-                        <p class="text-sm text-gray-500">Code: <span id="display-code" class="font-mono font-bold"></span></p>
+                        <h3 class="text-lg font-medium text-gray-900 mb-2"><span data-i18n="profileModal.step2.title">Profil de</span> <span id="profile-name"></span></h3>
+                        <p class="text-sm text-gray-500"><span data-i18n="profileModal.step2.codeLabel">Code:</span> <span id="display-code" class="font-mono font-bold"></span></p>
                     </div>
 
                     <!-- Statut des évaluations -->
                     <div class="bg-gray-50 rounded-lg p-4 mb-6">
-                        <h4 class="font-medium text-gray-900 mb-3">Statut des évaluations</h4>
+                        <h4 class="font-medium text-gray-900 mb-3" data-i18n="profileModal.step2.statusTitle">Statut des évaluations</h4>
                         <div class="space-y-3">
                             <div class="flex items-center justify-between">
-                                <span class="text-sm text-gray-600">Votre auto-évaluation</span>
+                                <span class="text-sm text-gray-600" data-i18n="profileModal.step2.selfEval">Votre auto-évaluation</span>
                                 <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">
-                                    <i class="fas fa-check mr-1"></i> Terminée
+                                    <i class="fas fa-check mr-1"></i> <span data-i18n="profileModal.step2.completed">Terminée</span>
                                 </span>
                             </div>
                             <div class="flex items-center justify-between">
-                                <span class="text-sm text-gray-600">Évaluations des proches</span>
+                                <span class="text-sm text-gray-600" data-i18n="profileModal.step2.relativesEval">Évaluations des proches</span>
                                 <span id="evaluations-status" class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium">
                                     <!-- Sera rempli dynamiquement -->
                                 </span>
@@ -4392,8 +4392,8 @@ function showSupport() {
                         <!-- Barre de progression -->
                         <div class="mt-4">
                             <div class="flex justify-between text-sm text-gray-600 mb-1">
-                                <span>Progression globale</span>
-                                <span id="progress-text">0/4 terminé</span>
+                                <span data-i18n="profileModal.step2.progress">Progression globale</span>
+                                <span id="progress-text" data-i18n="profileModal.step2.progressText">0/4 terminé</span>
                             </div>
                             <div class="w-full bg-gray-200 rounded-full h-2">
                                 <div id="progress-bar" class="bg-blue-600 h-2 rounded-full transition-all duration-500" style="width: 0%"></div>
@@ -4425,10 +4425,10 @@ function showSupport() {
                         <div class="mx-auto flex items-center justify-center h-12 w-12 rounded-full bg-red-100 mb-4">
                             <i class="fas fa-exclamation-triangle text-red-600 text-xl"></i>
                         </div>
-                        <h3 class="text-lg font-medium text-gray-900 mb-2">Code introuvable</h3>
-                        <p class="text-sm text-gray-500 mb-4">Le code que vous avez entré n'existe pas ou est incorrect.</p>
+                        <h3 class="text-lg font-medium text-gray-900 mb-2" data-i18n="profileModal.error.title">Code introuvable</h3>
+                        <p class="text-sm text-gray-500 mb-4" data-i18n="profileModal.error.desc">Le code que vous avez entré n'existe pas ou est incorrect.</p>
                         <button onclick="resetProfileModal()" class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-black hover:bg-gray-800">
-                            Réessayer
+                            <span data-i18n="profileModal.error.retry">Réessayer</span>
                         </button>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- add missing `data-i18n` attributes to profile modal in MBTI page
- translate profile modal sections in Enneagramme page
- enable profile modal i18n for Blog page

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a486c2b36883219848f5f5c20d7c21