### PR TITLE
fix(header-mobile): compact language trigger (globe+code) on small screens; preserve desktop unchanged

### DIFF
--- a/public/blog-enneagramme-instincts.html
+++ b/public/blog-enneagramme-instincts.html
@@ -399,10 +399,14 @@
             <div class="flex-shrink-0 flex items-center">
                 <img src="logo pc 3.png" alt="Personnalité Comparée logo" class="w-10 h-10 rounded-full object-cover"><span id="brand-home" class="ml-3 text-[1.05rem] sm:text-xl font-bold text-black" data-i18n="brand.name">Personnalité Comparée</span>
             </div>
-            <div id="lang-dropdown" class="language-switcher ml-4 relative text-sm font-bold z-50">
-                <button id="lang-trigger" type="button" class="flex items-center gap-1" aria-haspopup="true" aria-expanded="false">
+            <div id="lang-dropdown" class="language-switcher ml-4 mr-2 sm:mr-0 relative text-sm font-bold z-50">
+                <button id="lang-trigger" type="button" class="hidden sm:flex items-center gap-1 whitespace-nowrap" aria-haspopup="true" aria-expanded="false">
                     <span data-i18n="lang.language">Language</span>
                     <svg class="w-3 h-3" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
+                </button>
+                <button id="lang-trigger-compact" type="button" class="inline-flex items-center gap-1 text-sm whitespace-nowrap sm:hidden" aria-haspopup="true" aria-expanded="false">
+                    <i class="fas fa-globe"></i>
+                    <span id="lang-code" class="uppercase"></span>
                 </button>
                 <div id="lang-menu" role="menu" class="hidden absolute right-0 mt-2 w-32 rounded-md bg-white shadow-lg border">
                     <button class="lang-option flex w-full items-center px-2 py-1 hover:bg-gray-100" role="menuitem" data-lang="en"><span class="mr-2">🇬🇧</span><span data-i18n="lang.english">English</span></button>

--- a/public/blog-mbti-4-dimensions.html
+++ b/public/blog-mbti-4-dimensions.html
@@ -399,10 +399,14 @@
             <div class="flex-shrink-0 flex items-center">
                 <img src="logo pc 3.png" alt="Personnalité Comparée logo" class="w-10 h-10 rounded-full object-cover"><span id="brand-home" class="ml-3 text-[1.05rem] sm:text-xl font-bold text-black" data-i18n="brand.name">Personnalité Comparée</span>
             </div>
-            <div id="lang-dropdown" class="language-switcher ml-4 relative text-sm font-bold z-50">
-                <button id="lang-trigger" type="button" class="flex items-center gap-1" aria-haspopup="true" aria-expanded="false">
+            <div id="lang-dropdown" class="language-switcher ml-4 mr-2 sm:mr-0 relative text-sm font-bold z-50">
+                <button id="lang-trigger" type="button" class="hidden sm:flex items-center gap-1 whitespace-nowrap" aria-haspopup="true" aria-expanded="false">
                     <span data-i18n="lang.language">Language</span>
                     <svg class="w-3 h-3" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
+                </button>
+                <button id="lang-trigger-compact" type="button" class="inline-flex items-center gap-1 text-sm whitespace-nowrap sm:hidden" aria-haspopup="true" aria-expanded="false">
+                    <i class="fas fa-globe"></i>
+                    <span id="lang-code" class="uppercase"></span>
                 </button>
                 <div id="lang-menu" role="menu" class="hidden absolute right-0 mt-2 w-32 rounded-md bg-white shadow-lg border">
                     <button class="lang-option flex w-full items-center px-2 py-1 hover:bg-gray-100" role="menuitem" data-lang="en"><span class="mr-2">🇬🇧</span><span data-i18n="lang.english">English</span></button>

--- a/public/blog.html
+++ b/public/blog.html
@@ -399,10 +399,14 @@
             <div class="flex-shrink-0 flex items-center">
                 <img src="logo pc 3.png" alt="Personnalité Comparée logo" class="w-10 h-10 rounded-full object-cover"><span id="brand-home" class="ml-3 text-[1.05rem] sm:text-xl font-bold text-black" data-i18n="brand.name">Personnalité Comparée</span>
             </div>
