### PR TITLE
feat: responsive language selector with compact mobile trigger

### DIFF
--- a/public/blog-enneagramme-instincts.html
+++ b/public/blog-enneagramme-instincts.html
@@ -399,18 +399,7 @@
             <div class="flex-shrink-0 flex items-center">
                 <img src="logo pc 3.png" alt="Personnalité Comparée logo" class="w-10 h-10 rounded-full object-cover"><span id="brand-home" class="ml-3 text-[1.05rem] sm:text-xl font-bold text-black" data-i18n="brand.name">Personnalité Comparée</span>
             </div>
-            <div id="lang-dropdown" class="language-switcher ml-4 relative text-sm font-bold z-50">
-                <button id="lang-trigger" type="button" class="flex items-center gap-1" aria-haspopup="true" aria-expanded="false">
-                    <span data-i18n="lang.language">Language</span>
-                    <svg class="w-3 h-3" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                </button>
-                <div id="lang-menu" role="menu" class="hidden absolute right-0 mt-2 w-32 rounded-md bg-white shadow-lg border">
-                    <button class="lang-option flex w-full items-center px-2 py-1 hover:bg-gray-100" role="menuitem" data-lang="en"><span class="mr-2">🇬🇧</span><span data-i18n="lang.english">English</span></button>
-                    <button class="lang-option flex w-full items-center px-2 py-1 hover:bg-gray-100" role="menuitem" data-lang="fr"><span class="mr-2">🇫🇷</span><span data-i18n="lang.french">Français</span></button>
-                </div>
-            </div>
-        </div>
-        <nav class="desktop-nav hidden md:ml-6 md:flex md:items-center md:space-x-8">
+            <nav class="desktop-nav hidden md:ml-6 md:flex md:items-center md:space-x-8">
             <div id="home-menu-container" class="relative group">
                 <a id="home-menu-button" href="index.html" class="inline-flex items-center gap-2 text-gray-900 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
                     <span data-i18n="menu.home">Accueil</span>
@@ -464,12 +453,27 @@
                 Mon profil
             </button>
         </nav>
-        <div class="-mr-2 flex items-center md:hidden">
-            <button type="button" id="mobile-menu-button" class="inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500" aria-controls="mobile-menu" aria-expanded="false">
+        <div class="flex items-center gap-2 ml-auto">
+            <div id="lang-dropdown" class="language-switcher relative text-sm font-bold z-50">
+                <button id="lang-trigger-compact" type="button" class="inline-flex sm:hidden items-center gap-1 text-sm whitespace-nowrap shrink-0" aria-haspopup="true" aria-expanded="false">
+                    <i class="fas fa-globe"></i>
+                    <span id="lang-code">EN</span>
+                </button>
+                <button id="lang-trigger" type="button" class="hidden sm:inline-flex items-center gap-2 whitespace-nowrap" aria-haspopup="true" aria-expanded="false">
+                    <span data-i18n="lang.language" class="whitespace-nowrap">Language</span>
+                    <svg class="w-3 h-3" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
+                </button>
+                <div id="lang-menu" role="menu" class="hidden absolute right-0 mt-2 w-32 rounded-md bg-white shadow-lg border z-50">
+                    <button class="lang-option flex w-full items-center px-2 py-1 hover:bg-gray-100" role="menuitem" data-lang="en"><span class="mr-2">🇬🇧</span><span data-i18n="lang.english">English</span></button>
+                    <button class="lang-option flex w-full items-center px-2 py-1 hover:bg-gray-100" role="menuitem" data-lang="fr"><span class="mr-2">🇫🇷</span><span data-i18n="lang.french">Français</span></button>
+                </div>
+            </div>
+            <button type="button" id="mobile-menu-button" class="-mr-2 md:hidden inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500" aria-controls="mobile-menu" aria-expanded="false">
                 <span class="sr-only">Ouvrir le menu principal</span>
                 <i class="fas fa-bars" id="menu-icon"></i>
             </button>
         </div>
