### PR TITLE
Use dynamic career text for results

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1989,7 +1989,8 @@ const uniqueCode = genererUniqueCode();
 }
 
 function displayResults(results) {
-    const resultsHTML = generateResultsHTML(results);
+    const finalResults = results;
+    const resultsHTML = generateResultsHTML(finalResults);
     
     const resultsSection = document.createElement('div');
     resultsSection.className = 'bg-blue-50 py-16 px-4 sm:px-6 lg:px-8';
@@ -2002,14 +2003,19 @@ function displayResults(results) {
 
         applyTranslations();
         const lang = document.documentElement.lang || 'fr';
-        const mbti = results.mbtiType;
-        const ennea = results.enneagramType;
+        const mbti = finalResults.mbtiType;
+        const ennea = finalResults.enneagramType;
+
         let careerText =
-          translations[lang]["results"]["career"]["mbti"][mbti] ||
-          translations[lang]["results"]["career"]["ennea"][ennea] ||
+          (translations[lang]["results"]["career"]["mbti"] &&
+           translations[lang]["results"]["career"]["mbti"][mbti]) ||
+
+          (translations[lang]["results"]["career"]["ennea"] &&
+           translations[lang]["results"]["career"]["ennea"][ennea]) ||
+
           translations[lang]["results"]["career"]["fallback"];
-        const careerEl = document.querySelector('[data-i18n="results.career.text"]');
-        if (careerEl) careerEl.innerText = careerText;
+
+        document.querySelector('[data-i18n="results.career.text"]').innerText = careerText;
 
         setTimeout(() => {
             resultsSection.scrollIntoView({ behavior: 'smooth' });

--- a/public/lang.js
+++ b/public/lang.js
@@ -934,8 +934,6 @@ const translations = {
 
     "results.detailed.title": "Résultats complémentaires",
 
-    "results.career.title": "Carrière & Passions probables",
-    "results.career.text": "Ce profil aime explorer des environnements variés et s’épanouit dans des contextes flexibles.",
     "results.mirror.title": "Profil miroir (opposé)",
     "results.mirror.text": "Ton profil miroir est {mirror}. Il représente une approche presque inverse de la tienne.",
 
@@ -2115,8 +2113,6 @@ const translations = {
 
     "results.detailed.title": "Complementary Results",
 
-    "results.career.title": "Career & Likely Passions",
-    "results.career.text": "This profile enjoys exploring diverse environments and thrives in flexible contexts.",
     "results.mirror.title": "Mirror Profile (opposite)",
     "results.mirror.text": "Your mirror profile is {mirror}. It represents an almost inverse approach to yours.",
 


### PR DESCRIPTION
## Summary
- remove duplicate flat translation keys for career in `lang.js`
- inject career text dynamically based on MBTI or Enneagram type with fallback

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68acca9c7ec88321a21bd85a8886a2a7