-            <div id="lang-dropdown" class="language-switcher ml-4 relative text-sm font-bold z-50">
-                <button id="lang-trigger" type="button" class="flex items-center gap-1" aria-haspopup="true" aria-expanded="false">
+            <div id="lang-dropdown" class="language-switcher ml-4 mr-2 sm:mr-0 relative text-sm font-bold z-50">
+                <button id="lang-trigger" type="button" class="hidden sm:flex items-center gap-1 whitespace-nowrap" aria-haspopup="true" aria-expanded="false">
                     <span data-i18n="lang.language">Language</span>
                     <svg class="w-3 h-3" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
+                </button>
+                <button id="lang-trigger-compact" type="button" class="inline-flex items-center gap-1 text-sm whitespace-nowrap sm:hidden" aria-haspopup="true" aria-expanded="false">
+                    <i class="fas fa-globe"></i>
+                    <span id="lang-code" class="uppercase"></span>
                 </button>
                 <div id="lang-menu" role="menu" class="hidden absolute right-0 mt-2 w-32 rounded-md bg-white shadow-lg border">
                     <button class="lang-option flex w-full items-center px-2 py-1 hover:bg-gray-100" role="menuitem" data-lang="en"><span class="mr-2">🇬🇧</span><span data-i18n="lang.english">English</span></button>

