### PR TITLE
Replace FR|EN toggle with globe dropdown

### DIFF
--- a/public/blog-enneagramme-instincts.html
+++ b/public/blog-enneagramme-instincts.html
@@ -399,8 +399,14 @@
             <div class="flex-shrink-0 flex items-center">
                 <img src="logo pc 3.png" alt="Personnalité Comparée logo" class="w-10 h-10 rounded-full object-cover"><span id="brand-home" class="ml-3 text-[1.05rem] sm:text-xl font-bold text-black" data-i18n="brand.name">Personnalité Comparée</span>
             </div>
-            <div class="language-switcher ml-4 flex gap-0 text-sm font-bold">
-                <button onclick="switchLang('fr')" data-i18n="lang.fr">FR</button><span> | </span><button onclick="switchLang('en')" data-i18n="lang.en">EN</button>
+            <div class="relative ml-4">
+                <button id="lang-toggle" class="p-2" aria-haspopup="true" aria-expanded="false">
+                    <svg class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M21 12A9 9 0 113 12a9 9 0 0118 0z"/><path stroke-linecap="round" stroke-linejoin="round" d="M3.6 9h16.8M3.6 15h16.8M12 3.6v16.8"/></svg>
+                </button>
+                <div id="lang-menu" class="absolute right-0 mt-2 w-32 bg-white rounded-md shadow-lg ring-1 ring-black/5 hidden z-50">
+                    <button data-lang="en" class="flex items-center w-full px-4 py-2 text-sm hover:bg-gray-100"><span class="mr-2">🇬🇧</span> English</button>
+                    <button data-lang="fr" class="flex items-center w-full px-4 py-2 text-sm hover:bg-gray-100"><span class="mr-2">🇫🇷</span> Français</button>
+                </div>
             </div>
         </div>
         <nav class="desktop-nav hidden md:ml-6 md:flex md:items-center md:space-x-8">

--- a/public/blog-mbti-4-dimensions.html
+++ b/public/blog-mbti-4-dimensions.html
@@ -399,8 +399,14 @@
             <div class="flex-shrink-0 flex items-center">
                 <img src="logo pc 3.png" alt="Personnalité Comparée logo" class="w-10 h-10 rounded-full object-cover"><span id="brand-home" class="ml-3 text-[1.05rem] sm:text-xl font-bold text-black" data-i18n="brand.name">Personnalité Comparée</span>
             </div>
-            <div class="language-switcher ml-4 flex gap-0 text-sm font-bold">
-                <button onclick="switchLang('fr')" data-i18n="lang.fr">FR</button><span> | </span><button onclick="switchLang('en')" data-i18n="lang.en">EN</button>
+            <div class="relative ml-4">
+                <button id="lang-toggle" class="p-2" aria-haspopup="true" aria-expanded="false">
+                    <svg class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M21 12A9 9 0 113 12a9 9 0 0118 0z"/><path stroke-linecap="round" stroke-linejoin="round" d="M3.6 9h16.8M3.6 15h16.8M12 3.6v16.8"/></svg>
+                </button>
+                <div id="lang-menu" class="absolute right-0 mt-2 w-32 bg-white rounded-md shadow-lg ring-1 ring-black/5 hidden z-50">
+                    <button data-lang="en" class="flex items-center w-full px-4 py-2 text-sm hover:bg-gray-100"><span class="mr-2">🇬🇧</span> English</button>
+                    <button data-lang="fr" class="flex items-center w-full px-4 py-2 text-sm hover:bg-gray-100"><span class="mr-2">🇫🇷</span> Français</button>
+                </div>
             </div>
         </div>
         <nav class="desktop-nav hidden md:ml-6 md:flex md:items-center md:space-x-8">

--- a/public/blog.html
+++ b/public/blog.html
@@ -399,8 +399,14 @@
             <div class="flex-shrink-0 flex items-center">
                 <img src="logo pc 3.png" alt="Personnalité Comparée logo" class="w-10 h-10 rounded-full object-cover"><span id="brand-home" class="ml-3 text-[1.05rem] sm:text-xl font-bold text-black" data-i18n="brand.name">Personnalité Comparée</span>
             </div>
