### PR TITLE
fix(lang+i18n): add #lang-trigger and robust dropdown init; dedupe enneagramDetailedDescriptions to avoid re-declare crash

### DIFF
--- a/public/blog-enneagramme-instincts.html
+++ b/public/blog-enneagramme-instincts.html
@@ -399,14 +399,14 @@
             <div class="flex-shrink-0 flex items-center">
                 <img src="logo pc 3.png" alt="Personnalité Comparée logo" class="w-10 h-10 rounded-full object-cover"><span id="brand-home" class="ml-3 text-[1.05rem] sm:text-xl font-bold text-black" data-i18n="brand.name">Personnalité Comparée</span>
             </div>
-            <div class="language-switcher ml-4 relative text-sm font-bold">
-                <button id="lang-button" class="flex items-center gap-1" aria-haspopup="true" aria-expanded="false">
+            <div id="lang-dropdown" class="language-switcher ml-4 relative text-sm font-bold z-50">
+                <button id="lang-trigger" type="button" class="flex items-center gap-1" aria-haspopup="true" aria-expanded="false">
                     <span data-i18n="lang.language">Language</span>
                     <svg class="w-3 h-3" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
                 </button>
-                <div id="lang-menu" class="hidden absolute right-0 mt-2 w-32 rounded-md bg-white shadow-lg border">
-                    <button class="lang-option flex w-full items-center px-2 py-1 hover:bg-gray-100" data-lang="en"><span class="mr-2">🇬🇧</span><span data-i18n="lang.english">English</span></button>
-                    <button class="lang-option flex w-full items-center px-2 py-1 hover:bg-gray-100" data-lang="fr"><span class="mr-2">🇫🇷</span><span data-i18n="lang.french">Français</span></button>
+                <div id="lang-menu" role="menu" class="hidden absolute right-0 mt-2 w-32 rounded-md bg-white shadow-lg border">
+                    <button class="lang-option flex w-full items-center px-2 py-1 hover:bg-gray-100" role="menuitem" data-lang="en"><span class="mr-2">🇬🇧</span><span data-i18n="lang.english">English</span></button>
+                    <button class="lang-option flex w-full items-center px-2 py-1 hover:bg-gray-100" role="menuitem" data-lang="fr"><span class="mr-2">🇫🇷</span><span data-i18n="lang.french">Français</span></button>
                 </div>
             </div>
         </div>

--- a/public/blog-mbti-4-dimensions.html
+++ b/public/blog-mbti-4-dimensions.html
@@ -399,14 +399,14 @@
             <div class="flex-shrink-0 flex items-center">
                 <img src="logo pc 3.png" alt="Personnalité Comparée logo" class="w-10 h-10 rounded-full object-cover"><span id="brand-home" class="ml-3 text-[1.05rem] sm:text-xl font-bold text-black" data-i18n="brand.name">Personnalité Comparée</span>
             </div>
-            <div class="language-switcher ml-4 relative text-sm font-bold">
-                <button id="lang-button" class="flex items-center gap-1" aria-haspopup="true" aria-expanded="false">
+            <div id="lang-dropdown" class="language-switcher ml-4 relative text-sm font-bold z-50">
+                <button id="lang-trigger" type="button" class="flex items-center gap-1" aria-haspopup="true" aria-expanded="false">
                     <span data-i18n="lang.language">Language</span>
                     <svg class="w-3 h-3" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
                 </button>
-                <div id="lang-menu" class="hidden absolute right-0 mt-2 w-32 rounded-md bg-white shadow-lg border">
-                    <button class="lang-option flex w-full items-center px-2 py-1 hover:bg-gray-100" data-lang="en"><span class="mr-2">🇬🇧</span><span data-i18n="lang.english">English</span></button>
-                    <button class="lang-option flex w-full items-center px-2 py-1 hover:bg-gray-100" data-lang="fr"><span class="mr-2">🇫🇷</span><span data-i18n="lang.french">Français</span></button>
+                <div id="lang-menu" role="menu" class="hidden absolute right-0 mt-2 w-32 rounded-md bg-white shadow-lg border">
+                    <button class="lang-option flex w-full items-center px-2 py-1 hover:bg-gray-100" role="menuitem" data-lang="en"><span class="mr-2">🇬🇧</span><span data-i18n="lang.english">English</span></button>
+                    <button class="lang-option flex w-full items-center px-2 py-1 hover:bg-gray-100" role="menuitem" data-lang="fr"><span class="mr-2">🇫🇷</span><span data-i18n="lang.french">Français</span></button>
                 </div>
             </div>
         </div>

