### PR TITLE
fix: translate self and external evaluations

### DIFF
--- a/public/blog.html
+++ b/public/blog.html
@@ -3405,7 +3405,7 @@ function showSupport() {
                             <div class="space-y-2">
                                 <div class="flex items-center justify-between p-3 bg-green-50 rounded-lg">
                                     <div>
-                                        <span class="text-sm font-medium text-gray-700">Auto-évaluation</span>
+                                        <span class="text-sm font-medium text-gray-700" data-i18n="results.details.selfEvaluation">Auto-évaluation</span>
                                         <div class="text-xs text-gray-500">${profile.self.mbti} — type ${profile.self.enneagram}</div>
                                     </div>
                                     <span class="text-sm text-green-600 font-medium">✓ Complétée</span>

--- a/public/enneagramme.html
+++ b/public/enneagramme.html
@@ -3091,7 +3091,7 @@ function showSupport() {
 <div class="bg-white shadow-lg rounded-lg overflow-hidden">
                         <div class="bg-blue-600 px-6 py-4 flex justify-between items-center">
                             <div>
-                                <h2 class="text-2xl font-bold text-white">Évaluation externe</h2>
+                                <h2 class="text-2xl font-bold text-white" data-i18n="home.modal.externalEval.title">Évaluation externe</h2>
                                 <p class="text-blue-100 mt-1">Code: ${code} | Relation: ${relationLabels[relation]}</p>
                             </div>
                             <span class="close" onclick="closeModal()" style="color: white;">&times;</span>
@@ -3852,7 +3852,7 @@ function showSupport() {
                             <div class="space-y-2">
                                 <div class="flex items-center justify-between p-3 bg-green-50 rounded-lg">
                                     <div>
-                                        <span class="text-sm font-medium text-gray-700">Auto-évaluation</span>
+                                        <span class="text-sm font-medium text-gray-700" data-i18n="results.details.selfEvaluation">Auto-évaluation</span>
                                         <div class="text-xs text-gray-500">${profile.self.mbti} — type ${profile.self.enneagram}</div>
                                     </div>
                                     <span class="text-sm text-green-600 font-medium">✓ Complétée</span>

--- a/public/mbti.html
+++ b/public/mbti.html
@@ -3183,7 +3183,7 @@ function showSupport() {
 <div class="bg-white shadow-lg rounded-lg overflow-hidden">
                         <div class="bg-blue-600 px-6 py-4 flex justify-between items-center">
                             <div>
-                                <h2 class="text-2xl font-bold text-white">Évaluation externe</h2>
+                                <h2 class="text-2xl font-bold text-white" data-i18n="home.modal.externalEval.title">Évaluation externe</h2>
                                 <p class="text-blue-100 mt-1">Code: ${code} | Relation: ${relationLabels[relation]}</p>
                             </div>
                             <span class="close" onclick="closeModal()" style="color: white;">&times;</span>
@@ -3964,7 +3964,7 @@ function showSupport() {
                             <div class="space-y-2">
                                 <div class="flex items-center justify-between p-3 bg-green-50 rounded-lg">
                                     <div>
-                                        <span class="text-sm font-medium text-gray-700">Auto-évaluation</span>
+                                        <span class="text-sm font-medium text-gray-700" data-i18n="results.details.selfEvaluation">Auto-évaluation</span>
                                         <div class="text-xs text-gray-500">${profile.self.mbti} — type ${profile.self.enneagram}</div>
                                     </div>
                                     <span class="text-sm text-green-600 font-medium">✓ Complétée</span>


### PR DESCRIPTION
## Summary
- enable translation for self-evaluation labels in results pages
- enable translation for external evaluation modal titles on MBTI and Enneagram pages

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aa8c1a95ac83219d7558522a4545e1