-            <div class="language-switcher ml-4 flex gap-0 text-sm font-bold">
-                <button onclick="switchLang('fr')" data-i18n="lang.fr">FR</button><span> | </span><button onclick="switchLang('en')" data-i18n="lang.en">EN</button>
+            <div class="relative ml-4">
+                <button id="lang-toggle" class="p-2" aria-haspopup="true" aria-expanded="false">
+                    <svg class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M21 12A9 9 0 113 12a9 9 0 0118 0z"/><path stroke-linecap="round" stroke-linejoin="round" d="M3.6 9h16.8M3.6 15h16.8M12 3.6v16.8"/></svg>
+                </button>
+                <div id="lang-menu" class="absolute right-0 mt-2 w-32 bg-white rounded-md shadow-lg ring-1 ring-black/5 hidden z-50">
+                    <button data-lang="en" class="flex items-center w-full px-4 py-2 text-sm hover:bg-gray-100"><span class="mr-2">🇬🇧</span> English</button>
+                    <button data-lang="fr" class="flex items-center w-full px-4 py-2 text-sm hover:bg-gray-100"><span class="mr-2">🇫🇷</span> Français</button>
+                </div>
             </div>
         </div>
         <nav class="desktop-nav hidden md:ml-6 md:flex md:items-center md:space-x-8">

--- a/public/enneagramme.html
+++ b/public/enneagramme.html
@@ -399,8 +399,14 @@
             <div class="flex-shrink-0 flex items-center">
                 <img src="logo pc 3.png" alt="Personnalité Comparée logo" class="w-10 h-10 rounded-full object-cover"><span id="brand-home" class="ml-3 text-[1.05rem] sm:text-xl font-bold text-black" data-i18n="brand.name">Personnalité Comparée</span>
             </div>
-            <div class="language-switcher ml-4 flex gap-0 text-sm font-bold">
-                <button onclick="switchLang('fr')" data-i18n="lang.fr">FR</button><span> | </span><button onclick="switchLang('en')" data-i18n="lang.en">EN</button>
+            <div class="relative ml-4">
+                <button id="lang-toggle" class="p-2" aria-haspopup="true" aria-expanded="false">
+                    <svg class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M21 12A9 9 0 113 12a9 9 0 0118 0z"/><path stroke-linecap="round" stroke-linejoin="round" d="M3.6 9h16.8M3.6 15h16.8M12 3.6v16.8"/></svg>
+                </button>
+                <div id="lang-menu" class="absolute right-0 mt-2 w-32 bg-white rounded-md shadow-lg ring-1 ring-black/5 hidden z-50">
+                    <button data-lang="en" class="flex items-center w-full px-4 py-2 text-sm hover:bg-gray-100"><span class="mr-2">🇬🇧</span> English</button>
+                    <button data-lang="fr" class="flex items-center w-full px-4 py-2 text-sm hover:bg-gray-100"><span class="mr-2">🇫🇷</span> Français</button>
+                </div>
             </div>
         </div>
         <nav class="desktop-nav hidden md:ml-6 md:flex md:items-center md:space-x-8">

--- a/public/index.html
+++ b/public/index.html
@@ -433,8 +433,14 @@
             <div class="flex-shrink-0 flex items-center">
                 <img src="logo pc 3.png" alt="Personnalité Comparée logo" class="w-10 h-10 rounded-full object-cover"><span id="brand-home" class="ml-3 text-[1.05rem] sm:text-xl font-bold text-black" data-i18n="brand.name">Personnalité Comparée</span>
             </div>
-            <div class="language-switcher ml-4 flex gap-0 text-sm font-bold">
-                <button onclick="switchLang('fr'); updatePlaceholders();" data-i18n="lang.fr">FR</button><span> | </span><button onclick="switchLang('en'); updatePlaceholders();" data-i18n="lang.en">EN</button>
+            <div class="relative ml-4">
+                <button id="lang-toggle" class="p-2" aria-haspopup="true" aria-expanded="false">
+                    <svg class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M21 12A9 9 0 113 12a9 9 0 0118 0z"/><path stroke-linecap="round" stroke-linejoin="round" d="M3.6 9h16.8M3.6 15h16.8M12 3.6v16.8"/></svg>
+                </button>
+                <div id="lang-menu" class="absolute right-0 mt-2 w-32 bg-white rounded-md shadow-lg ring-1 ring-black/5 hidden z-50">
+                    <button data-lang="en" class="flex items-center w-full px-4 py-2 text-sm hover:bg-gray-100"><span class="mr-2">🇬🇧</span> English</button>
+                    <button data-lang="fr" class="flex items-center w-full px-4 py-2 text-sm hover:bg-gray-100"><span class="mr-2">🇫🇷</span> Français</button>
+                </div>
             </div>
         </div>
         <nav class="desktop-nav hidden md:ml-6 md:flex md:items-center md:space-x-8">