--- a/public/common.js
+++ b/public/common.js
@@ -28,19 +28,24 @@ if (mobileMenuButton && mobileMenu) {
 
 document.addEventListener('DOMContentLoaded', () => {
   const langTrigger = document.getElementById('lang-trigger');
+  const langTriggerCompact = document.getElementById('lang-trigger-compact');
+  const langCode = document.getElementById('lang-code');
   const langMenu = document.getElementById('lang-menu');
   const langDropdown = document.getElementById('lang-dropdown');
-  if (!langTrigger || !langMenu) return;
+  const langTriggers = [langTrigger, langTriggerCompact].filter(Boolean);
+  if (langTriggers.length === 0 || !langMenu) return;
 
   const closeLangMenu = () => {
     langMenu.classList.add('hidden');
-    langTrigger.setAttribute('aria-expanded', 'false');
+    langTriggers.forEach(t => t.setAttribute('aria-expanded', 'false'));
   };
 
-  langTrigger.addEventListener('click', () => {
-    const expanded = langTrigger.getAttribute('aria-expanded') === 'true';
-    langTrigger.setAttribute('aria-expanded', String(!expanded));
-    langMenu.classList.toggle('hidden', expanded);
+  langTriggers.forEach(trigger => {
+    trigger.addEventListener('click', () => {
+      const hidden = langMenu.classList.contains('hidden');
+      langMenu.classList.toggle('hidden', !hidden);
+      langTriggers.forEach(t => t.setAttribute('aria-expanded', String(hidden)));
+    });
   });
 
   langMenu.querySelectorAll('.lang-option').forEach(opt => {
@@ -49,6 +54,7 @@ document.addEventListener('DOMContentLoaded', () => {
       i18n.setLanguage(lang);
       localStorage.setItem('pc_lang', lang);
       renderI18n();
+      if (langCode) langCode.textContent = lang.toUpperCase();
       if (typeof updatePlaceholders === 'function') updatePlaceholders();
       closeLangMenu();
     });
@@ -67,6 +73,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const savedLang = localStorage.getItem('pc_lang') || 'en';
   i18n.setLanguage(savedLang);
   renderI18n();
+  if (langCode) langCode.textContent = savedLang.toUpperCase();
   if (typeof updatePlaceholders === 'function') updatePlaceholders();
 });
 

--- a/public/enneagramme.html
+++ b/public/enneagramme.html
@@ -399,10 +399,14 @@
             <div class="flex-shrink-0 flex items-center">
                 <img src="logo pc 3.png" alt="Personnalité Comparée logo" class="w-10 h-10 rounded-full object-cover"><span id="brand-home" class="ml-3 text-[1.05rem] sm:text-xl font-bold text-black" data-i18n="brand.name">Personnalité Comparée</span>
             </div>
-            <div id="lang-dropdown" class="language-switcher ml-4 relative text-sm font-bold z-50">
-                <button id="lang-trigger" type="button" class="flex items-center gap-1" aria-haspopup="true" aria-expanded="false">
+            <div id="lang-dropdown" class="language-switcher ml-4 mr-2 sm:mr-0 relative text-sm font-bold z-50">
+                <button id="lang-trigger" type="button" class="hidden sm:flex items-center gap-1 whitespace-nowrap" aria-haspopup="true" aria-expanded="false">
                     <span data-i18n="lang.language">Language</span>
                     <svg class="w-3 h-3" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
+                </button>
+                <button id="lang-trigger-compact" type="button" class="inline-flex items-center gap-1 text-sm whitespace-nowrap sm:hidden" aria-haspopup="true" aria-expanded="false">
+                    <i class="fas fa-globe"></i>
+                    <span id="lang-code" class="uppercase"></span>
                 </button>
                 <div id="lang-menu" role="menu" class="hidden absolute right-0 mt-2 w-32 rounded-md bg-white shadow-lg border">
                     <button class="lang-option flex w-full items-center px-2 py-1 hover:bg-gray-100" role="menuitem" data-lang="en"><span class="mr-2">🇬🇧</span><span data-i18n="lang.english">English</span></button>

--- a/public/index.html
+++ b/public/index.html
@@ -433,10 +433,14 @@
             <div class="flex-shrink-0 flex items-center">
                 <img src="logo pc 3.png" alt="Personnalité Comparée logo" class="w-10 h-10 rounded-full object-cover"><span id="brand-home" class="ml-3 text-[1.05rem] sm:text-xl font-bold text-black" data-i18n="brand.name">Personnalité Comparée</span>
             </div>
-            <div id="lang-dropdown" class="language-switcher ml-4 relative text-sm font-bold z-50">
-                <button id="lang-trigger" type="button" class="flex items-center gap-1" aria-haspopup="true" aria-expanded="false">
+            <div id="lang-dropdown" class="language-switcher ml-4 mr-2 sm:mr-0 relative text-sm font-bold z-50">
+                <button id="lang-trigger" type="button" class="hidden sm:flex items-center gap-1 whitespace-nowrap" aria-haspopup="true" aria-expanded="false">
                     <span data-i18n="lang.language">Language</span>
                     <svg class="w-3 h-3" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
+                </button>
+                <button id="lang-trigger-compact" type="button" class="inline-flex items-center gap-1 text-sm whitespace-nowrap sm:hidden" aria-haspopup="true" aria-expanded="false">
+                    <i class="fas fa-globe"></i>
+                    <span id="lang-code" class="uppercase"></span>
                 </button>
                 <div id="lang-menu" role="menu" class="hidden absolute right-0 mt-2 w-32 rounded-md bg-white shadow-lg border">
                     <button class="lang-option flex w-full items-center px-2 py-1 hover:bg-gray-100" role="menuitem" data-lang="en"><span class="mr-2">🇬🇧</span><span data-i18n="lang.english">English</span></button>

--- a/public/mbti.html
+++ b/public/mbti.html
@@ -399,10 +399,14 @@
             <div class="flex-shrink-0 flex items-center">
                 <img src="logo pc 3.png" alt="Personnalité Comparée logo" class="w-10 h-10 rounded-full object-cover"><span id="brand-home" class="ml-3 text-[1.05rem] sm:text-xl font-bold text-black" data-i18n="brand.name">Personnalité Comparée</span>
             </div>
-            <div id="lang-dropdown" class="language-switcher ml-4 relative text-sm font-bold z-50">
-                <button id="lang-trigger" type="button" class="flex items-center gap-1" aria-haspopup="true" aria-expanded="false">
+            <div id="lang-dropdown" class="language-switcher ml-4 mr-2 sm:mr-0 relative text-sm font-bold z-50">
+                <button id="lang-trigger" type="button" class="hidden sm:flex items-center gap-1 whitespace-nowrap" aria-haspopup="true" aria-expanded="false">
                     <span data-i18n="lang.language">Language</span>
                     <svg class="w-3 h-3" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
+                </button>
+                <button id="lang-trigger-compact" type="button" class="inline-flex items-center gap-1 text-sm whitespace-nowrap sm:hidden" aria-haspopup="true" aria-expanded="false">
+                    <i class="fas fa-globe"></i>
+                    <span id="lang-code" class="uppercase"></span>
                 </button>
                 <div id="lang-menu" role="menu" class="hidden absolute right-0 mt-2 w-32 rounded-md bg-white shadow-lg border">
                     <button class="lang-option flex w-full items-center px-2 py-1 hover:bg-gray-100" role="menuitem" data-lang="en"><span class="mr-2">🇬🇧</span><span data-i18n="lang.english">English</span></button>


### PR DESCRIPTION
## Summary
- add mobile-only language trigger with globe + code, keeping desktop language button unchanged
- wire new trigger to existing dropdown logic and sync displayed language code
- ensure mobile layout spacing with right margin on dropdown container

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a9c654062c8321a96a52606b4d464c