### PR TITLE
feat: scroll to results after finishing test

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1490,9 +1490,13 @@ function displayQuestion(index) {
             }
             
             if (finishButton) {
-                finishButton.addEventListener('click', function() {
+                finishButton.addEventListener('click', async function() {
                     if (Object.keys(answers).length === AUTO_QUESTIONS.length) {
-                        calculateResults();
+                        await calculateResults();
+                        const resultsSection = document.getElementById('results-section');
+                        if (resultsSection) {
+                            resultsSection.scrollIntoView({ behavior: 'smooth' });
+                        }
                     } else {
                         alert('Veuillez répondre à toutes les questions avant de terminer.');
                     }
@@ -2018,6 +2022,7 @@ function displayResults(results) {
     
     const resultsSection = document.createElement('div');
     resultsSection.className = 'bg-blue-50 py-16 px-4 sm:px-6 lg:px-8';
+    resultsSection.id = 'results-section';
     resultsSection.innerHTML = resultsHTML;
     
     const autoEvalSection = document.getElementById('home-mbti');
@@ -2052,10 +2057,6 @@ console.log("Texte carrière choisi:", careerText);
 
         // Injection dans le bloc
         document.getElementById("careerProfileText").innerText = careerText;
-
-        setTimeout(() => {
-            resultsSection.scrollIntoView({ behavior: 'smooth' });
-        }, 100);
     }
     
     localStorage.setItem('personalityTestResults', JSON.stringify(results));


### PR DESCRIPTION
## Summary
- smooth-scroll from "Terminer le test" button to generated results section
- mark results container with an id for direct scrolling

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b0391df2788321a56038fb5a6959b5