### PR TITLE
Fix career profile text injection

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2015,7 +2015,7 @@ function displayResults(results) {
 
           translations[lang]["results"]["career"]["fallback"];
 
-        document.querySelector('[data-i18n="results.career.text"]').innerText = careerText;
+        document.getElementById("careerProfileText").innerText = careerText;
 
         setTimeout(() => {
             resultsSection.scrollIntoView({ behavior: 'smooth' });
@@ -4047,12 +4047,7 @@ window.showSupport = showSupport;
           Carrière & Passions probables
         </span>
       </div>
-      <p class="mt-3 text-gray-700 leading-relaxed bg-blue-100/40 border border-blue-200 rounded-2xl p-4 shadow-sm text-center">
-        <span data-i18n="results.career.text">
-          Les personnes avec ce profil s’épanouissent souvent dans des contextes où leurs qualités naturelles peuvent s’exprimer. 
-          Elles aiment travailler dans des environnements qui valorisent leur manière unique de voir et d’agir.
-        </span>
-      </p>
+      <p id="careerProfileText" class="mt-3 text-gray-700 leading-relaxed bg-blue-100/40 border border-blue-200 rounded-2xl p-4 shadow-sm"></p>
     </div>
 
     <!-- Profil miroir -->


### PR DESCRIPTION
## Summary
- Replace career profile paragraph with `careerProfileText` element
- Inject career profile text via JS based on MBTI/Enneagram fallback

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68accc58eb4c8321bbad11cce84afaf2