### PR TITLE
Fix language switch and auto-evaluation initialization

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1112,12 +1112,12 @@
         </div>
     </footer>
     <script src="questions-v2.js"></script>
-      
+
    <script>
         // Configuration et données
-                // Récupère les questions externes depuis Supabase si l'utilisateur est un proche
-let questions = LANG[document.documentElement.lang || 'fr'].AUTO_QUESTIONS;
-let externalQuestions = LANG[document.documentElement.lang || 'fr'].EXTERNAL_QUESTIONS;
+        // Récupère les questions externes depuis Supabase si l'utilisateur est un proche
+let questions = [];
+let externalQuestions = [];
 
 function enrichExternalQuestions() {
     externalQuestions.forEach(q => {
@@ -1126,7 +1126,15 @@ function enrichExternalQuestions() {
         }
     });
 }
-enrichExternalQuestions();
+
+function loadQuestions() {
+    const lang = document.documentElement.lang || 'fr';
+    if (window.LANG && window.LANG[lang]) {
+        questions = window.LANG[lang].AUTO_QUESTIONS;
+        externalQuestions = window.LANG[lang].EXTERNAL_QUESTIONS;
+        enrichExternalQuestions();
+    }
+}
 // 🔐 Génére un code aléatoire
 function genererUniqueCode() {
   
@@ -1196,6 +1204,7 @@ if (window.location.href.includes("external")) {
         });
 
         function initializeApp() {
+            loadQuestions();
             setupMobileMenu();
             setupDesktopDropdowns();
             setupFAQ();
@@ -1219,10 +1228,7 @@ if (window.location.href.includes("external")) {
         }
 
         function updateQuestionsLanguage() {
-            const lang = document.documentElement.lang || 'fr';
-            questions = LANG[lang].AUTO_QUESTIONS;
-            externalQuestions = LANG[lang].EXTERNAL_QUESTIONS;
-            enrichExternalQuestions();
+            loadQuestions();
             displayQuestion(currentQuestionIndex);
             updateNavigationButtons();
             if (typeof displayExternalQuestion === 'function') {

--- a/public/lang.js
+++ b/public/lang.js
@@ -2299,6 +2299,8 @@ const LANG = {
 };
 
 if (typeof window !== 'undefined') {
+  window.translations = translations;
+  window.i18n = i18n;
   window.LANG = LANG;
 }
 


### PR DESCRIPTION
## Summary
- expose translation helpers globally so header language toggle works
- load questionnaire data after translations are ready and reload when language changes

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aa56080568832181fefdcb07a0dc9f