--- a/public/blog.html
+++ b/public/blog.html
@@ -399,14 +399,14 @@
             <div class="flex-shrink-0 flex items-center">
                 <img src="logo pc 3.png" alt="Personnalité Comparée logo" class="w-10 h-10 rounded-full object-cover"><span id="brand-home" class="ml-3 text-[1.05rem] sm:text-xl font-bold text-black" data-i18n="brand.name">Personnalité Comparée</span>
             </div>
-            <div class="language-switcher ml-4 relative text-sm font-bold">
-                <button id="lang-button" class="flex items-center gap-1" aria-haspopup="true" aria-expanded="false">
+            <div id="lang-dropdown" class="language-switcher ml-4 relative text-sm font-bold z-50">
+                <button id="lang-trigger" type="button" class="flex items-center gap-1" aria-haspopup="true" aria-expanded="false">
                     <span data-i18n="lang.language">Language</span>
                     <svg class="w-3 h-3" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
                 </button>
-                <div id="lang-menu" class="hidden absolute right-0 mt-2 w-32 rounded-md bg-white shadow-lg border">
-                    <button class="lang-option flex w-full items-center px-2 py-1 hover:bg-gray-100" data-lang="en"><span class="mr-2">🇬🇧</span><span data-i18n="lang.english">English</span></button>
-                    <button class="lang-option flex w-full items-center px-2 py-1 hover:bg-gray-100" data-lang="fr"><span class="mr-2">🇫🇷</span><span data-i18n="lang.french">Français</span></button>
+                <div id="lang-menu" role="menu" class="hidden absolute right-0 mt-2 w-32 rounded-md bg-white shadow-lg border">
+                    <button class="lang-option flex w-full items-center px-2 py-1 hover:bg-gray-100" role="menuitem" data-lang="en"><span class="mr-2">🇬🇧</span><span data-i18n="lang.english">English</span></button>
+                    <button class="lang-option flex w-full items-center px-2 py-1 hover:bg-gray-100" role="menuitem" data-lang="fr"><span class="mr-2">🇫🇷</span><span data-i18n="lang.french">Français</span></button>
                 </div>
             </div>
         </div>
@@ -2140,7 +2140,7 @@ function displayResults(results) {
         };
 
         // Descriptions détaillées Ennéagramme