+    </div>
         <!-- Menu mobile -->
         <div class="mobile-menu md:hidden" id="mobile-menu">
             <div class="px-2 pt-2 pb-3 space-y-1 sm:px-3 bg-white border-t border-gray-200">

--- a/public/blog-mbti-4-dimensions.html
+++ b/public/blog-mbti-4-dimensions.html
@@ -399,18 +399,7 @@
             <div class="flex-shrink-0 flex items-center">
                 <img src="logo pc 3.png" alt="Personnalité Comparée logo" class="w-10 h-10 rounded-full object-cover"><span id="brand-home" class="ml-3 text-[1.05rem] sm:text-xl font-bold text-black" data-i18n="brand.name">Personnalité Comparée</span>
             </div>
-            <div id="lang-dropdown" class="language-switcher ml-4 relative text-sm font-bold z-50">
-                <button id="lang-trigger" type="button" class="flex items-center gap-1" aria-haspopup="true" aria-expanded="false">
-                    <span data-i18n="lang.language">Language</span>
-                    <svg class="w-3 h-3" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                </button>
-                <div id="lang-menu" role="menu" class="hidden absolute right-0 mt-2 w-32 rounded-md bg-white shadow-lg border">
-                    <button class="lang-option flex w-full items-center px-2 py-1 hover:bg-gray-100" role="menuitem" data-lang="en"><span class="mr-2">🇬🇧</span><span data-i18n="lang.english">English</span></button>
-                    <button class="lang-option flex w-full items-center px-2 py-1 hover:bg-gray-100" role="menuitem" data-lang="fr"><span class="mr-2">🇫🇷</span><span data-i18n="lang.french">Français</span></button>
-                </div>
-            </div>
-        </div>
-        <nav class="desktop-nav hidden md:ml-6 md:flex md:items-center md:space-x-8">
+            <nav class="desktop-nav hidden md:ml-6 md:flex md:items-center md:space-x-8">
             <div id="home-menu-container" class="relative group">
                 <a id="home-menu-button" href="index.html" class="inline-flex items-center gap-2 text-gray-900 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
                     <span data-i18n="menu.home">Accueil</span>
@@ -464,12 +453,27 @@
                 Mon profil
             </button>
         </nav>
-        <div class="-mr-2 flex items-center md:hidden">
-            <button type="button" id="mobile-menu-button" class="inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500" aria-controls="mobile-menu" aria-expanded="false">
+        <div class="flex items-center gap-2 ml-auto">
+            <div id="lang-dropdown" class="language-switcher relative text-sm font-bold z-50">
+                <button id="lang-trigger-compact" type="button" class="inline-flex sm:hidden items-center gap-1 text-sm whitespace-nowrap shrink-0" aria-haspopup="true" aria-expanded="false">
+                    <i class="fas fa-globe"></i>
+                    <span id="lang-code">EN</span>
+                </button>
+                <button id="lang-trigger" type="button" class="hidden sm:inline-flex items-center gap-2 whitespace-nowrap" aria-haspopup="true" aria-expanded="false">
+                    <span data-i18n="lang.language" class="whitespace-nowrap">Language</span>
+                    <svg class="w-3 h-3" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
+                </button>
+                <div id="lang-menu" role="menu" class="hidden absolute right-0 mt-2 w-32 rounded-md bg-white shadow-lg border z-50">
+                    <button class="lang-option flex w-full items-center px-2 py-1 hover:bg-gray-100" role="menuitem" data-lang="en"><span class="mr-2">🇬🇧</span><span data-i18n="lang.english">English</span></button>
+                    <button class="lang-option flex w-full items-center px-2 py-1 hover:bg-gray-100" role="menuitem" data-lang="fr"><span class="mr-2">🇫🇷</span><span data-i18n="lang.french">Français</span></button>
+                </div>
+            </div>
+            <button type="button" id="mobile-menu-button" class="-mr-2 md:hidden inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500" aria-controls="mobile-menu" aria-expanded="false">
                 <span class="sr-only">Ouvrir le menu principal</span>
                 <i class="fas fa-bars" id="menu-icon"></i>
             </button>
         </div>
