### PR TITLE
feat(algo): set Faible coherence weight 0.3 to ensure 2xFaible < 1xMoyenne

### DIFF
--- a/computeFinalProfileFromExternalEvaluations.js
+++ b/computeFinalProfileFromExternalEvaluations.js
@@ -127,7 +127,7 @@ function internalCoherenceEnneagram(scores) {
 const COHERENCE_COEFFICIENT = {
   Forte: 1.0,
   Moyenne: 0.7,
-  Faible: 0.4,
+  Faible: 0.3,
 };
 
 // Bonus de majorité additif (simple et lisible)


### PR DESCRIPTION
## Summary
- Adjust coherence coefficients so Faible weight is 0.3, keeping other weights and BETA intact.
- Verifies weight inequality logic via console snippet.

## Testing
- `node - <<'NODE'
// Poids cibles après modif :
const W = { forte: 1.0, moyenne: 0.7, faible: 0.3 };

// 2 faibles vs 1 moyenne
console.log('2 faibles vs 1 moyenne:', 2*W.faible, '<', W.moyenne, 2*W.faible < W.moyenne);

// 2 faibles vs 1 forte
console.log('2 faibles vs 1 forte:', 2*W.faible, '<', W.forte, 2*W.faible < W.forte);

// 2 moyennes vs 1 forte
console.log('2 moyennes vs 1 forte:', 2*W.moyenne, '>', W.forte, 2*W.moyenne > W.forte);
NODE`
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68af71d0d5b8832193f663d6af3dbcc6