### PR TITLE
refactor water fill effect

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -76,33 +76,26 @@
         #autoEvalCard .water-fill {
             position: absolute;
             inset: 0;
-            bottom: 0;
-            height: 100%;
             transform: translateY(100%);
-            transition: transform 600ms cubic-bezier(.25,.8,.25,1);
-            background: linear-gradient(to top, rgba(59,130,246,.35), rgba(59,130,246,.15));
+            transition: transform 700ms cubic-bezier(.22,.61,.36,1);
+            pointer-events: none;
         }
-        #autoEvalCard .water-fill svg {
+        #autoEvalCard .water-fill::after {
+            content: "";
             position: absolute;
-            bottom: 0;
-            width: 200%;
+            inset: 0;
+            background: radial-gradient(closest-side at 50% 20%, rgba(255,255,255,0.12), rgba(255,255,255,0) 70%);
+            filter: blur(8px);
+            pointer-events: none;
+        }
+        #autoEvalCard .water-svg {
+            display: block;
+            width: 100%;
             height: 100%;
-        }
-        #autoEvalCard .wave {
-            fill: rgba(59,130,246,0.5);
-            animation: wave-drift 8s linear infinite;
-        }
-        #autoEvalCard .wave2 {
-            fill: rgba(59,130,246,0.6);
-            animation-duration: 12s;
-        }
-        @keyframes wave-drift {
-            from { transform: translateX(0); }
-            to { transform: translateX(-50%); }
         }
         @media (prefers-reduced-motion: reduce) {
-            #autoEvalCard .wave { animation: none; }
-            #autoEvalCard .water-fill { transition-duration: 200ms; }
+            #autoEvalCard .ripple-anim { display: none; }
+            #autoEvalCard .water-fill { transition-duration: 300ms; }
         }
 
         /* Styles pour les modales */
@@ -732,10 +725,24 @@
         <!-- Encadré parent -->
         <div id="autoEvalCard" class="mt-12 mb-4 rounded-[2rem] shadow-sm border border-gray-200 bg-gray-50 relative overflow-hidden">
             <div aria-hidden="true" class="absolute inset-0 pointer-events-none">
-                <div class="water-fill">
-                    <svg viewBox="0 0 1200 100" preserveAspectRatio="none" class="absolute bottom-0 w-[200%] h-full">
-                        <path class="wave wave1" d="M0 30 Q 60 0 120 30 T 240 30 T 360 30 T 480 30 T 600 30 T 720 30 T 840 30 T 960 30 T 1080 30 T 1200 30 V100 H0 Z" />
-                        <path class="wave wave2" d="M0 30 Q 60 0 120 30 T 240 30 T 360 30 T 480 30 T 600 30 T 720 30 T 840 30 T 960 30 T 1080 30 T 1200 30 V100 H0 Z" />
+                <div class="water-fill" aria-hidden="true">
+                    <svg class="water-svg" viewBox="0 0 100 100" preserveAspectRatio="none">
+                        <defs>
+                            <linearGradient id="waterGradient" x1="0" y1="1" x2="0" y2="0">
+                                <stop offset="0%" stop-color="hsla(215, 90%, 58%, 0.25)" />
+                                <stop offset="60%" stop-color="hsla(215, 90%, 60%, 0.18)" />
+                                <stop offset="100%" stop-color="hsla(215, 90%, 65%, 0.10)" />
+                            </linearGradient>
+                            <filter id="waterRipple">
+                                <feTurbulence type="fractalNoise" baseFrequency="0.008 0.02" numOctaves="2" seed="2">
+                                    <animate class="ripple-anim" attributeName="baseFrequency" dur="8s" values="0.008 0.02;0.01 0.025;0.008 0.02" repeatCount="indefinite" />
+                                </feTurbulence>
+                                <feDisplacementMap in="SourceGraphic" scale="6" xChannelSelector="R" yChannelSelector="G">
+                                    <animate class="ripple-anim" attributeName="scale" dur="8s" values="5;8;5" repeatCount="indefinite" />
+                                </feDisplacementMap>
+                            </filter>
+                        </defs>
+                        <rect width="100" height="100" fill="url(#waterGradient)" filter="url(#waterRipple)" />
                     </svg>
                 </div>
             </div>

--- a/public/waterProgress.js
+++ b/public/waterProgress.js
@@ -2,16 +2,48 @@
   function initWaterFill() {
     const card = document.getElementById('autoEvalCard');
     if (!card) return null;
-    const water = card.querySelector('.water-fill');
+
+    let water = card.querySelector('.water-fill');
+    if (!water) {
+      water = document.createElement('div');
+      water.className = 'water-fill';
+      water.setAttribute('aria-hidden', 'true');
+      card.prepend(water);
+    }
+
+    if (!water.querySelector('.water-svg')) {
+      water.innerHTML = `
+        <svg class="water-svg" viewBox="0 0 100 100" preserveAspectRatio="none">
+          <defs>
+            <linearGradient id="waterGradient" x1="0" y1="1" x2="0" y2="0">
+              <stop offset="0%" stop-color="hsla(215, 90%, 58%, 0.25)" />
+              <stop offset="60%" stop-color="hsla(215, 90%, 60%, 0.18)" />
+              <stop offset="100%" stop-color="hsla(215, 90%, 65%, 0.10)" />
+            </linearGradient>
+            <filter id="waterRipple">
+              <feTurbulence type="fractalNoise" baseFrequency="0.008 0.02" numOctaves="2" seed="2">
+                <animate class="ripple-anim" attributeName="baseFrequency" dur="8s" values="0.008 0.02;0.01 0.025;0.008 0.02" repeatCount="indefinite" />
+              </feTurbulence>
+              <feDisplacementMap in="SourceGraphic" scale="6" xChannelSelector="R" yChannelSelector="G">
+                <animate class="ripple-anim" attributeName="scale" dur="8s" values="5;8;5" repeatCount="indefinite" />
+              </feDisplacementMap>
+            </filter>
+          </defs>
+          <rect width="100" height="100" fill="url(#waterGradient)" filter="url(#waterRipple)" />
+        </svg>`;
+    }
+
     const percentEl = card.querySelector('[data-water-percent]');
+
     function setWaterProgress(percentage) {
       if (!water) return;
-      const clamped = Math.max(0, Math.min(100, Math.round(percentage)));
+      const clamped = Math.max(0, Math.min(100, Math.round(Number(percentage))));
       water.style.transform = `translateY(${100 - clamped}%)`;
       if (percentEl) {
         percentEl.textContent = `Progression : ${clamped}%`;
       }
     }
+
     window.setWaterProgress = setWaterProgress;
     return setWaterProgress;
   }


### PR DESCRIPTION
## Summary
- replace horizontal wave animation with translucent SVG water ripple
- add subtle radial highlight and reduced motion handling
- ensure JS clamps progress and creates water SVG when missing

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ac991472008321957cda5a26aaf53f