### PR TITLE
fix: align French translation

### DIFF
--- a/public/lang.js
+++ b/public/lang.js
@@ -1092,7 +1092,7 @@ const translations = {
     "questions.external.12.option2": "Cherche les mots qui rassemblent.",
     "questions.external.12.option3": "Met en avant la structure et le résultat.",
     "questions.external.12.option4": "Démontre la cohérence logique.",
-    "questions.external.13.question": "Face à l’erreur votre proche :",
+    "questions.external.13.question": "Face à l’erreur votre proche :",
     "questions.external.13.option1": "Corrige le process durablement.",
     "questions.external.13.option2": "Comprend le mécanisme de la faille.",
     "questions.external.13.option3": "Repère les patterns annonciateurs.",


### PR DESCRIPTION
## Summary
- replace non-breaking space with regular space in `questions.external.13.question`
- verify all question keys exist in translations

## Testing
- `node <<'NODE'
const fs=require('fs');
const code=fs.readFileSync('./public/lang.js','utf8');
const translations=eval(code + ';translations;');
const {AUTO_QUESTIONS, EXTERNAL_QUESTIONS}=require('./public/questions-v2.js');
const keys=[];
AUTO_QUESTIONS.forEach(q=>{keys.push(q.i18nKey); q.options.forEach(o=>keys.push(o.i18nKey));});
EXTERNAL_QUESTIONS.forEach(q=>{keys.push(q.i18nKey); q.options.forEach(o=>keys.push(o.i18nKey));});
let missingFr=[], missingEn=[], mismatchFr=[];
function check(array){
  for(const q of array){
    const f=translations.fr[q.i18nKey];
    if(f!==q.question) mismatchFr.push(q.i18nKey);
    const e=translations.en[q.i18nKey];
    if(!e) missingEn.push(q.i18nKey);
    q.options.forEach(o=>{
       const fopt=translations.fr[o.i18nKey];
       if(fopt!==o.text) mismatchFr.push(o.i18nKey);
       const eopt=translations.en[o.i18nKey];
       if(!eopt) missingEn.push(o.i18nKey);
    });
  }
}
check(AUTO_QUESTIONS); check(EXTERNAL_QUESTIONS);
console.log('missing fr', missingFr.length);
console.log('missing en', missingEn.length);
console.log('mismatch fr', mismatchFr.length);
if(mismatchFr.length) console.log(mismatchFr.slice(0,20));
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68aa8ede4e4883219e0e2fa9c027d684