### PR TITLE
Add functionScores before saving user profile

### DIFF
--- a/public/blog.html
+++ b/public/blog.html
@@ -1420,6 +1420,7 @@ async function calculateResults() {
         timestamp: Date.now()
     };
 
+    userProfile.functionScores = userProfile.mbtiScores;
     await saveUserProfileToSupabase(userProfile);
     localStorage.setItem('userProfile_' + uniqueCode, JSON.stringify(userProfile));
     

--- a/public/enneagramme.html
+++ b/public/enneagramme.html
@@ -1851,6 +1851,7 @@ async function calculateResults() {
         timestamp: Date.now()
     };
 
+    userProfile.functionScores = userProfile.mbtiScores;
     await saveUserProfileToSupabase(userProfile);
     localStorage.setItem('userProfile_' + uniqueCode, JSON.stringify(userProfile));
     

--- a/public/index.html
+++ b/public/index.html
@@ -1949,6 +1949,7 @@ const uniqueCode = genererUniqueCode();
         timestamp: Date.now()
     };
 
+    userProfile.functionScores = userProfile.mbtiScores;
     await saveUserProfileToSupabase(userProfile);
     localStorage.setItem('userProfile_' + uniqueCode, JSON.stringify(userProfile));
 

--- a/public/mbti.html
+++ b/public/mbti.html
@@ -1947,6 +1947,7 @@ async function calculateResults() {
         timestamp: Date.now()
     };
 
+    userProfile.functionScores = userProfile.mbtiScores;
     await saveUserProfileToSupabase(userProfile);
     localStorage.setItem('userProfile_' + uniqueCode, JSON.stringify(userProfile));
     


### PR DESCRIPTION
## Summary
- set `userProfile.functionScores` from `userProfile.mbtiScores` before persisting profiles

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a563b5759c8321ab4973cbc1f79e28