+    </div>
         <!-- Menu mobile -->
         <div class="mobile-menu md:hidden" id="mobile-menu">
             <div class="px-2 pt-2 pb-3 space-y-1 sm:px-3 bg-white border-t border-gray-200">

--- a/public/blog.html
+++ b/public/blog.html
@@ -399,18 +399,7 @@
             <div class="flex-shrink-0 flex items-center">
                 <img src="logo pc 3.png" alt="Personnalité Comparée logo" class="w-10 h-10 rounded-full object-cover"><span id="brand-home" class="ml-3 text-[1.05rem] sm:text-xl font-bold text-black" data-i18n="brand.name">Personnalité Comparée</span>
             </div>
-            <div id="lang-dropdown" class="language-switcher ml-4 relative text-sm font-bold z-50">
-                <button id="lang-trigger" type="button" class="flex items-center gap-1" aria-haspopup="true" aria-expanded="false">
-                    <span data-i18n="lang.language">Language</span>
-                    <svg class="w-3 h-3" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                </button>
-                <div id="lang-menu" role="menu" class="hidden absolute right-0 mt-2 w-32 rounded-md bg-white shadow-lg border">
-                    <button class="lang-option flex w-full items-center px-2 py-1 hover:bg-gray-100" role="menuitem" data-lang="en"><span class="mr-2">🇬🇧</span><span data-i18n="lang.english">English</span></button>
-                    <button class="lang-option flex w-full items-center px-2 py-1 hover:bg-gray-100" role="menuitem" data-lang="fr"><span class="mr-2">🇫🇷</span><span data-i18n="lang.french">Français</span></button>
-                </div>
-            </div>
-        </div>
-        <nav class="desktop-nav hidden md:ml-6 md:flex md:items-center md:space-x-8">
+            <nav class="desktop-nav hidden md:ml-6 md:flex md:items-center md:space-x-8">
             <div id="home-menu-container" class="relative group">
                 <a id="home-menu-button" href="index.html" class="inline-flex items-center gap-2 text-gray-900 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
                     <span data-i18n="menu.home">Accueil</span>
@@ -464,12 +453,27 @@
                 Mon profil
             </button>
         </nav>
-        <div class="-mr-2 flex items-center md:hidden">
-            <button type="button" id="mobile-menu-button" class="inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500" aria-controls="mobile-menu" aria-expanded="false">
+        <div class="flex items-center gap-2 ml-auto">
+            <div id="lang-dropdown" class="language-switcher relative text-sm font-bold z-50">
+                <button id="lang-trigger-compact" type="button" class="inline-flex sm:hidden items-center gap-1 text-sm whitespace-nowrap shrink-0" aria-haspopup="true" aria-expanded="false">
+                    <i class="fas fa-globe"></i>
+                    <span id="lang-code">EN</span>
+                </button>
+                <button id="lang-trigger" type="button" class="hidden sm:inline-flex items-center gap-2 whitespace-nowrap" aria-haspopup="true" aria-expanded="false">
+                    <span data-i18n="lang.language" class="whitespace-nowrap">Language</span>
+                    <svg class="w-3 h-3" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
+                </button>
+                <div id="lang-menu" role="menu" class="hidden absolute right-0 mt-2 w-32 rounded-md bg-white shadow-lg border z-50">
+                    <button class="lang-option flex w-full items-center px-2 py-1 hover:bg-gray-100" role="menuitem" data-lang="en"><span class="mr-2">🇬🇧</span><span data-i18n="lang.english">English</span></button>
+                    <button class="lang-option flex w-full items-center px-2 py-1 hover:bg-gray-100" role="menuitem" data-lang="fr"><span class="mr-2">🇫🇷</span><span data-i18n="lang.french">Français</span></button>
+                </div>
+            </div>
+            <button type="button" id="mobile-menu-button" class="-mr-2 md:hidden inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500" aria-controls="mobile-menu" aria-expanded="false">
                 <span class="sr-only">Ouvrir le menu principal</span>
                 <i class="fas fa-bars" id="menu-icon"></i>
             </button>
         </div>
