### PR TITLE
Clamp MBTI chart percentages

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4178,12 +4178,14 @@ window.showSupport = showSupport;
                 J: (profile.mbtiScores.Te || 0) + (profile.mbtiScores.Fe || 0),
                 P: (profile.mbtiScores.Se || 0) + (profile.mbtiScores.Ne || 0)
             };
+            // Normalisation des pourcentages (empêche > 100% ou < 0%)
+            const clamp = (val) => Math.min(100, Math.max(0, val));
             const mbtiData = mbtiPairs.map(pair => {
                 const aScore = traitScores[pair.a];
                 const bScore = traitScores[pair.b];
                 const dominant = aScore > bScore ? pair.a : pair.b;
-                const value = Math.round((Math.max(aScore, bScore) / (aScore + bScore)) * 100);
-                return { label: pair.label, value, dominant };
+                const rawValue = Math.round((Math.max(aScore, bScore) / (aScore + bScore)) * 100);
+                return { label: pair.label, value: clamp(rawValue), dominant };
             });
             const mbtiDescriptions = { E: 'Extraversion', I: 'Introversion', S: 'Sensation', N: 'Intuition', T: 'Pensée', F: 'Sentiment', J: 'Jugement', P: 'Perception' };
             Chart.register(ChartDataLabels);


### PR DESCRIPTION
## Summary
- Clamp MBTI percentage calculations to [0,100] before rendering

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68acd8dcf8208321aae827451679d521