### PR TITLE
feat: add English question translations

### DIFF
--- a/public/questions-v2.js
+++ b/public/questions-v2.js
@@ -380,12 +380,360 @@ const EXTERNAL_QUESTIONS = [
   }
 ];
 
+const AUTO_TRANSLATIONS_EN = {
+  1: {
+    question: "When a plan goes off track, what do you do first?",
+    options: [
+      "I question point by point until it's clear.",
+      "I reframe and set a simple, measurable plan.",
+      "I step back to grasp the overall meaning.",
+      "I test live and adjust as I go."
+    ]
+  },
+  2: {
+    question: "Faced with a delicate decision:",
+    options: [
+      "I stay true to my convictions, even if it's unpopular.",
+      "I weigh the human impact and group cohesion.",
+      "I decide based on efficiency and priorities.",
+      "I check logical consistency above all."
+    ]
+  },
+  3: {
+    question: "Your way of learning something new:",
+    options: [
+      "I link concepts to reliable past experiences.",
+      "I pick up subtle cues and anticipate what's next.",
+      "I explore several paths in parallel out of curiosity.",
+      "I handle things directly to feel how they respond."
+    ]
+  },
+  4: {
+    question: "In a conflict:",
+    options: [
+      "I protect the group's peace and soothe tensions.",
+      "I stand firm with my values, even if it offends.",
+      "I set criteria and propose an exit structure.",
+      "I clarify areas of inconsistency to defuse."
+    ]
+  },
+  5: {
+    question: "When you start a project:",
+    options: [
+      "I list the steps and move forward in an orderly way.",
+      "I envision the ideal outcome and the implicit path.",
+      "I brainstorm thoroughly and keep the best.",
+      "I jump straight into tangible action."
+    ]
+  },
+  6: {
+    question: "In a group:",
+    options: [
+      "I create harmony and connect people.",
+      "I keep my independence and internal boundaries.",
+      "I organize to move forward and deliver.",
+      "I analyze the logic of what's happening."
+    ]
+  },
+  7: {
+    question: "Under short-term pressure:",
+    options: [
+      "I react quickly and leverage the situation.",
+      "I simplify and set a clear course.",
+      "I look for the hidden through-line.",
+      "I rely on what's already proven."
+    ]
+  },
+  8: {
+    question: "To settle a technical disagreement:",
+    options: [
+      "I test in real conditions.",
+      "I compare with standards and precedents.",
+      "I model the problem and deduce the solution.",
+      "I look for the solution that preserves cohesion."
+    ]
+  },
+  9: {
+    question: "Your relationship to rules:",
+    options: [
+      "I respect them if they make sense and have history.",
+      "I change them if they block efficiency.",
+      "I stray from them if they clash with my values.",
+      "I question them if they're illogical."
+    ]
+  },
+  10: {
+    question: "When you look ahead:",
+    options: [
+      "I see the thread running through events.",
+      "I imagine multiple alternative scenarios.",
+      "I transpose what worked yesterday.",
+      "I rely on what I can test right now."
+    ]
+  },
+  11: {
+    question: "Toward others:",
+    options: [
+      "I want everyone to feel respected and heard.",
+      "I keep my authenticity without overplaying.",
+      "I clarify criteria and responsibilities.",
+      "I clarify concepts to avoid vagueness."
+    ]
+  },
+  12: {
+    question: "When you doubt:",
+    options: [
+      "I return to facts and traces from the past.",
+      "I look for the underlying pattern.",
+      "I multiply avenues and compare.",
+      "I run a quick field test."
+    ]
+  },
+  13: {
+    question: "Your way of being effective:",
+    options: [
+      "Criteria, milestones, something concrete.",
+      "A clear, logical model.",
+      "Choices aligned with my values.",
+      "Visible, measurable actions."
+    ]
+  },
+  14: {
+    question: "When someone suggests a shaky idea:",
+    options: [
+      "I frame it and rephrase it into a workable plan.",
+      "I question it until I find the flaw.",
+      "I try to value and include the person.",
+      "I offer creative alternatives."
+    ]
+  },
+  15: {
+    question: "Your daily preference:",
+    options: [
+      "Stable routines and landmarks.",
+      "Discoveries and variety.",
+      "Underlying vision and internal continuity.",
+      "Action and immediate feedback."
+    ]
+  },
+  16: {
+    question: "When you help:",
+    options: [
+      "I create connection and facilitate exchanges.",
+      "I respect each person's autonomy and boundaries.",
+      "I put in useful tools/processes.",
+      "I clarify so the person can understand on their own."
+    ]
+  },
+  17: {
+    question: "Under uncertainty:",
+    options: [
+      "I rely on deep cues.",
+      "I multiply quick trials.",
+      "I create several competing hypotheses.",
+      "I return to precedents and rules."
+    ]
+  },
+  18: {
+    question: "When you express yourself:",
+    options: [
+      "I speak about what is true for me.",
+      "I look for words that bring people together.",
+      "I structure and go straight to the point.",
+      "I specify each term to avoid vagueness."
+    ]
+  },
+  19: {
+    question: "When faced with an error:",
+    options: [
+      "I fix the process so it doesn't happen again.",
+      "I understand the mechanism that went off track.",
+      "I spot the warning signs.",
+      "I run a field test to secure it."
+    ]
+  },
+  20: {
+    question: "Your deep motivation:",
+    options: [
+      "Being aligned with who I am.",
+      "Uplifting others and the relationship.",
+      "Turning things into concrete results.",
+      "Understanding and clarifying truth."
+    ]
+  }
+};
+
+const EXTERNAL_TRANSLATIONS_EN = {
+  1: {
+    question: "When something unexpected happens, your relative:",
+    options: [
+      "Acts quickly and adjusts on the spot.",
+      "Steps back to grasp the overall meaning.",
+      "Looks for a precedent and an applicable rule.",
+      "Unfolds the logic of the problem before acting."
+    ]
+  },
+  2: {
+    question: "In a group discussion, he/she:",
+    options: [
+      "Encourages everyone to participate and keeps harmony.",
+      "Expresses ideas authentically, even if it bothers others.",
+      "Refocuses the discussion toward a concrete goal.",
+      "Asks questions to clarify the logic."
+    ]
+  },
+  3: {
+    question: "Their relationship to values:",
+    options: [
+      "Stays authentic even if it's unpopular.",
+      "Prioritizes group cohesion and feelings.",
+      "Prioritizes measurable efficiency.",
+      "Prioritizes logical correctness."
+    ]
+  },
+  4: {
+    question: "When he/she learns something new:",
+    options: [
+      "Leans on past experiences and references.",
+      "Experiments quickly to see what happens.",
+      "Imagines alternative and creative scenarios.",
+      "Grasps the deeper meaning without explaining everything."
+    ]
+  },
+  5: {
+    question: "When he/she has to handle a practical problem:",
+    options: [
+      "Looks for a rule or past example.",
+      "Tests a concrete solution right away.",
+      "Seeks a detailed logical explanation.",
+      "Wonders how to maintain human cohesion."
+    ]
+  },
+  6: {
+    question: "When he/she makes quick decisions:",
+    options: [
+      "Relies on broad intuitions.",
+      "Follows personal values without compromise.",
+      "Focuses on immediate efficiency.",
+      "Tests directly in the field."
+    ]
+  },
+  7: {
+    question: "In relationships, your relative tends to:",
+    options: [
+      "Calm tensions and seek harmony.",
+      "Assert their authenticity and feelings.",
+      "Give clear, concrete directives.",
+      "Favor precision and logic."
+    ]
+  },
+  8: {
+    question: "When faced with a new idea, your relative:",
+    options: [
+      "Looks for how it has been done elsewhere.",
+      "Imagines other avenues from there.",
+      "Immediately senses where it could lead.",
+      "Tests it concretely and observes the result."
+    ]
+  },
+  9: {
+    question: "When he/she expresses an opinion:",
+    options: [
+      "Highlights their personal truth.",
+      "Adapts speech to bring people together.",
+      "Structures it in logical, measurable steps.",
+      "Defends intellectual coherence."
+    ]
+  },
+  10: {
+    question: "Their relationship to rules:",
+    options: [
+      "Relies on them for security.",
+      "Changes them if they hinder results.",
+      "Debates them if they're illogical.",
+      "Veers away if they clash with their values."
+    ]
+  },
+  12: {
+    question: "When he/she defends a point:",
+    options: [
+      "Aligns with their inner values.",
+      "Seeks words that bring people together.",
+      "Highlights the structure and outcome.",
+      "Demonstrates logical coherence."
+    ]
+  },
+  14: {
+    question: "Your relative's general style:",
+    options: [
+      "Rather stable and consistent.",
+      "Rather adventurous and curious.",
+      "Rather visionary and synthetic.",
+      "Rather pragmatic and physical."
+    ]
+  },
+  15: {
+    question: "In debates, your relative:",
+    options: [
+      "Stays focused on results and decisions.",
+      "Prioritizes conceptual clarity.",
+      "Seeks cohesion and peace.",
+      "Asserts quiet authenticity."
+    ]
+  },
+  18: {
+    question: "Your relative's decision-making style:",
+    options: [
+      "Pragmatic, hands-on first.",
+      "Structured, with steps and criteria.",
+      "Intuitive, captures the implicit direction.",
+      "Logical, demonstrates before deciding."
+    ]
+  },
+  19: {
+    question: "Over time, your relative:",
+    options: [
+      "Stays the course through solid habits.",
+      "Refreshes with new ideas.",
+      "Keeps the underlying coherence.",
+      "Delivers through tangible actions."
+    ]
+  },
+  20: {
+    question: "What people remember most about him/her:",
+    options: [
+      "Personal alignment and integrity.",
+      "Relational support and bringing people together.",
+      "Ability to deliver and organize.",
+      "Intellectual clarity and precision."
+    ]
+  }
+};
+
+const AUTO_QUESTIONS_EN = AUTO_QUESTIONS.map(q => ({
+  ...q,
+  question: AUTO_TRANSLATIONS_EN[q.id].question,
+  options: q.options.map((opt, i) => ({ ...opt, text: AUTO_TRANSLATIONS_EN[q.id].options[i] }))
+}));
+
+const EXTERNAL_QUESTIONS_EN = EXTERNAL_QUESTIONS.map(q => ({
+  ...q,
+  question: EXTERNAL_TRANSLATIONS_EN[q.id].question,
+  options: q.options.map((opt, i) => ({ ...opt, text: EXTERNAL_TRANSLATIONS_EN[q.id].options[i] }))
+}));
+
+const LANG = {
+  fr: { AUTO_QUESTIONS, EXTERNAL_QUESTIONS },
+  en: { AUTO_QUESTIONS: AUTO_QUESTIONS_EN, EXTERNAL_QUESTIONS: EXTERNAL_QUESTIONS_EN }
+};
+
 
 // Expose (browser/Node)
 if (typeof window !== 'undefined') {
   window.AUTO_QUESTIONS = AUTO_QUESTIONS;
   window.EXTERNAL_QUESTIONS = EXTERNAL_QUESTIONS;
+  window.LANG = LANG;
 }
 if (typeof module !== 'undefined' && module.exports) {
-  module.exports = { AUTO_QUESTIONS, EXTERNAL_QUESTIONS };
+  module.exports = { AUTO_QUESTIONS, EXTERNAL_QUESTIONS, AUTO_QUESTIONS_EN, EXTERNAL_QUESTIONS_EN, LANG };
 }


### PR DESCRIPTION
## Summary
- add English translations for self and external question sets
- expose French and English question arrays via new `LANG` helper

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68aa63e5d0cc8321a035f7d1c3bb5781