+    </div>
         <!-- Menu mobile -->
         <div class="mobile-menu md:hidden" id="mobile-menu">
             <div class="px-2 pt-2 pb-3 space-y-1 sm:px-3 bg-white border-t border-gray-200">

--- a/public/common.js
+++ b/public/common.js
@@ -27,20 +27,26 @@ if (mobileMenuButton && mobileMenu) {
 }
 
 document.addEventListener('DOMContentLoaded', () => {
-  const langTrigger = document.getElementById('lang-trigger');
+  const langTriggers = [document.getElementById('lang-trigger'), document.getElementById('lang-trigger-compact')].filter(Boolean);
   const langMenu = document.getElementById('lang-menu');
   const langDropdown = document.getElementById('lang-dropdown');
-  if (!langTrigger || !langMenu) return;
+  const langCode = document.getElementById('lang-code');
+  if (!langMenu || !langTriggers.length) return;
 
-  const closeLangMenu = () => {
-    langMenu.classList.add('hidden');
-    langTrigger.setAttribute('aria-expanded', 'false');
+  const updateLangCode = () => {
+    if (langCode) langCode.textContent = i18n.currentLang.toUpperCase();
   };
 
-  langTrigger.addEventListener('click', () => {
-    const expanded = langTrigger.getAttribute('aria-expanded') === 'true';
-    langTrigger.setAttribute('aria-expanded', String(!expanded));
-    langMenu.classList.toggle('hidden', expanded);
+  const setExpanded = expanded => {
+    langMenu.classList.toggle('hidden', !expanded);
+    langTriggers.forEach(t => t.setAttribute('aria-expanded', String(expanded)));
+  };
+
+  langTriggers.forEach(trigger => {
+    trigger.addEventListener('click', () => {
+      const expanded = langMenu.classList.contains('hidden');
+      setExpanded(expanded);
+    });
   });
 
   langMenu.querySelectorAll('.lang-option').forEach(opt => {
@@ -50,24 +56,26 @@ document.addEventListener('DOMContentLoaded', () => {
       localStorage.setItem('pc_lang', lang);
       renderI18n();
       if (typeof updatePlaceholders === 'function') updatePlaceholders();
-      closeLangMenu();
+      updateLangCode();
+      setExpanded(false);
     });
   });
 
   document.addEventListener('click', e => {
     if (langDropdown && !langDropdown.contains(e.target)) {
-      closeLangMenu();
+      setExpanded(false);
     }
   });
 
   document.addEventListener('keydown', e => {
-    if (e.key === 'Escape') closeLangMenu();
+    if (e.key === 'Escape') setExpanded(false);
   });
 
   const savedLang = localStorage.getItem('pc_lang') || 'en';
   i18n.setLanguage(savedLang);
   renderI18n();
   if (typeof updatePlaceholders === 'function') updatePlaceholders();
+  updateLangCode();
 });
 
 const homeMenuContainer = document.getElementById('home-menu-container');

--- a/public/enneagramme.html
+++ b/public/enneagramme.html
@@ -399,18 +399,7 @@
             <div class="flex-shrink-0 flex items-center">
                 <img src="logo pc 3.png" alt="Personnalité Comparée logo" class="w-10 h-10 rounded-full object-cover"><span id="brand-home" class="ml-3 text-[1.05rem] sm:text-xl font-bold text-black" data-i18n="brand.name">Personnalité Comparée</span>
             </div>
-            <div id="lang-dropdown" class="language-switcher ml-4 relative text-sm font-bold z-50">
-                <button id="lang-trigger" type="button" class="flex items-center gap-1" aria-haspopup="true" aria-expanded="false">
-                    <span data-i18n="lang.language">Language</span>
-                    <svg class="w-3 h-3" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                </button>
-                <div id="lang-menu" role="menu" class="hidden absolute right-0 mt-2 w-32 rounded-md bg-white shadow-lg border">
-                    <button class="lang-option flex w-full items-center px-2 py-1 hover:bg-gray-100" role="menuitem" data-lang="en"><span class="mr-2">🇬🇧</span><span data-i18n="lang.english">English</span></button>
-                    <button class="lang-option flex w-full items-center px-2 py-1 hover:bg-gray-100" role="menuitem" data-lang="fr"><span class="mr-2">🇫🇷</span><span data-i18n="lang.french">Français</span></button>
-                </div>
-            </div>
-        </div>
-        <nav class="desktop-nav hidden md:ml-6 md:flex md:items-center md:space-x-8">
+            <nav class="desktop-nav hidden md:ml-6 md:flex md:items-center md:space-x-8">
             <div id="home-menu-container" class="relative group">
                 <a id="home-menu-button" href="index.html" class="inline-flex items-center gap-2 text-gray-900 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
                     <span data-i18n="menu.home">Accueil</span>
@@ -462,12 +451,27 @@
             <a href="index.html#home-faq" class="text-gray-500 hover:text-gray-700 inline-flex items-center px-1 pt-1 text-sm font-medium" data-i18n="menu.faq">FAQ</a>
             <button id="profile-btn-desktop" onclick="openProfileModal()" class="ml-4 inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-black hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black" data-i18n="menu.profile">Mon profil</button>
         </nav>
-        <div class="-mr-2 flex items-center md:hidden">
-            <button type="button" id="mobile-menu-button" class="inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500" aria-controls="mobile-menu" aria-expanded="false">
+        <div class="flex items-center gap-2 ml-auto">
+            <div id="lang-dropdown" class="language-switcher relative text-sm font-bold z-50">
+                <button id="lang-trigger-compact" type="button" class="inline-flex sm:hidden items-center gap-1 text-sm whitespace-nowrap shrink-0" aria-haspopup="true" aria-expanded="false">
+                    <i class="fas fa-globe"></i>
+                    <span id="lang-code">EN</span>
+                </button>
+                <button id="lang-trigger" type="button" class="hidden sm:inline-flex items-center gap-2 whitespace-nowrap" aria-haspopup="true" aria-expanded="false">
+                    <span data-i18n="lang.language" class="whitespace-nowrap">Language</span>
+                    <svg class="w-3 h-3" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
+                </button>
+                <div id="lang-menu" role="menu" class="hidden absolute right-0 mt-2 w-32 rounded-md bg-white shadow-lg border z-50">
+                    <button class="lang-option flex w-full items-center px-2 py-1 hover:bg-gray-100" role="menuitem" data-lang="en"><span class="mr-2">🇬🇧</span><span data-i18n="lang.english">English</span></button>
+                    <button class="lang-option flex w-full items-center px-2 py-1 hover:bg-gray-100" role="menuitem" data-lang="fr"><span class="mr-2">🇫🇷</span><span data-i18n="lang.french">Français</span></button>
+                </div>
+            </div>
+            <button type="button" id="mobile-menu-button" class="-mr-2 md:hidden inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500" aria-controls="mobile-menu" aria-expanded="false">
                 <span class="sr-only" data-i18n="nav.open_main">Ouvrir le menu principal</span>
                 <i class="fas fa-bars" id="menu-icon"></i>
             </button>
         </div>
+    </div>
         <!-- Menu mobile -->
         <div class="mobile-menu md:hidden" id="mobile-menu">
             <div class="px-2 pt-2 pb-3 space-y-1 sm:px-3 bg-white border-t border-gray-200">

--- a/public/index.html
+++ b/public/index.html
@@ -433,18 +433,7 @@
             <div class="flex-shrink-0 flex items-center">
                 <img src="logo pc 3.png" alt="Personnalité Comparée logo" class="w-10 h-10 rounded-full object-cover"><span id="brand-home" class="ml-3 text-[1.05rem] sm:text-xl font-bold text-black" data-i18n="brand.name">Personnalité Comparée</span>
             </div>
-            <div id="lang-dropdown" class="language-switcher ml-4 relative text-sm font-bold z-50">
-                <button id="lang-trigger" type="button" class="flex items-center gap-1" aria-haspopup="true" aria-expanded="false">
-                    <span data-i18n="lang.language">Language</span>
-                    <svg class="w-3 h-3" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                </button>
-                <div id="lang-menu" role="menu" class="hidden absolute right-0 mt-2 w-32 rounded-md bg-white shadow-lg border">
-                    <button class="lang-option flex w-full items-center px-2 py-1 hover:bg-gray-100" role="menuitem" data-lang="en"><span class="mr-2">🇬🇧</span><span data-i18n="lang.english">English</span></button>
-                    <button class="lang-option flex w-full items-center px-2 py-1 hover:bg-gray-100" role="menuitem" data-lang="fr"><span class="mr-2">🇫🇷</span><span data-i18n="lang.french">Français</span></button>
-                </div>
-            </div>
-        </div>
-        <nav class="desktop-nav hidden md:ml-6 md:flex md:items-center md:space-x-8">
+            <nav class="desktop-nav hidden md:ml-6 md:flex md:items-center md:space-x-8">
             <div id="home-menu-container" class="relative">
                 <a id="home-menu-button" href="index.html" class="inline-flex items-center gap-2 text-gray-900 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
                     <span data-i18n="menu.home">Accueil</span>
@@ -498,12 +487,27 @@
                 Mon profil
             </button>
         </nav>
-        <div class="-mr-2 flex items-center md:hidden">
-            <button type="button" id="mobile-menu-button" class="inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500" aria-controls="mobile-menu" aria-expanded="false">
+        <div class="flex items-center gap-2 ml-auto">
+            <div id="lang-dropdown" class="language-switcher relative text-sm font-bold z-50">
+                <button id="lang-trigger-compact" type="button" class="inline-flex sm:hidden items-center gap-1 text-sm whitespace-nowrap shrink-0" aria-haspopup="true" aria-expanded="false">
+                    <i class="fas fa-globe"></i>
+                    <span id="lang-code">EN</span>
+                </button>
+                <button id="lang-trigger" type="button" class="hidden sm:inline-flex items-center gap-2 whitespace-nowrap" aria-haspopup="true" aria-expanded="false">
+                    <span data-i18n="lang.language" class="whitespace-nowrap">Language</span>
+                    <svg class="w-3 h-3" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
+                </button>
+                <div id="lang-menu" role="menu" class="hidden absolute right-0 mt-2 w-32 rounded-md bg-white shadow-lg border z-50">
+                    <button class="lang-option flex w-full items-center px-2 py-1 hover:bg-gray-100" role="menuitem" data-lang="en"><span class="mr-2">🇬🇧</span><span data-i18n="lang.english">English</span></button>
+                    <button class="lang-option flex w-full items-center px-2 py-1 hover:bg-gray-100" role="menuitem" data-lang="fr"><span class="mr-2">🇫🇷</span><span data-i18n="lang.french">Français</span></button>
+                </div>
+            </div>
+            <button type="button" id="mobile-menu-button" class="-mr-2 md:hidden inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500" aria-controls="mobile-menu" aria-expanded="false">
                 <span class="sr-only" data-i18n="nav.open_main">Ouvrir le menu principal</span>
                 <i class="fas fa-bars" id="menu-icon"></i>
             </button>
         </div>
+    </div>
         <!-- Menu mobile -->
         <div class="mobile-menu md:hidden" id="mobile-menu">
             <div class="px-2 pt-2 pb-3 space-y-1 sm:px-3 bg-white border-t border-gray-200">

--- a/public/mbti.html
+++ b/public/mbti.html
@@ -399,18 +399,7 @@
             <div class="flex-shrink-0 flex items-center">
                 <img src="logo pc 3.png" alt="Personnalité Comparée logo" class="w-10 h-10 rounded-full object-cover"><span id="brand-home" class="ml-3 text-[1.05rem] sm:text-xl font-bold text-black" data-i18n="brand.name">Personnalité Comparée</span>
             </div>
-            <div id="lang-dropdown" class="language-switcher ml-4 relative text-sm font-bold z-50">
-                <button id="lang-trigger" type="button" class="flex items-center gap-1" aria-haspopup="true" aria-expanded="false">
-                    <span data-i18n="lang.language">Language</span>
-                    <svg class="w-3 h-3" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
-                </button>
-                <div id="lang-menu" role="menu" class="hidden absolute right-0 mt-2 w-32 rounded-md bg-white shadow-lg border">
-                    <button class="lang-option flex w-full items-center px-2 py-1 hover:bg-gray-100" role="menuitem" data-lang="en"><span class="mr-2">🇬🇧</span><span data-i18n="lang.english">English</span></button>
-                    <button class="lang-option flex w-full items-center px-2 py-1 hover:bg-gray-100" role="menuitem" data-lang="fr"><span class="mr-2">🇫🇷</span><span data-i18n="lang.french">Français</span></button>
-                </div>
-            </div>
-        </div>
-        <nav class="desktop-nav hidden md:ml-6 md:flex md:items-center md:space-x-8">
+            <nav class="desktop-nav hidden md:ml-6 md:flex md:items-center md:space-x-8">
             <div id="home-menu-container" class="relative group">
                 <a id="home-menu-button" href="index.html" class="inline-flex items-center gap-2 text-gray-900 px-1 pt-1 text-sm font-medium" aria-haspopup="true" aria-expanded="false">
                     <span data-i18n="menu.home">Accueil</span>
@@ -464,12 +453,27 @@
                 Mon profil
             </button>
         </nav>
-        <div class="-mr-2 flex items-center md:hidden">
-            <button type="button" id="mobile-menu-button" class="inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500" aria-controls="mobile-menu" aria-expanded="false">
+        <div class="flex items-center gap-2 ml-auto">
+            <div id="lang-dropdown" class="language-switcher relative text-sm font-bold z-50">
+                <button id="lang-trigger-compact" type="button" class="inline-flex sm:hidden items-center gap-1 text-sm whitespace-nowrap shrink-0" aria-haspopup="true" aria-expanded="false">
+                    <i class="fas fa-globe"></i>
+                    <span id="lang-code">EN</span>
+                </button>
+                <button id="lang-trigger" type="button" class="hidden sm:inline-flex items-center gap-2 whitespace-nowrap" aria-haspopup="true" aria-expanded="false">
+                    <span data-i18n="lang.language" class="whitespace-nowrap">Language</span>
+                    <svg class="w-3 h-3" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
+                </button>
+                <div id="lang-menu" role="menu" class="hidden absolute right-0 mt-2 w-32 rounded-md bg-white shadow-lg border z-50">
+                    <button class="lang-option flex w-full items-center px-2 py-1 hover:bg-gray-100" role="menuitem" data-lang="en"><span class="mr-2">🇬🇧</span><span data-i18n="lang.english">English</span></button>
+                    <button class="lang-option flex w-full items-center px-2 py-1 hover:bg-gray-100" role="menuitem" data-lang="fr"><span class="mr-2">🇫🇷</span><span data-i18n="lang.french">Français</span></button>
+                </div>
+            </div>
+            <button type="button" id="mobile-menu-button" class="-mr-2 md:hidden inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500" aria-controls="mobile-menu" aria-expanded="false">
                 <span class="sr-only">Ouvrir le menu principal</span>
                 <i class="fas fa-bars" id="menu-icon"></i>
             </button>
         </div>
+    </div>
         <!-- Menu mobile -->
         <div class="mobile-menu md:hidden" id="mobile-menu">
             <div class="px-2 pt-2 pb-3 space-y-1 sm:px-3 bg-white border-t border-gray-200">


### PR DESCRIPTION
## Summary
- make language menu responsive with compact trigger on mobile
- support two dropdown triggers via shared JS logic

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a9c24c46148321a9ecd640b0ec1fd1