### PR TITLE
Fix translation for career heading in results modal

### DIFF
--- a/public/i18n.js
+++ b/public/i18n.js
@@ -6,7 +6,16 @@ function applyTranslations(lang = null) {
 
   document.querySelectorAll("[data-i18n]").forEach(el => {
     const key = el.getAttribute("data-i18n");
-    const value = translations[lang] ? translations[lang][key] : null;
+    let value = translations[lang];
+    if (value) {
+      key.split('.').forEach(k => {
+        value = value && Object.prototype.hasOwnProperty.call(value, k)
+          ? value[k]
+          : undefined;
+      });
+    } else {
+      value = undefined;
+    }
 
     // on écrase toujours le texte si une traduction existe
     if (value !== undefined && value !== null) {


### PR DESCRIPTION
## Summary
- handle nested i18n keys so elements like `results.career.title` translate correctly

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68af737923fc8321af68e6bdd844a232