-        const enneagramDetailedDescriptions = {
+        window.enneagramDetailedDescriptions = window.enneagramDetailedDescriptions || {
             '1': {
                 title: 'Type 1 - Le Perfectionniste',
                 content: `
@@ -2415,7 +2415,7 @@ function displayResults(results) {
         }
 
         function showEnneagramDetails(type) {
-            const details = enneagramDetailedDescriptions[type];
+            const details = window.enneagramDetailedDescriptions[type];
             if (details) {
                 showModal(details.title, details.content);
             } else {

--- a/public/common.js
+++ b/public/common.js
@@ -27,18 +27,19 @@ if (mobileMenuButton && mobileMenu) {
 }
 
 document.addEventListener('DOMContentLoaded', () => {
-  const langButton = document.getElementById('lang-button');
+  const langTrigger = document.getElementById('lang-trigger');
   const langMenu = document.getElementById('lang-menu');
-  if (!langButton || !langMenu) return;
+  const langDropdown = document.getElementById('lang-dropdown');
+  if (!langTrigger || !langMenu) return;
 
   const closeLangMenu = () => {
     langMenu.classList.add('hidden');
-    langButton.setAttribute('aria-expanded', 'false');
+    langTrigger.setAttribute('aria-expanded', 'false');
   };
 
-  langButton.addEventListener('click', () => {
-    const expanded = langButton.getAttribute('aria-expanded') === 'true';
-    langButton.setAttribute('aria-expanded', String(!expanded));
+  langTrigger.addEventListener('click', () => {
+    const expanded = langTrigger.getAttribute('aria-expanded') === 'true';
+    langTrigger.setAttribute('aria-expanded', String(!expanded));
     langMenu.classList.toggle('hidden', expanded);
   });
 
@@ -54,13 +55,7 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   document.addEventListener('click', e => {
-    if (!langButton.contains(e.target) && !langMenu.contains(e.target)) {
-      closeLangMenu();
-    }
-  });
-
-  document.addEventListener('focusin', e => {
-    if (!langButton.contains(e.target) && !langMenu.contains(e.target)) {
+    if (langDropdown && !langDropdown.contains(e.target)) {
       closeLangMenu();
     }
   });
@@ -195,7 +190,7 @@ function showMBTIDetails(type){
   if (d) showModal(d.title, d.content);
 }
 
-const enneagramDetailedDescriptions = {
+window.enneagramDetailedDescriptions = window.enneagramDetailedDescriptions || {
   '1':{title:'Type 1 - Le Perfectionniste',content:'<p>Éthique, engagé et cherche la perfection.</p>'},
   '2':{title:'Type 2 - L\'Altruiste',content:'<p>Chaleureux et serviable, orienté vers les autres.</p>'},
   '3':{title:'Type 3 - Le Performant',content:'<p>Ambitieux, axé sur la réussite.</p>'},
@@ -207,7 +202,7 @@ const enneagramDetailedDescriptions = {
   '9':{title:'Type 9 - Le Médiateur',content:'<p>Calme, cherche l’harmonie.</p>'}
 };
 function showEnneagramDetails(type){
-  const d = enneagramDetailedDescriptions[type];
+  const d = window.enneagramDetailedDescriptions[type];
   if (d) showModal(d.title, d.content);
 }
 

--- a/public/enneagramme.html
+++ b/public/enneagramme.html
@@ -399,14 +399,14 @@
             <div class="flex-shrink-0 flex items-center">
                 <img src="logo pc 3.png" alt="Personnalité Comparée logo" class="w-10 h-10 rounded-full object-cover"><span id="brand-home" class="ml-3 text-[1.05rem] sm:text-xl font-bold text-black" data-i18n="brand.name">Personnalité Comparée</span>
             </div>
-            <div class="language-switcher ml-4 relative text-sm font-bold">
-                <button id="lang-button" class="flex items-center gap-1" aria-haspopup="true" aria-expanded="false">
+            <div id="lang-dropdown" class="language-switcher ml-4 relative text-sm font-bold z-50">
+                <button id="lang-trigger" type="button" class="flex items-center gap-1" aria-haspopup="true" aria-expanded="false">
                     <span data-i18n="lang.language">Language</span>
                     <svg class="w-3 h-3" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
                 </button>
-                <div id="lang-menu" class="hidden absolute right-0 mt-2 w-32 rounded-md bg-white shadow-lg border">
-                    <button class="lang-option flex w-full items-center px-2 py-1 hover:bg-gray-100" data-lang="en"><span class="mr-2">🇬🇧</span><span data-i18n="lang.english">English</span></button>
-                    <button class="lang-option flex w-full items-center px-2 py-1 hover:bg-gray-100" data-lang="fr"><span class="mr-2">🇫🇷</span><span data-i18n="lang.french">Français</span></button>
+                <div id="lang-menu" role="menu" class="hidden absolute right-0 mt-2 w-32 rounded-md bg-white shadow-lg border">
+                    <button class="lang-option flex w-full items-center px-2 py-1 hover:bg-gray-100" role="menuitem" data-lang="en"><span class="mr-2">🇬🇧</span><span data-i18n="lang.english">English</span></button>
+                    <button class="lang-option flex w-full items-center px-2 py-1 hover:bg-gray-100" role="menuitem" data-lang="fr"><span class="mr-2">🇫🇷</span><span data-i18n="lang.french">Français</span></button>
                 </div>
             </div>
         </div>
@@ -2571,7 +2571,7 @@ function displayResults(results) {
         };
 
         // Descriptions détaillées Ennéagramme
-        const enneagramDetailedDescriptions = {
+        window.enneagramDetailedDescriptions = window.enneagramDetailedDescriptions || {
             '1': {
                 title: '<span data-i18n="enneagramme.modals.1.title">Type 1 - Le Perfectionniste</span>',
                 content: `
@@ -2846,7 +2846,7 @@ function displayResults(results) {
         }
 
         function showEnneagramDetails(type) {
-            const details = enneagramDetailedDescriptions[type];
+            const details = window.enneagramDetailedDescriptions[type];
             if (details) {
                 showModal(details.title, details.content);
             } else {

--- a/public/index.html
+++ b/public/index.html
@@ -433,14 +433,14 @@
             <div class="flex-shrink-0 flex items-center">
                 <img src="logo pc 3.png" alt="Personnalité Comparée logo" class="w-10 h-10 rounded-full object-cover"><span id="brand-home" class="ml-3 text-[1.05rem] sm:text-xl font-bold text-black" data-i18n="brand.name">Personnalité Comparée</span>
             </div>
-            <div class="language-switcher ml-4 relative text-sm font-bold">
-                <button id="lang-button" class="flex items-center gap-1" aria-haspopup="true" aria-expanded="false">
+            <div id="lang-dropdown" class="language-switcher ml-4 relative text-sm font-bold z-50">
+                <button id="lang-trigger" type="button" class="flex items-center gap-1" aria-haspopup="true" aria-expanded="false">
                     <span data-i18n="lang.language">Language</span>
                     <svg class="w-3 h-3" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
                 </button>
-                <div id="lang-menu" class="hidden absolute right-0 mt-2 w-32 rounded-md bg-white shadow-lg border">
-                    <button class="lang-option flex w-full items-center px-2 py-1 hover:bg-gray-100" data-lang="en"><span class="mr-2">🇬🇧</span><span data-i18n="lang.english">English</span></button>
-                    <button class="lang-option flex w-full items-center px-2 py-1 hover:bg-gray-100" data-lang="fr"><span class="mr-2">🇫🇷</span><span data-i18n="lang.french">Français</span></button>
+                <div id="lang-menu" role="menu" class="hidden absolute right-0 mt-2 w-32 rounded-md bg-white shadow-lg border">
+                    <button class="lang-option flex w-full items-center px-2 py-1 hover:bg-gray-100" role="menuitem" data-lang="en"><span class="mr-2">🇬🇧</span><span data-i18n="lang.english">English</span></button>
+                    <button class="lang-option flex w-full items-center px-2 py-1 hover:bg-gray-100" role="menuitem" data-lang="fr"><span class="mr-2">🇫🇷</span><span data-i18n="lang.french">Français</span></button>
                 </div>
             </div>
         </div>
@@ -2657,7 +2657,7 @@ function displayResults(results) {
         };
 
         // Descriptions détaillées Ennéagramme
-        const enneagramDetailedDescriptions = {
+        window.enneagramDetailedDescriptions = window.enneagramDetailedDescriptions || {
             '1': {
                 title: 'Type 1 - Le Perfectionniste',
                 content: `
@@ -2932,7 +2932,7 @@ function displayResults(results) {
         }
 
         function showEnneagramDetails(type) {
-            const details = enneagramDetailedDescriptions[type];
+            const details = window.enneagramDetailedDescriptions[type];
             if (details) {
                 showModal(details.title, details.content);
             } else {

--- a/public/mbti.html
+++ b/public/mbti.html
@@ -399,14 +399,14 @@
             <div class="flex-shrink-0 flex items-center">
                 <img src="logo pc 3.png" alt="Personnalité Comparée logo" class="w-10 h-10 rounded-full object-cover"><span id="brand-home" class="ml-3 text-[1.05rem] sm:text-xl font-bold text-black" data-i18n="brand.name">Personnalité Comparée</span>
             </div>
-            <div class="language-switcher ml-4 relative text-sm font-bold">
-                <button id="lang-button" class="flex items-center gap-1" aria-haspopup="true" aria-expanded="false">
+            <div id="lang-dropdown" class="language-switcher ml-4 relative text-sm font-bold z-50">
+                <button id="lang-trigger" type="button" class="flex items-center gap-1" aria-haspopup="true" aria-expanded="false">
                     <span data-i18n="lang.language">Language</span>
                     <svg class="w-3 h-3" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
                 </button>
-                <div id="lang-menu" class="hidden absolute right-0 mt-2 w-32 rounded-md bg-white shadow-lg border">
-                    <button class="lang-option flex w-full items-center px-2 py-1 hover:bg-gray-100" data-lang="en"><span class="mr-2">🇬🇧</span><span data-i18n="lang.english">English</span></button>
-                    <button class="lang-option flex w-full items-center px-2 py-1 hover:bg-gray-100" data-lang="fr"><span class="mr-2">🇫🇷</span><span data-i18n="lang.french">Français</span></button>
+                <div id="lang-menu" role="menu" class="hidden absolute right-0 mt-2 w-32 rounded-md bg-white shadow-lg border">
+                    <button class="lang-option flex w-full items-center px-2 py-1 hover:bg-gray-100" role="menuitem" data-lang="en"><span class="mr-2">🇬🇧</span><span data-i18n="lang.english">English</span></button>
+                    <button class="lang-option flex w-full items-center px-2 py-1 hover:bg-gray-100" role="menuitem" data-lang="fr"><span class="mr-2">🇫🇷</span><span data-i18n="lang.french">Français</span></button>
                 </div>
             </div>
         </div>
@@ -2664,7 +2664,7 @@ function displayResults(results) {
         };
 
         // Descriptions détaillées Ennéagramme
-        const enneagramDetailedDescriptions = {
+        window.enneagramDetailedDescriptions = window.enneagramDetailedDescriptions || {
             '1': {
                 title: 'Type 1 - Le Perfectionniste',
                 content: `
@@ -2939,7 +2939,7 @@ function displayResults(results) {
         }
 
         function showEnneagramDetails(type) {
-            const details = enneagramDetailedDescriptions[type];
+            const details = window.enneagramDetailedDescriptions[type];
             if (details) {
                 showModal(details.title, details.content);
             } else {


### PR DESCRIPTION
## Summary
- add #lang-trigger button and dropdown container with ARIA roles and z-index
- initialize language switcher after DOM ready and persist selection
- dedupe enneagramDetailedDescriptions using window property to avoid redeclaration

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a9bfb1d7788321a1d1522fd2ef5591