### PR TITLE
feat: improve English translation for first question

### DIFF
--- a/public/lang.js
+++ b/public/lang.js
@@ -2066,8 +2066,8 @@ const translations = {
       missingEvaluations: "You need to complete all evaluations to access your detailed results page. Share your unique code with your relatives so they can complete your profile and give you access to your results!"
     },
     "shareCodeAlert": "Here is your code to give to 3 relatives: ",
-    "questions.auto.1.question": "When a plan starts in a spin, what are you doing first?",
-    "questions.auto.1.option1": "I question point by point until clarifying.",
+    "questions.auto.1.question": "When a plan goes off track, what do you do first?",
+    "questions.auto.1.option1": "I question point by point until it's clear.",
     "questions.auto.1.option2": "I reframe and fix a simple and measurable plan.",
     "questions.auto.1.option3": "I take a step back to grasp the overall meaning.",
     "questions.auto.1.option4": "I test live and adjust as you go.",


### PR DESCRIPTION
## Summary
- refine English phrasing for first self-assessment question
- verify all question keys exist in French and English

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68aa90942d3c832180773c55f2c147e3