### PR TITLE
Affiche l'aile Ennéagramme dans le titre des résultats détaillés

### DIFF
--- a/public/blog.html
+++ b/public/blog.html
@@ -1159,6 +1159,13 @@ const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBh
             return "Faible";
         }
 
+        function computeEnneagramWing(scores, coreType) {
+            if (!scores || !coreType) return null;
+            const left = coreType === '1' ? '9' : String(Number(coreType) - 1);
+            const right = coreType === '9' ? '1' : String(Number(coreType) + 1);
+            return (scores[left] || 0) >= (scores[right] || 0) ? left : right;
+        }
+
        function computeWeightedResults(evaluations) {
     const baseWeights = {
         family: 30,
@@ -3288,14 +3295,16 @@ function showSupport() {
             });
             const certaintyScore = result.overallCertainty ??
                 (result.user.certainty_score != null ? Number(result.user.certainty_score) : null);
+            const enneaWing = computeEnneagramWing(result.user.enneagram_scores, result.user.enneagram_type);
             const finalProfile = {
                 uniqueCode: userCode,
-                name: `${result.user.mbti_type} — type ${result.user.enneagram_type}`,
+                name: `${result.user.mbti_type} — Type ${result.user.enneagram_type}${enneaWing ? 'w' + enneaWing : ''}`,
                 self: { mbti: selfProfile.mbtiType, enneagram: selfProfile.enneagramType },
                 results: {
                     mbti: result.user.mbti_type,
                     mbtiCertainty: result.mbtiCertainty ?? certaintyScore,
                     enneagram: result.user.enneagram_type,
+                    enneagramWing: enneaWing,
                     enneagramCertainty: result.enneagramCertainty ?? certaintyScore,
                     overallCertainty: certaintyScore
                 },
@@ -3347,7 +3356,7 @@ function showSupport() {
           </div>
           <div class="bg-purple-50 rounded-lg p-4">
             <h4 class="font-semibold text-purple-900 mb-2">Ennéagramme</h4>
-            <div class="text-2xl font-bold text-purple-600 mb-2">${profile.results.enneagram}</div>
+            <div class="text-2xl font-bold text-purple-600 mb-2">Type ${profile.results.enneagram}${profile.results.enneagramWing ? 'w' + profile.results.enneagramWing : ''}</div>
             <div class="mt-2">
               ${
                 profile.results.enneagramCertainty != null

--- a/public/enneagramme.html
+++ b/public/enneagramme.html
@@ -1590,6 +1590,13 @@ const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBh
             return "Faible";
         }
 
+        function computeEnneagramWing(scores, coreType) {
+            if (!scores || !coreType) return null;
+            const left = coreType === '1' ? '9' : String(Number(coreType) - 1);
+            const right = coreType === '9' ? '1' : String(Number(coreType) + 1);
+            return (scores[left] || 0) >= (scores[right] || 0) ? left : right;
+        }
+
        function computeWeightedResults(evaluations) {
     const baseWeights = {
         family: 30,
@@ -3735,14 +3742,16 @@ function showSupport() {
             });
             const certaintyScore = result.overallCertainty ??
                 (result.user.certainty_score != null ? Number(result.user.certainty_score) : null);
+            const enneaWing = computeEnneagramWing(result.user.enneagram_scores, result.user.enneagram_type);
             const finalProfile = {
                 uniqueCode: userCode,
-                name: `${result.user.mbti_type} — type ${result.user.enneagram_type}`,
+                name: `${result.user.mbti_type} — Type ${result.user.enneagram_type}${enneaWing ? 'w' + enneaWing : ''}`,
                 self: { mbti: selfProfile.mbtiType, enneagram: selfProfile.enneagramType },
                 results: {
                     mbti: result.user.mbti_type,
                     mbtiCertainty: result.mbtiCertainty ?? certaintyScore,
                     enneagram: result.user.enneagram_type,
+                    enneagramWing: enneaWing,
                     enneagramCertainty: result.enneagramCertainty ?? certaintyScore,
                     overallCertainty: certaintyScore
                 },
@@ -3794,7 +3803,7 @@ function showSupport() {
           </div>
           <div class="bg-purple-50 rounded-lg p-4">
             <h4 class="font-semibold text-purple-900 mb-2">Ennéagramme</h4>
-            <div class="text-2xl font-bold text-purple-600 mb-2">${profile.results.enneagram}</div>
+            <div class="text-2xl font-bold text-purple-600 mb-2">Type ${profile.results.enneagram}${profile.results.enneagramWing ? 'w' + profile.results.enneagramWing : ''}</div>
             <div class="mt-2">
               ${
                 profile.results.enneagramCertainty != null

--- a/public/index.html
+++ b/public/index.html
@@ -3911,7 +3911,7 @@ window.showSupport = showSupport;
             const enneaWing = computeEnneagramWing(result.user.enneagram_scores, result.user.enneagram_type);
             const finalProfile = {
                 uniqueCode: userCode,
-                name: `${result.user.mbti_type} — type ${result.user.enneagram_type}`,
+                name: `${result.user.mbti_type} — Type ${result.user.enneagram_type}${enneaWing ? 'w' + enneaWing : ''}`,
                 self: { mbti: selfProfile.mbtiType, enneagram: selfProfile.enneagramType },
                 results: {
                     mbti: result.user.mbti_type,
@@ -4154,7 +4154,7 @@ window.showSupport = showSupport;
     initCountUp(resultsModal);
     applyTranslations();
     const titleEl = resultsModal.querySelector('[data-i18n="results.details.title"]');
-    if (titleEl) { titleEl.innerHTML = titleEl.innerHTML.replace('{name}', profile.name); }
+    if (titleEl) { titleEl.innerHTML = titleEl.innerHTML.replace('{name}', `${profile.results.mbti} — ${enneaDisplay}`); }
 
     // Texte carrière : MBTI > Ennéagramme > fallback
     const careerEl = document.getElementById("careerProfileText");

--- a/public/mbti.html
+++ b/public/mbti.html
@@ -1686,6 +1686,13 @@ const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBh
             return "Faible";
         }
 
+        function computeEnneagramWing(scores, coreType) {
+            if (!scores || !coreType) return null;
+            const left = coreType === '1' ? '9' : String(Number(coreType) - 1);
+            const right = coreType === '9' ? '1' : String(Number(coreType) + 1);
+            return (scores[left] || 0) >= (scores[right] || 0) ? left : right;
+        }
+
        function computeWeightedResults(evaluations) {
     const baseWeights = {
         family: 30,
@@ -3847,14 +3854,16 @@ function showSupport() {
             });
             const certaintyScore = result.overallCertainty ??
                 (result.user.certainty_score != null ? Number(result.user.certainty_score) : null);
+            const enneaWing = computeEnneagramWing(result.user.enneagram_scores, result.user.enneagram_type);
             const finalProfile = {
                 uniqueCode: userCode,
-                name: `${result.user.mbti_type} — type ${result.user.enneagram_type}`,
+                name: `${result.user.mbti_type} — Type ${result.user.enneagram_type}${enneaWing ? 'w' + enneaWing : ''}`,
                 self: { mbti: selfProfile.mbtiType, enneagram: selfProfile.enneagramType },
                 results: {
                     mbti: result.user.mbti_type,
                     mbtiCertainty: result.mbtiCertainty ?? certaintyScore,
                     enneagram: result.user.enneagram_type,
+                    enneagramWing: enneaWing,
                     enneagramCertainty: result.enneagramCertainty ?? certaintyScore,
                     overallCertainty: certaintyScore
                 },
@@ -3906,7 +3915,7 @@ function showSupport() {
           </div>
           <div class="bg-purple-50 rounded-lg p-4">
             <h4 class="font-semibold text-purple-900 mb-2">Ennéagramme</h4>
-            <div class="text-2xl font-bold text-purple-600 mb-2">${profile.results.enneagram}</div>
+            <div class="text-2xl font-bold text-purple-600 mb-2">Type ${profile.results.enneagram}${profile.results.enneagramWing ? 'w' + profile.results.enneagramWing : ''}</div>
             <div class="mt-2">
               ${
                 profile.results.enneagramCertainty != null


### PR DESCRIPTION
## Summary
- Affiche le type Ennéagramme complet (Type XwY) dans le titre de la modale de résultats
- Aligne les autres pages pour calculer l’aile et nommer le profil avec le même format

## Testing
- `npm test` *(script manquant)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1f37633c8321b95bdff5062f4ad3