### PR TITLE
Fix language switch and questionnaire navigation

### DIFF
--- a/public/blog.html
+++ b/public/blog.html
@@ -625,7 +625,17 @@
     <script>
         // Configuration et données
                 // Récupère les questions externes depuis Supabase si l'utilisateur est un proche
-let questions = AUTO_QUESTIONS;
+let questions = LANG[document.documentElement.lang || 'fr'].AUTO_QUESTIONS;
+let externalQuestions = LANG[document.documentElement.lang || 'fr'].EXTERNAL_QUESTIONS;
+
+function enrichExternalQuestions() {
+    externalQuestions.forEach(q => {
+        if (!q.options.some(opt => opt.text === 'Je ne sais pas')) {
+            q.options.push({ text: 'Je ne sais pas', functions: {}, enneagram: {} });
+        }
+    });
+}
+enrichExternalQuestions();
 // 🔐 Génére un code aléatoire
 function genererUniqueCode() {
   const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
@@ -668,7 +678,8 @@ if (window.location.href.includes("external")) {
       .eq("code", code)
       .then(({ data, error }) => {
         if (!error && data && data.length > 0 && data[0].external_questions) {
-          questions = data[0].external_questions;
+          externalQuestions = data[0].external_questions;
+          enrichExternalQuestions();
           console.log("Questions externes chargées :", questions);
           afficherQuestions(); // appel explicite
         } else {
@@ -700,6 +711,22 @@ if (window.location.href.includes("external")) {
             setupEvaluationForm();
             loadFirstQuestion();
             initCountUp();
+        }
+
+        function updateQuestionsLanguage() {
+            const lang = document.documentElement.lang || 'fr';
+            questions = LANG[lang].AUTO_QUESTIONS;
+            externalQuestions = LANG[lang].EXTERNAL_QUESTIONS;
+            enrichExternalQuestions();
+            displayQuestion(currentQuestionIndex);
+            updateNavigationButtons();
+            if (typeof displayExternalQuestion === 'function') {
+                displayExternalQuestion(currentExternalQuestionIndex);
+                updateExternalNavigationButtons();
+            }
+        }
+        if (typeof window !== 'undefined') {
+            window.updateQuestionsLanguage = updateQuestionsLanguage;
         }
 
         // Menu mobile
@@ -849,18 +876,18 @@ if (window.location.href.includes("external")) {
        // Affichage d'une question
 function displayQuestion(index) {
   const questionsContainer = document.getElementById('questions-container');
-  const question = AUTO_QUESTIONS[index];
+  const question = questions[index];
 
   if (!question || !questionsContainer) return;
 
-  const progress = ((index + 1) / AUTO_QUESTIONS.length) * 100;
+  const progress = ((index + 1) / questions.length) * 100;
 
   const questionHTML = `
     <div class="question-container fade active bg-transparent overflow-hidden">
       <div class="px-6 py-4">
         <div class="flex justify-between items-center mb-4">
           <span class="text-sm font-medium text-blue-600">
-            <span data-i18n="question.label">Question</span> ${index + 1}/${AUTO_QUESTIONS.length}
+            <span data-i18n="question.label">Question</span> ${index + 1}/${questions.length}
           </span>
           <div class="w-full bg-gray-200 rounded-full h-2.5 ml-4">
             <div class="progress-bar bg-blue-600 h-2.5 rounded-full transition-all duration-500"
@@ -928,8 +955,8 @@ function displayQuestion(index) {
             
             if (nextButton) {
                 nextButton.addEventListener('click', function() {
-                    if (answers[AUTO_QUESTIONS[currentQuestionIndex].id] !== undefined) {
-                        if (currentQuestionIndex < AUTO_QUESTIONS.length - 1) {
+                    if (answers[questions[currentQuestionIndex].id] !== undefined) {
+                        if (currentQuestionIndex < questions.length - 1) {
                             currentQuestionIndex++;
                             displayQuestion(currentQuestionIndex);
                         }
@@ -941,7 +968,7 @@ function displayQuestion(index) {
             
             if (finishButton) {
                 finishButton.addEventListener('click', function() {
-                    if (Object.keys(answers).length === AUTO_QUESTIONS.length) {
+                    if (Object.keys(answers).length === questions.length) {
                         calculateResults();
                     } else {
                         alert('Veuillez répondre à toutes les questions avant de terminer.');
@@ -960,8 +987,8 @@ function displayQuestion(index) {
                 prevButton.style.display = currentQuestionIndex > 0 ? 'inline-flex' : 'none';
             }
             
-            const isLastQuestion = currentQuestionIndex === AUTO_QUESTIONS.length - 1;
-            const hasAnswer = answers[AUTO_QUESTIONS[currentQuestionIndex].id] !== undefined;
+            const isLastQuestion = currentQuestionIndex === questions.length - 1;
+            const hasAnswer = answers[questions[currentQuestionIndex].id] !== undefined;
             
             if (nextButton && finishButton) {
                 if (isLastQuestion) {
@@ -1368,7 +1395,7 @@ async function calculateResults() {
     Object.keys(answers).forEach(questionId => {
         const questionIndex = parseInt(questionId) - 1;
         const answerIndex = answers[questionId];
-        const question = AUTO_QUESTIONS[questionIndex];
+        const question = questions[questionIndex];
         const selectedOption = question.options[answerIndex];
         
         Object.keys(selectedOption.mbti).forEach(trait => {
@@ -2716,22 +2743,24 @@ function showSupport() {
         
         // Questions pour l'évaluation externe (20 questions)
         // Ajout de l'option "Je ne sais pas" à chaque question d'évaluation externe
-        EXTERNAL_QUESTIONS.forEach(q => {
-            q.options.push({ text: "Je ne sais pas", functions: {}, enneagram: {} });
+        externalQuestions.forEach(q => {
+            if (!q.options.some(opt => opt.text === "Je ne sais pas")) {
+                q.options.push({ text: "Je ne sais pas", functions: {}, enneagram: {} });
+            }
         });
 
         // Fonction pour afficher une question externe
         function displayExternalQuestion(index) {
-            const question = EXTERNAL_QUESTIONS[index];
+            const question = externalQuestions[index];
             if (!question) return;
-            
-            const progress = ((index + 1) / EXTERNAL_QUESTIONS.length) * 100;
+
+            const progress = ((index + 1) / externalQuestions.length) * 100;
             const questionsContent = document.getElementById('external-questions-content');
             
             questionsContent.innerHTML = `
                 <div class="mb-4">
                     <div class="flex justify-between items-center mb-4">
-                        <span class="text-sm font-medium text-blue-600"><span data-i18n="question.label">Question</span> ${index + 1}/${EXTERNAL_QUESTIONS.length}</span>
+                        <span class="text-sm font-medium text-blue-600"><span data-i18n="question.label">Question</span> ${index + 1}/${externalQuestions.length}</span>
                         <div class="w-full bg-gray-200 rounded-full h-2.5 ml-4">
                             <div class="bg-blue-600 h-2.5 rounded-full transition-all duration-500" style="width: ${progress}%"></div>
                         </div>
@@ -2787,8 +2816,8 @@ function showSupport() {
             
             if (nextButton) {
                 nextButton.addEventListener('click', function() {
-                    if (externalAnswers[EXTERNAL_QUESTIONS[currentExternalQuestionIndex].id] !== undefined) {
-                        if (currentExternalQuestionIndex < EXTERNAL_QUESTIONS.length - 1) {
+                    if (externalAnswers[externalQuestions[currentExternalQuestionIndex].id] !== undefined) {
+                        if (currentExternalQuestionIndex < externalQuestions.length - 1) {
                             currentExternalQuestionIndex++;
                             displayExternalQuestion(currentExternalQuestionIndex);
                         }
@@ -2809,8 +2838,8 @@ function showSupport() {
                 prevButton.style.display = currentExternalQuestionIndex > 0 ? 'inline-flex' : 'none';
             }
 
-            const isLastQuestion = currentExternalQuestionIndex === EXTERNAL_QUESTIONS.length - 1;
-            const hasAnswer = externalAnswers[EXTERNAL_QUESTIONS[currentExternalQuestionIndex].id] !== undefined;
+            const isLastQuestion = currentExternalQuestionIndex === externalQuestions.length - 1;
+            const hasAnswer = externalAnswers[externalQuestions[currentExternalQuestionIndex].id] !== undefined;
 
             if (nextButton && finishButton) {
                 if (isLastQuestion) {
@@ -2859,7 +2888,7 @@ function showSupport() {
             form.addEventListener('submit', async function(e) {
                 e.preventDefault();
                 if (btn.disabled) return;
-                if (Object.keys(externalAnswers).length !== EXTERNAL_QUESTIONS.length) {
+                if (Object.keys(externalAnswers).length !== externalQuestions.length) {
                     alert('Veuillez répondre à toutes les questions avant de terminer.');
                     return;
                 }
@@ -2899,7 +2928,7 @@ function showSupport() {
             const mbtiScores = { E: 0, I: 0, S: 0, N: 0, T: 0, F: 0, J: 0, P: 0 };
             const enneagramScores = { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0, 6: 0, 7: 0, 8: 0, 9: 0 };
             Object.keys(externalAnswers).forEach(questionId => {
-                const question = EXTERNAL_QUESTIONS.find(q => q.id === parseInt(questionId));
+                const question = externalQuestions.find(q => q.id === parseInt(questionId));
                 const value = externalAnswers[questionId];
                 if (value === 0) {
                     return;

--- a/public/enneagramme.html
+++ b/public/enneagramme.html
@@ -1050,7 +1050,17 @@
     <script>
         // Configuration et données
                 // Récupère les questions externes depuis Supabase si l'utilisateur est un proche
-let questions = AUTO_QUESTIONS;
+let questions = LANG[document.documentElement.lang || 'fr'].AUTO_QUESTIONS;
+let externalQuestions = LANG[document.documentElement.lang || 'fr'].EXTERNAL_QUESTIONS;
+
+function enrichExternalQuestions() {
+    externalQuestions.forEach(q => {
+        if (!q.options.some(opt => opt.text === 'Je ne sais pas')) {
+            q.options.push({ text: 'Je ne sais pas', functions: {}, enneagram: {} });
+        }
+    });
+}
+enrichExternalQuestions();
 // 🔐 Génére un code aléatoire
 function genererUniqueCode() {
   const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
@@ -1093,7 +1103,8 @@ if (window.location.href.includes("external")) {
       .eq("code", code)
       .then(({ data, error }) => {
         if (!error && data && data.length > 0 && data[0].external_questions) {
-          questions = data[0].external_questions;
+          externalQuestions = data[0].external_questions;
+          enrichExternalQuestions();
           console.log("Questions externes chargées :", questions);
           afficherQuestions(); // appel explicite
         } else {
@@ -1125,6 +1136,22 @@ if (window.location.href.includes("external")) {
             setupEvaluationForm();
             loadFirstQuestion();
             initCountUp();
+        }
+
+        function updateQuestionsLanguage() {
+            const lang = document.documentElement.lang || 'fr';
+            questions = LANG[lang].AUTO_QUESTIONS;
+            externalQuestions = LANG[lang].EXTERNAL_QUESTIONS;
+            enrichExternalQuestions();
+            displayQuestion(currentQuestionIndex);
+            updateNavigationButtons();
+            if (typeof displayExternalQuestion === 'function') {
+                displayExternalQuestion(currentExternalQuestionIndex);
+                updateExternalNavigationButtons();
+            }
+        }
+        if (typeof window !== 'undefined') {
+            window.updateQuestionsLanguage = updateQuestionsLanguage;
         }
 
         // Menu mobile
@@ -1280,18 +1307,18 @@ if (window.location.href.includes("external")) {
        // Affichage d'une question
 function displayQuestion(index) {
   const questionsContainer = document.getElementById('questions-container');
-  const question = AUTO_QUESTIONS[index];
+  const question = questions[index];
 
   if (!question || !questionsContainer) return;
 
-  const progress = ((index + 1) / AUTO_QUESTIONS.length) * 100;
+  const progress = ((index + 1) / questions.length) * 100;
 
   const questionHTML = `
     <div class="question-container fade active bg-transparent overflow-hidden">
       <div class="px-6 py-4">
         <div class="flex justify-between items-center mb-4">
           <span class="text-sm font-medium text-blue-600">
-            Question ${index + 1}/${AUTO_QUESTIONS.length}
+            Question ${index + 1}/${questions.length}
           </span>
           <div class="w-full bg-gray-200 rounded-full h-2.5 ml-4">
             <div class="progress-bar bg-blue-600 h-2.5 rounded-full transition-all duration-500"
@@ -1359,8 +1386,8 @@ function displayQuestion(index) {
             
             if (nextButton) {
                 nextButton.addEventListener('click', function() {
-                    if (answers[AUTO_QUESTIONS[currentQuestionIndex].id] !== undefined) {
-                        if (currentQuestionIndex < AUTO_QUESTIONS.length - 1) {
+                    if (answers[questions[currentQuestionIndex].id] !== undefined) {
+                        if (currentQuestionIndex < questions.length - 1) {
                             currentQuestionIndex++;
                             displayQuestion(currentQuestionIndex);
                         }
@@ -1372,7 +1399,7 @@ function displayQuestion(index) {
             
             if (finishButton) {
                 finishButton.addEventListener('click', function() {
-                    if (Object.keys(answers).length === AUTO_QUESTIONS.length) {
+                    if (Object.keys(answers).length === questions.length) {
                         calculateResults();
                     } else {
                         alert('Veuillez répondre à toutes les questions avant de terminer.');
@@ -1391,8 +1418,8 @@ function displayQuestion(index) {
                 prevButton.style.display = currentQuestionIndex > 0 ? 'inline-flex' : 'none';
             }
             
-            const isLastQuestion = currentQuestionIndex === AUTO_QUESTIONS.length - 1;
-            const hasAnswer = answers[AUTO_QUESTIONS[currentQuestionIndex].id] !== undefined;
+            const isLastQuestion = currentQuestionIndex === questions.length - 1;
+            const hasAnswer = answers[questions[currentQuestionIndex].id] !== undefined;
             
             if (nextButton && finishButton) {
                 if (isLastQuestion) {
@@ -1799,7 +1826,7 @@ async function calculateResults() {
     Object.keys(answers).forEach(questionId => {
         const questionIndex = parseInt(questionId) - 1;
         const answerIndex = answers[questionId];
-        const question = AUTO_QUESTIONS[questionIndex];
+        const question = questions[questionIndex];
         const selectedOption = question.options[answerIndex];
         
         Object.keys(selectedOption.mbti).forEach(trait => {
@@ -3145,22 +3172,24 @@ function showSupport() {
         
         // Questions pour l'évaluation externe (20 questions)
         // Ajout de l'option "Je ne sais pas" à chaque question d'évaluation externe
-        EXTERNAL_QUESTIONS.forEach(q => {
-            q.options.push({ text: "Je ne sais pas", functions: {}, enneagram: {} });
+        externalQuestions.forEach(q => {
+            if (!q.options.some(opt => opt.text === "Je ne sais pas")) {
+                q.options.push({ text: "Je ne sais pas", functions: {}, enneagram: {} });
+            }
         });
 
         // Fonction pour afficher une question externe
         function displayExternalQuestion(index) {
-            const question = EXTERNAL_QUESTIONS[index];
+            const question = externalQuestions[index];
             if (!question) return;
-            
-            const progress = ((index + 1) / EXTERNAL_QUESTIONS.length) * 100;
+
+            const progress = ((index + 1) / externalQuestions.length) * 100;
             const questionsContent = document.getElementById('external-questions-content');
             
             questionsContent.innerHTML = `
                 <div class="mb-4">
                     <div class="flex justify-between items-center mb-4">
-                        <span class="text-sm font-medium text-blue-600">Question ${index + 1}/${EXTERNAL_QUESTIONS.length}</span>
+                        <span class="text-sm font-medium text-blue-600">Question ${index + 1}/${externalQuestions.length}</span>
                         <div class="w-full bg-gray-200 rounded-full h-2.5 ml-4">
                             <div class="bg-blue-600 h-2.5 rounded-full transition-all duration-500" style="width: ${progress}%"></div>
                         </div>
@@ -3216,8 +3245,8 @@ function showSupport() {
             
             if (nextButton) {
                 nextButton.addEventListener('click', function() {
-                    if (externalAnswers[EXTERNAL_QUESTIONS[currentExternalQuestionIndex].id] !== undefined) {
-                        if (currentExternalQuestionIndex < EXTERNAL_QUESTIONS.length - 1) {
+                    if (externalAnswers[externalQuestions[currentExternalQuestionIndex].id] !== undefined) {
+                        if (currentExternalQuestionIndex < externalQuestions.length - 1) {
                             currentExternalQuestionIndex++;
                             displayExternalQuestion(currentExternalQuestionIndex);
                         }
@@ -3238,8 +3267,8 @@ function showSupport() {
                 prevButton.style.display = currentExternalQuestionIndex > 0 ? 'inline-flex' : 'none';
             }
 
-            const isLastQuestion = currentExternalQuestionIndex === EXTERNAL_QUESTIONS.length - 1;
-            const hasAnswer = externalAnswers[EXTERNAL_QUESTIONS[currentExternalQuestionIndex].id] !== undefined;
+            const isLastQuestion = currentExternalQuestionIndex === externalQuestions.length - 1;
+            const hasAnswer = externalAnswers[externalQuestions[currentExternalQuestionIndex].id] !== undefined;
 
             if (nextButton && finishButton) {
                 if (isLastQuestion) {
@@ -3288,7 +3317,7 @@ function showSupport() {
             form.addEventListener('submit', async function(e) {
                 e.preventDefault();
                 if (btn.disabled) return;
-                if (Object.keys(externalAnswers).length !== EXTERNAL_QUESTIONS.length) {
+                if (Object.keys(externalAnswers).length !== externalQuestions.length) {
                     alert('Veuillez répondre à toutes les questions avant de terminer.');
                     return;
                 }
@@ -3328,7 +3357,7 @@ function showSupport() {
             const mbtiScores = { E: 0, I: 0, S: 0, N: 0, T: 0, F: 0, J: 0, P: 0 };
             const enneagramScores = { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0, 6: 0, 7: 0, 8: 0, 9: 0 };
             Object.keys(externalAnswers).forEach(questionId => {
-                const question = EXTERNAL_QUESTIONS.find(q => q.id === parseInt(questionId));
+                const question = externalQuestions.find(q => q.id === parseInt(questionId));
                 const value = externalAnswers[questionId];
                 if (value === 0) {
                     return;

--- a/public/index.html
+++ b/public/index.html
@@ -1116,7 +1116,17 @@
    <script>
         // Configuration et données
                 // Récupère les questions externes depuis Supabase si l'utilisateur est un proche
-let questions = AUTO_QUESTIONS;
+let questions = LANG[document.documentElement.lang || 'fr'].AUTO_QUESTIONS;
+let externalQuestions = LANG[document.documentElement.lang || 'fr'].EXTERNAL_QUESTIONS;
+
+function enrichExternalQuestions() {
+    externalQuestions.forEach(q => {
+        if (!q.options.some(opt => opt.text === 'Je ne sais pas')) {
+            q.options.push({ text: 'Je ne sais pas', functions: {}, enneagram: {} });
+        }
+    });
+}
+enrichExternalQuestions();
 // 🔐 Génére un code aléatoire
 function genererUniqueCode() {
   
@@ -1160,8 +1170,9 @@ if (window.location.href.includes("external")) {
       .eq("code", code)
       .then(({ data, error }) => {
         if (!error && data && data.length > 0 && data[0].external_questions) {
-          questions = data[0].external_questions;
-          console.log("Questions externes chargées :", questions);
+          externalQuestions = data[0].external_questions;
+          enrichExternalQuestions();
+          console.log("Questions externes chargées :", externalQuestions);
           afficherQuestions(); // appel explicite
         } else {
           console.error("Aucune question externe trouvée ou erreur :", error);
@@ -1205,6 +1216,22 @@ if (window.location.href.includes("external")) {
                     el.placeholder = translation;
                 }
             });
+        }
+
+        function updateQuestionsLanguage() {
+            const lang = document.documentElement.lang || 'fr';
+            questions = LANG[lang].AUTO_QUESTIONS;
+            externalQuestions = LANG[lang].EXTERNAL_QUESTIONS;
+            enrichExternalQuestions();
+            displayQuestion(currentQuestionIndex);
+            updateNavigationButtons();
+            if (typeof displayExternalQuestion === 'function') {
+                displayExternalQuestion(currentExternalQuestionIndex);
+                updateExternalNavigationButtons();
+            }
+        }
+        if (typeof window !== 'undefined') {
+            window.updateQuestionsLanguage = updateQuestionsLanguage;
         }
 
         // Menu mobile
@@ -1384,18 +1411,18 @@ if (window.location.href.includes("external")) {
        // Affichage d'une question
 function displayQuestion(index) {
   const questionsContainer = document.getElementById('questions-container');
-  const question = AUTO_QUESTIONS[index];
+  const question = questions[index];
 
   if (!question || !questionsContainer) return;
 
-  const progress = ((index + 1) / AUTO_QUESTIONS.length) * 100;
+  const progress = ((index + 1) / questions.length) * 100;
 
   const questionHTML = `
     <div class="question-container fade active bg-transparent overflow-hidden">
       <div class="px-6 py-4">
         <div class="flex justify-between items-center mb-4">
           <span class="text-sm font-medium text-blue-600">
-            <span data-i18n="question.label">Question</span> ${index + 1}/${AUTO_QUESTIONS.length}
+            <span data-i18n="question.label">Question</span> ${index + 1}/${questions.length}
           </span>
           <div class="w-full bg-gray-200 rounded-full h-2.5 ml-4">
             <div class="progress-bar bg-blue-600 h-2.5 rounded-full transition-all duration-500"
@@ -1463,8 +1490,8 @@ function displayQuestion(index) {
             
             if (nextButton) {
                 nextButton.addEventListener('click', function() {
-                    if (answers[AUTO_QUESTIONS[currentQuestionIndex].id] !== undefined) {
-                        if (currentQuestionIndex < AUTO_QUESTIONS.length - 1) {
+                    if (answers[questions[currentQuestionIndex].id] !== undefined) {
+                        if (currentQuestionIndex < questions.length - 1) {
                             currentQuestionIndex++;
                             displayQuestion(currentQuestionIndex);
                         }
@@ -1476,7 +1503,7 @@ function displayQuestion(index) {
             
             if (finishButton) {
                 finishButton.addEventListener('click', function() {
-                    if (Object.keys(answers).length === AUTO_QUESTIONS.length) {
+                    if (Object.keys(answers).length === questions.length) {
                         calculateResults();
                     } else {
                         alert('Veuillez répondre à toutes les questions avant de terminer.');
@@ -1495,8 +1522,8 @@ function displayQuestion(index) {
                 prevButton.style.display = currentQuestionIndex > 0 ? 'inline-flex' : 'none';
             }
             
-            const isLastQuestion = currentQuestionIndex === AUTO_QUESTIONS.length - 1;
-            const hasAnswer = answers[AUTO_QUESTIONS[currentQuestionIndex].id] !== undefined;
+            const isLastQuestion = currentQuestionIndex === questions.length - 1;
+            const hasAnswer = answers[questions[currentQuestionIndex].id] !== undefined;
             
             if (nextButton && finishButton) {
                 if (isLastQuestion) {
@@ -1907,7 +1934,7 @@ async function calculateResults() {
     Object.keys(answers).forEach(questionId => {
         const questionIndex = parseInt(questionId) - 1;
         const answerIndex = answers[questionId];
-        const question = AUTO_QUESTIONS[questionIndex];
+        const question = questions[questionIndex];
         const selectedOption = question.options[answerIndex];
 
         Object.keys(selectedOption.functions).forEach(func => {
@@ -3239,22 +3266,24 @@ window.showSupport = showSupport;
         
         // Questions pour l'évaluation externe (20 questions)
         // Ajout de l'option "Je ne sais pas" à chaque question d'évaluation externe
-        EXTERNAL_QUESTIONS.forEach(q => {
-            q.options.push({ text: "Je ne sais pas", functions: {}, enneagram: {} });
+        externalQuestions.forEach(q => {
+            if (!q.options.some(opt => opt.text === "Je ne sais pas")) {
+                q.options.push({ text: "Je ne sais pas", functions: {}, enneagram: {} });
+            }
         });
 
         // Fonction pour afficher une question externe
         function displayExternalQuestion(index) {
-            const question = EXTERNAL_QUESTIONS[index];
+            const question = externalQuestions[index];
             if (!question) return;
-            
-            const progress = ((index + 1) / EXTERNAL_QUESTIONS.length) * 100;
+
+            const progress = ((index + 1) / externalQuestions.length) * 100;
             const questionsContent = document.getElementById('external-questions-content');
 
             questionsContent.innerHTML = `
                 <div class="mb-4">
                     <div class="flex justify-between items-center mb-4">
-                        <span class="text-sm font-medium text-blue-600"><span data-i18n="question.label">Question</span> ${index + 1}/${EXTERNAL_QUESTIONS.length}</span>
+                        <span class="text-sm font-medium text-blue-600"><span data-i18n="question.label">Question</span> ${index + 1}/${externalQuestions.length}</span>
                         <div class="w-full bg-gray-200 rounded-full h-2.5 ml-4">
                             <div class="bg-blue-600 h-2.5 rounded-full transition-all duration-500" style="width: ${progress}%"></div>
                         </div>
@@ -3310,8 +3339,8 @@ window.showSupport = showSupport;
             
             if (nextButton) {
                 nextButton.addEventListener('click', function() {
-                    if (externalAnswers[EXTERNAL_QUESTIONS[currentExternalQuestionIndex].id] !== undefined) {
-                        if (currentExternalQuestionIndex < EXTERNAL_QUESTIONS.length - 1) {
+                    if (externalAnswers[externalQuestions[currentExternalQuestionIndex].id] !== undefined) {
+                        if (currentExternalQuestionIndex < externalQuestions.length - 1) {
                             currentExternalQuestionIndex++;
                             displayExternalQuestion(currentExternalQuestionIndex);
                         }
@@ -3332,8 +3361,8 @@ window.showSupport = showSupport;
                 prevButton.style.display = currentExternalQuestionIndex > 0 ? 'inline-flex' : 'none';
             }
 
-            const isLastQuestion = currentExternalQuestionIndex === EXTERNAL_QUESTIONS.length - 1;
-            const hasAnswer = externalAnswers[EXTERNAL_QUESTIONS[currentExternalQuestionIndex].id] !== undefined;
+            const isLastQuestion = currentExternalQuestionIndex === externalQuestions.length - 1;
+            const hasAnswer = externalAnswers[externalQuestions[currentExternalQuestionIndex].id] !== undefined;
 
             if (nextButton && finishButton) {
                 if (isLastQuestion) {
@@ -3382,7 +3411,7 @@ window.showSupport = showSupport;
             form.addEventListener('submit', async function(e) {
                 e.preventDefault();
                 if (btn.disabled) return;
-                if (Object.keys(externalAnswers).length !== EXTERNAL_QUESTIONS.length) {
+                if (Object.keys(externalAnswers).length !== externalQuestions.length) {
                     alert('Veuillez répondre à toutes les questions avant de terminer.');
                     return;
                 }
@@ -3422,7 +3451,7 @@ window.showSupport = showSupport;
             const functionScores = { Fi: 0, Fe: 0, Ti: 0, Te: 0, Ni: 0, Ne: 0, Si: 0, Se: 0 };
             const enneagramScores = { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0, 6: 0, 7: 0, 8: 0, 9: 0 };
             Object.keys(externalAnswers).forEach(questionId => {
-                const question = EXTERNAL_QUESTIONS.find(q => q.id === parseInt(questionId));
+                const question = externalQuestions.find(q => q.id === parseInt(questionId));
                 const value = externalAnswers[questionId];
                 if (value === 0) {
                     return;

--- a/public/lang.js
+++ b/public/lang.js
@@ -2253,6 +2253,16 @@ const i18n = {
   t(key) {
     const lang = (typeof document !== 'undefined' && document.documentElement.lang) || 'fr';
     return key.split('.').reduce((obj, k) => obj && obj[k], translations[lang]) || key;
+  },
+  setLanguage(lang) {
+    if (translations[lang]) {
+      if (typeof document !== 'undefined') {
+        document.documentElement.setAttribute('lang', lang);
+      }
+      if (typeof localStorage !== 'undefined') {
+        localStorage.setItem('lang', lang);
+      }
+    }
   }
 };
 

--- a/public/mbti.html
+++ b/public/mbti.html
@@ -1146,7 +1146,17 @@
     <script>
         // Configuration et données
                 // Récupère les questions externes depuis Supabase si l'utilisateur est un proche
-let questions = AUTO_QUESTIONS;
+let questions = LANG[document.documentElement.lang || 'fr'].AUTO_QUESTIONS;
+let externalQuestions = LANG[document.documentElement.lang || 'fr'].EXTERNAL_QUESTIONS;
+
+function enrichExternalQuestions() {
+    externalQuestions.forEach(q => {
+        if (!q.options.some(opt => opt.text === 'Je ne sais pas')) {
+            q.options.push({ text: 'Je ne sais pas', functions: {}, enneagram: {} });
+        }
+    });
+}
+enrichExternalQuestions();
 // 🔐 Génére un code aléatoire
 function genererUniqueCode() {
   const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
@@ -1189,7 +1199,8 @@ if (window.location.href.includes("external")) {
       .eq("code", code)
       .then(({ data, error }) => {
         if (!error && data && data.length > 0 && data[0].external_questions) {
-          questions = data[0].external_questions;
+          externalQuestions = data[0].external_questions;
+          enrichExternalQuestions();
           console.log("Questions externes chargées :", questions);
           afficherQuestions(); // appel explicite
         } else {
@@ -1221,6 +1232,22 @@ if (window.location.href.includes("external")) {
             setupEvaluationForm();
             loadFirstQuestion();
             initCountUp();
+        }
+
+        function updateQuestionsLanguage() {
+            const lang = document.documentElement.lang || 'fr';
+            questions = LANG[lang].AUTO_QUESTIONS;
+            externalQuestions = LANG[lang].EXTERNAL_QUESTIONS;
+            enrichExternalQuestions();
+            displayQuestion(currentQuestionIndex);
+            updateNavigationButtons();
+            if (typeof displayExternalQuestion === 'function') {
+                displayExternalQuestion(currentExternalQuestionIndex);
+                updateExternalNavigationButtons();
+            }
+        }
+        if (typeof window !== 'undefined') {
+            window.updateQuestionsLanguage = updateQuestionsLanguage;
         }
 
         // Menu mobile
@@ -1376,18 +1403,18 @@ if (window.location.href.includes("external")) {
        // Affichage d'une question
 function displayQuestion(index) {
   const questionsContainer = document.getElementById('questions-container');
-  const question = AUTO_QUESTIONS[index];
+  const question = questions[index];
 
   if (!question || !questionsContainer) return;
 
-  const progress = ((index + 1) / AUTO_QUESTIONS.length) * 100;
+  const progress = ((index + 1) / questions.length) * 100;
 
   const questionHTML = `
     <div class="question-container fade active bg-transparent overflow-hidden">
       <div class="px-6 py-4">
         <div class="flex justify-between items-center mb-4">
           <span class="text-sm font-medium text-blue-600">
-            Question ${index + 1}/${AUTO_QUESTIONS.length}
+            Question ${index + 1}/${questions.length}
           </span>
           <div class="w-full bg-gray-200 rounded-full h-2.5 ml-4">
             <div class="progress-bar bg-blue-600 h-2.5 rounded-full transition-all duration-500"
@@ -1455,8 +1482,8 @@ function displayQuestion(index) {
             
             if (nextButton) {
                 nextButton.addEventListener('click', function() {
-                    if (answers[AUTO_QUESTIONS[currentQuestionIndex].id] !== undefined) {
-                        if (currentQuestionIndex < AUTO_QUESTIONS.length - 1) {
+                    if (answers[questions[currentQuestionIndex].id] !== undefined) {
+                        if (currentQuestionIndex < questions.length - 1) {
                             currentQuestionIndex++;
                             displayQuestion(currentQuestionIndex);
                         }
@@ -1468,7 +1495,7 @@ function displayQuestion(index) {
             
             if (finishButton) {
                 finishButton.addEventListener('click', function() {
-                    if (Object.keys(answers).length === AUTO_QUESTIONS.length) {
+                    if (Object.keys(answers).length === questions.length) {
                         calculateResults();
                     } else {
                         alert('Veuillez répondre à toutes les questions avant de terminer.');
@@ -1487,8 +1514,8 @@ function displayQuestion(index) {
                 prevButton.style.display = currentQuestionIndex > 0 ? 'inline-flex' : 'none';
             }
             
-            const isLastQuestion = currentQuestionIndex === AUTO_QUESTIONS.length - 1;
-            const hasAnswer = answers[AUTO_QUESTIONS[currentQuestionIndex].id] !== undefined;
+            const isLastQuestion = currentQuestionIndex === questions.length - 1;
+            const hasAnswer = answers[questions[currentQuestionIndex].id] !== undefined;
             
             if (nextButton && finishButton) {
                 if (isLastQuestion) {
@@ -1895,7 +1922,7 @@ async function calculateResults() {
     Object.keys(answers).forEach(questionId => {
         const questionIndex = parseInt(questionId) - 1;
         const answerIndex = answers[questionId];
-        const question = AUTO_QUESTIONS[questionIndex];
+        const question = questions[questionIndex];
         const selectedOption = question.options[answerIndex];
         
         Object.keys(selectedOption.mbti).forEach(trait => {
@@ -3237,22 +3264,24 @@ function showSupport() {
         
         // Questions pour l'évaluation externe (20 questions)
         // Ajout de l'option "Je ne sais pas" à chaque question d'évaluation externe
-        EXTERNAL_QUESTIONS.forEach(q => {
-            q.options.push({ text: "Je ne sais pas", functions: {}, enneagram: {} });
+        externalQuestions.forEach(q => {
+            if (!q.options.some(opt => opt.text === "Je ne sais pas")) {
+                q.options.push({ text: "Je ne sais pas", functions: {}, enneagram: {} });
+            }
         });
 
         // Fonction pour afficher une question externe
         function displayExternalQuestion(index) {
-            const question = EXTERNAL_QUESTIONS[index];
+            const question = externalQuestions[index];
             if (!question) return;
-            
-            const progress = ((index + 1) / EXTERNAL_QUESTIONS.length) * 100;
+
+            const progress = ((index + 1) / externalQuestions.length) * 100;
             const questionsContent = document.getElementById('external-questions-content');
             
             questionsContent.innerHTML = `
                 <div class="mb-4">
                     <div class="flex justify-between items-center mb-4">
-                        <span class="text-sm font-medium text-blue-600">Question ${index + 1}/${EXTERNAL_QUESTIONS.length}</span>
+                        <span class="text-sm font-medium text-blue-600">Question ${index + 1}/${externalQuestions.length}</span>
                         <div class="w-full bg-gray-200 rounded-full h-2.5 ml-4">
                             <div class="bg-blue-600 h-2.5 rounded-full transition-all duration-500" style="width: ${progress}%"></div>
                         </div>
@@ -3308,8 +3337,8 @@ function showSupport() {
             
             if (nextButton) {
                 nextButton.addEventListener('click', function() {
-                    if (externalAnswers[EXTERNAL_QUESTIONS[currentExternalQuestionIndex].id] !== undefined) {
-                        if (currentExternalQuestionIndex < EXTERNAL_QUESTIONS.length - 1) {
+                    if (externalAnswers[externalQuestions[currentExternalQuestionIndex].id] !== undefined) {
+                        if (currentExternalQuestionIndex < externalQuestions.length - 1) {
                             currentExternalQuestionIndex++;
                             displayExternalQuestion(currentExternalQuestionIndex);
                         }
@@ -3330,8 +3359,8 @@ function showSupport() {
                 prevButton.style.display = currentExternalQuestionIndex > 0 ? 'inline-flex' : 'none';
             }
 
-            const isLastQuestion = currentExternalQuestionIndex === EXTERNAL_QUESTIONS.length - 1;
-            const hasAnswer = externalAnswers[EXTERNAL_QUESTIONS[currentExternalQuestionIndex].id] !== undefined;
+            const isLastQuestion = currentExternalQuestionIndex === externalQuestions.length - 1;
+            const hasAnswer = externalAnswers[externalQuestions[currentExternalQuestionIndex].id] !== undefined;
 
             if (nextButton && finishButton) {
                 if (isLastQuestion) {
@@ -3380,7 +3409,7 @@ function showSupport() {
             form.addEventListener('submit', async function(e) {
                 e.preventDefault();
                 if (btn.disabled) return;
-                if (Object.keys(externalAnswers).length !== EXTERNAL_QUESTIONS.length) {
+                if (Object.keys(externalAnswers).length !== externalQuestions.length) {
                     alert('Veuillez répondre à toutes les questions avant de terminer.');
                     return;
                 }
@@ -3420,7 +3449,7 @@ function showSupport() {
             const mbtiScores = { E: 0, I: 0, S: 0, N: 0, T: 0, F: 0, J: 0, P: 0 };
             const enneagramScores = { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0, 6: 0, 7: 0, 8: 0, 9: 0 };
             Object.keys(externalAnswers).forEach(questionId => {
-                const question = EXTERNAL_QUESTIONS.find(q => q.id === parseInt(questionId));
+                const question = externalQuestions.find(q => q.id === parseInt(questionId));
                 const value = externalAnswers[questionId];
                 if (value === 0) {
                     return;

--- a/public/nav.js
+++ b/public/nav.js
@@ -146,6 +146,7 @@
           if(typeof switchLang==='function') switchLang(lang);
           if(typeof applyTranslations==='function') applyTranslations();
           if(typeof updatePlaceholders==='function') updatePlaceholders();
+          if(typeof updateQuestionsLanguage==='function') updateQuestionsLanguage();
         };
         langToggle.addEventListener('click',e=>{
           e.stopPropagation();


### PR DESCRIPTION
## Summary
- Restore header language toggle by adding `setLanguage` helper and updating navigation script
- Replace hard-coded question arrays with language-aware versions so next/finish buttons work
- Ensure external evaluation questionnaire updates and navigates correctly

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68aa53ddcb2883218fe3dc0a0ad0081f