### PR TITLE
fix: persist language selection and dedupe MBTI globals

### DIFF
--- a/public/blog.html
+++ b/public/blog.html
@@ -1687,7 +1687,7 @@ function displayResults(results) {
         }
 
         // Descriptions détaillées MBTI
-        const mbtiDetailedDescriptions = {
+        window.mbtiDetailedDescriptions = window.mbtiDetailedDescriptions || {
             'INTJ': {
                 title: 'INTJ - L\'Architecte',
                 content: `
@@ -2406,7 +2406,7 @@ function displayResults(results) {
 
         // Fonctions pour afficher les détails
         function showMBTIDetails(type) {
-            const details = mbtiDetailedDescriptions[type];
+            const details = window.mbtiDetailedDescriptions[type];
             if (details) {
                 showModal(details.title, details.content);
             } else {

--- a/public/common.js
+++ b/public/common.js
@@ -26,31 +26,54 @@ if (mobileMenuButton && mobileMenu) {
   });
 }
 
-const langButton = document.getElementById('lang-button');
-const langMenu = document.getElementById('lang-menu');
-if (langButton && langMenu) {
+document.addEventListener('DOMContentLoaded', () => {
+  const langButton = document.getElementById('lang-button');
+  const langMenu = document.getElementById('lang-menu');
+  if (!langButton || !langMenu) return;
+
+  const closeLangMenu = () => {
+    langMenu.classList.add('hidden');
+    langButton.setAttribute('aria-expanded', 'false');
+  };
+
   langButton.addEventListener('click', () => {
     const expanded = langButton.getAttribute('aria-expanded') === 'true';
     langButton.setAttribute('aria-expanded', String(!expanded));
     langMenu.classList.toggle('hidden', expanded);
   });
+
   langMenu.querySelectorAll('.lang-option').forEach(opt => {
     opt.addEventListener('click', () => {
       const lang = opt.getAttribute('data-lang');
       i18n.setLanguage(lang);
+      localStorage.setItem('pc_lang', lang);
       renderI18n();
       if (typeof updatePlaceholders === 'function') updatePlaceholders();
-      langMenu.classList.add('hidden');
-      langButton.setAttribute('aria-expanded', 'false');
+      closeLangMenu();
     });
   });
+
   document.addEventListener('click', e => {
     if (!langButton.contains(e.target) && !langMenu.contains(e.target)) {
-      langMenu.classList.add('hidden');
-      langButton.setAttribute('aria-expanded', 'false');
+      closeLangMenu();
     }
   });
-}
+
+  document.addEventListener('focusin', e => {
+    if (!langButton.contains(e.target) && !langMenu.contains(e.target)) {
+      closeLangMenu();
+    }
+  });
+
+  document.addEventListener('keydown', e => {
+    if (e.key === 'Escape') closeLangMenu();
+  });
+
+  const savedLang = localStorage.getItem('pc_lang') || 'en';
+  i18n.setLanguage(savedLang);
+  renderI18n();
+  if (typeof updatePlaceholders === 'function') updatePlaceholders();
+});
 
 const homeMenuContainer = document.getElementById('home-menu-container');
 const homeMenuButton = document.getElementById('home-menu-button');
@@ -149,7 +172,7 @@ function checkProfileCode() {
 function shareCode(){ alert('Fonctionnalité à venir'); }
 function viewResults(){ alert('Fonctionnalité à venir'); }
 
-const mbtiDetailedDescriptions = {
+window.mbtiDetailedDescriptions = window.mbtiDetailedDescriptions || {
   INTJ:{title:"INTJ - L'Architecte",content:'<p>Visionnaires stratégiques avec un plan pour tout.</p>'},
   ENTJ:{title:"ENTJ - Le Commandant",content:'<p>Leaders naturels, charismatiques et déterminés.</p>'},
   INTP:{title:"INTP - Le Penseur",content:'<p>Penseurs logiques et créatifs, en quête d’idées.</p>'},
@@ -168,7 +191,7 @@ const mbtiDetailedDescriptions = {
   ESFP:{title:"ESFP - L'Artiste",content:'<p>Spontanés, débordant d’énergie et de joie de vivre.</p>'}
 };
 function showMBTIDetails(type){
-  const d = mbtiDetailedDescriptions[type];
+  const d = window.mbtiDetailedDescriptions[type];
   if (d) showModal(d.title, d.content);
 }
 

--- a/public/enneagramme.html
+++ b/public/enneagramme.html
@@ -2118,7 +2118,7 @@ function displayResults(results) {
         }
 
         // Descriptions détaillées MBTI
-        const mbtiDetailedDescriptions = {
+        window.mbtiDetailedDescriptions = window.mbtiDetailedDescriptions || {
             'INTJ': {
                 title: 'INTJ - L\'Architecte',
                 content: `
@@ -2837,7 +2837,7 @@ function displayResults(results) {
 
         // Fonctions pour afficher les détails
         function showMBTIDetails(type) {
-            const details = mbtiDetailedDescriptions[type];
+            const details = window.mbtiDetailedDescriptions[type];
             if (details) {
                 showModal(details.title, details.content);
             } else {

--- a/public/index.html
+++ b/public/index.html
@@ -2204,7 +2204,7 @@ function displayResults(results) {
         }
 
         // Descriptions détaillées MBTI
-        const mbtiDetailedDescriptions = {
+        window.mbtiDetailedDescriptions = window.mbtiDetailedDescriptions || {
             'INTJ': {
                 title: 'INTJ - L\'Architecte',
                 content: `
@@ -2923,7 +2923,7 @@ function displayResults(results) {
 
         // Fonctions pour afficher les détails
         function showMBTIDetails(type) {
-            const details = mbtiDetailedDescriptions[type];
+            const details = window.mbtiDetailedDescriptions[type];
             if (details) {
                 showModal(details.title, details.content);
             } else {

--- a/public/mbti.html
+++ b/public/mbti.html
@@ -2212,7 +2212,7 @@ function displayResults(results) {
         }
 
         // Descriptions détaillées MBTI
-        const mbtiDetailedDescriptions = {
+        window.mbtiDetailedDescriptions = window.mbtiDetailedDescriptions || {
             'INTJ': {
                 title: '<h2 class="text-xl font-bold text-gray-900" data-i18n="mbti.modals.intj.title">INTJ - L\'Architecte</h2>',
                 content: `
@@ -2930,7 +2930,7 @@ function displayResults(results) {
 
         // Fonctions pour afficher les détails
         function showMBTIDetails(type) {
-            const details = mbtiDetailedDescriptions[type];
+            const details = window.mbtiDetailedDescriptions[type];
             if (details) {
                 showModal(details.title, details.content);
             } else {


### PR DESCRIPTION
## Summary
- avoid redeclaring `mbtiDetailedDescriptions` by guarding assignment on `window`
- rework language dropdown to init from stored locale and close on outside click, blur, or Escape

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a9bd59611083219c7d569d799bd1cc