--- a/public/mbti.html
+++ b/public/mbti.html
@@ -399,8 +399,14 @@
             <div class="flex-shrink-0 flex items-center">
                 <img src="logo pc 3.png" alt="Personnalité Comparée logo" class="w-10 h-10 rounded-full object-cover"><span id="brand-home" class="ml-3 text-[1.05rem] sm:text-xl font-bold text-black" data-i18n="brand.name">Personnalité Comparée</span>
             </div>
-            <div class="language-switcher ml-4 flex gap-0 text-sm font-bold">
-                <button onclick="switchLang('fr')" data-i18n="lang.fr">FR</button><span> | </span><button onclick="switchLang('en')" data-i18n="lang.en">EN</button>
+            <div class="relative ml-4">
+                <button id="lang-toggle" class="p-2" aria-haspopup="true" aria-expanded="false">
+                    <svg class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M21 12A9 9 0 113 12a9 9 0 0118 0z"/><path stroke-linecap="round" stroke-linejoin="round" d="M3.6 9h16.8M3.6 15h16.8M12 3.6v16.8"/></svg>
+                </button>
+                <div id="lang-menu" class="absolute right-0 mt-2 w-32 bg-white rounded-md shadow-lg ring-1 ring-black/5 hidden z-50">
+                    <button data-lang="en" class="flex items-center w-full px-4 py-2 text-sm hover:bg-gray-100"><span class="mr-2">🇬🇧</span> English</button>
+                    <button data-lang="fr" class="flex items-center w-full px-4 py-2 text-sm hover:bg-gray-100"><span class="mr-2">🇫🇷</span> Français</button>
+                </div>
             </div>
         </div>
         <nav class="desktop-nav hidden md:ml-6 md:flex md:items-center md:space-x-8">

--- a/public/nav.js
+++ b/public/nav.js
@@ -127,12 +127,41 @@
       });
     }
 
-    const supportLink = document.getElementById('support-link');
-    if (supportLink) {
-      supportLink.addEventListener('click', function(e) {
-        e.preventDefault();
-        showSupport();
-      });
-    }
-  });
-})();
+      const supportLink = document.getElementById('support-link');
+      if (supportLink) {
+        supportLink.addEventListener('click', function(e) {
+          e.preventDefault();
+          showSupport();
+        });
+      }
+
+      const langToggle=document.getElementById('lang-toggle');
+      const langMenu=document.getElementById('lang-menu');
+      if(langToggle&&langMenu){
+        const changeLanguage=lang=>{
+          if(window.i18n&&typeof i18n.setLanguage==='function'){
+            i18n.setLanguage(lang);
+          }
+          if(typeof renderI18n==='function') renderI18n();
+          if(typeof switchLang==='function') switchLang(lang);
+          if(typeof applyTranslations==='function') applyTranslations();
+          if(typeof updatePlaceholders==='function') updatePlaceholders();
+        };
+        langToggle.addEventListener('click',e=>{
+          e.stopPropagation();
+          langMenu.classList.toggle('hidden');
+        });
+        langMenu.querySelectorAll('button[data-lang]').forEach(btn=>{
+          btn.addEventListener('click',()=>{
+            changeLanguage(btn.getAttribute('data-lang'));
+            langMenu.classList.add('hidden');
+          });
+        });
+        document.addEventListener('click',e=>{
+          if(!langMenu.contains(e.target)&&!langToggle.contains(e.target)){
+            langMenu.classList.add('hidden');
+          }
+        });
+      }
+    });
+  })();


### PR DESCRIPTION
## Summary
- replace FR|EN language toggle in header with globe icon and dropdown across pages
- add flag icons and invoke `i18n.setLanguage` and `renderI18n` when a language is chosen
- centralize dropdown logic in `nav.js`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aa30f010b88321b947432de07cd475