### PR TITLE
feat: ensure event_category is recorded in trackEvent

### DIFF
--- a/public/blog-enneagramme-instincts.html
+++ b/public/blog-enneagramme-instincts.html
@@ -1013,6 +1013,7 @@
       const { error } = await supabase.from("events").insert([{
         session_id: sessionId,
         event_name: eventName,
+        event_category: eventName,   // ✅ ajout pour éviter event_category null
         element_selector: extraData.element_selector || null,
         value: extraData.value || null,
         meta: extraData.meta || {},
@@ -1024,7 +1025,6 @@
     } catch (err) {
       console.error("Erreur trackEvent:", err);
     } finally {
-      // on tient à jour la session (last_activity_at + last_event_name + engagement_ms)
       upsertSession(false, eventName);
     }
   }

--- a/public/blog-mbti-4-dimensions.html
+++ b/public/blog-mbti-4-dimensions.html
@@ -1097,6 +1097,7 @@ function viewResults(){ alert('Fonctionnalité à venir'); }
       const { error } = await supabase.from("events").insert([{
         session_id: sessionId,
         event_name: eventName,
+        event_category: eventName,   // ✅ ajout pour éviter event_category null
         element_selector: extraData.element_selector || null,
         value: extraData.value || null,
         meta: extraData.meta || {},
@@ -1108,7 +1109,6 @@ function viewResults(){ alert('Fonctionnalité à venir'); }
     } catch (err) {
       console.error("Erreur trackEvent:", err);
     } finally {
-      // on tient à jour la session (last_activity_at + last_event_name + engagement_ms)
       upsertSession(false, eventName);
     }
   }

--- a/public/enneagramme.html
+++ b/public/enneagramme.html
@@ -4822,6 +4822,7 @@ addChatStyles();
       const { error } = await supabase.from("events").insert([{
         session_id: sessionId,
         event_name: eventName,
+        event_category: eventName,   // ✅ ajout pour éviter event_category null
         element_selector: extraData.element_selector || null,
         value: extraData.value || null,
         meta: extraData.meta || {},
@@ -4833,7 +4834,6 @@ addChatStyles();
     } catch (err) {
       console.error("Erreur trackEvent:", err);
     } finally {
-      // on tient à jour la session (last_activity_at + last_event_name + engagement_ms)
       upsertSession(false, eventName);
     }
   }

--- a/public/index.html
+++ b/public/index.html
@@ -4913,6 +4913,7 @@ window.addEventListener('scroll', () => {
       const { error } = await supabase.from("events").insert([{
         session_id: sessionId,
         event_name: eventName,
+        event_category: eventName,   // ✅ ajout pour éviter event_category null
         element_selector: extraData.element_selector || null,
         value: extraData.value || null,
         meta: extraData.meta || {},
@@ -4924,7 +4925,6 @@ window.addEventListener('scroll', () => {
     } catch (err) {
       console.error("Erreur trackEvent:", err);
     } finally {
-      // on tient à jour la session (last_activity_at + last_event_name + engagement_ms)
       upsertSession(false, eventName);
     }
   }

--- a/public/mbti.html
+++ b/public/mbti.html
@@ -4934,6 +4934,7 @@ addChatStyles();
       const { error } = await supabase.from("events").insert([{
         session_id: sessionId,
         event_name: eventName,
+        event_category: eventName,   // ✅ ajout pour éviter event_category null
         element_selector: extraData.element_selector || null,
         value: extraData.value || null,
         meta: extraData.meta || {},
@@ -4945,7 +4946,6 @@ addChatStyles();
     } catch (err) {
       console.error("Erreur trackEvent:", err);
     } finally {
-      // on tient à jour la session (last_activity_at + last_event_name + engagement_ms)
       upsertSession(false, eventName);
     }
   }


### PR DESCRIPTION
## Summary
- record event_category alongside event_name in trackEvent calls to prevent null categories
- keep session updates intact

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a66f2790d4832180473069f8f855f0