### PR TITLE
Enable smooth scroll to results after finishing test

### DIFF
--- a/public/blog.html
+++ b/public/blog.html
@@ -940,9 +940,13 @@ function displayQuestion(index) {
             }
             
             if (finishButton) {
-                finishButton.addEventListener('click', function() {
+                finishButton.addEventListener('click', async function() {
                     if (Object.keys(answers).length === AUTO_QUESTIONS.length) {
-                        calculateResults();
+                        await calculateResults();
+                        const resultsSection = document.getElementById('results-section');
+                        if (resultsSection) {
+                            resultsSection.scrollIntoView({ behavior: 'smooth' });
+                        }
                     } else {
                         alert('Veuillez répondre à toutes les questions avant de terminer.');
                     }
@@ -1453,16 +1457,13 @@ function displayResults(results) {
     
     const resultsSection = document.createElement('div');
     resultsSection.className = 'bg-blue-50 py-16 px-4 sm:px-6 lg:px-8';
+    resultsSection.id = 'results-section';
     resultsSection.innerHTML = resultsHTML;
     
     const autoEvalSection = document.getElementById('home-mbti');
     if (autoEvalSection) {
         autoEvalSection.parentNode.insertBefore(resultsSection, autoEvalSection.nextSibling);
         initCountUp(resultsSection);
-
-        setTimeout(() => {
-            resultsSection.scrollIntoView({ behavior: 'smooth' });
-        }, 100);
     }
     
     localStorage.setItem('personalityTestResults', JSON.stringify(results));

--- a/public/enneagramme.html
+++ b/public/enneagramme.html
@@ -1371,9 +1371,13 @@ function displayQuestion(index) {
             }
             
             if (finishButton) {
-                finishButton.addEventListener('click', function() {
+                finishButton.addEventListener('click', async function() {
                     if (Object.keys(answers).length === AUTO_QUESTIONS.length) {
-                        calculateResults();
+                        await calculateResults();
+                        const resultsSection = document.getElementById('results-section');
+                        if (resultsSection) {
+                            resultsSection.scrollIntoView({ behavior: 'smooth' });
+                        }
                     } else {
                         alert('Veuillez répondre à toutes les questions avant de terminer.');
                     }
@@ -1884,16 +1888,13 @@ function displayResults(results) {
     
     const resultsSection = document.createElement('div');
     resultsSection.className = 'bg-blue-50 py-16 px-4 sm:px-6 lg:px-8';
+    resultsSection.id = 'results-section';
     resultsSection.innerHTML = resultsHTML;
     
     const autoEvalSection = document.getElementById('home-mbti');
     if (autoEvalSection) {
         autoEvalSection.parentNode.insertBefore(resultsSection, autoEvalSection.nextSibling);
         initCountUp(resultsSection);
-
-        setTimeout(() => {
-            resultsSection.scrollIntoView({ behavior: 'smooth' });
-        }, 100);
     }
     
     localStorage.setItem('personalityTestResults', JSON.stringify(results));

--- a/public/mbti.html
+++ b/public/mbti.html
@@ -1467,9 +1467,13 @@ function displayQuestion(index) {
             }
             
             if (finishButton) {
-                finishButton.addEventListener('click', function() {
+                finishButton.addEventListener('click', async function() {
                     if (Object.keys(answers).length === AUTO_QUESTIONS.length) {
-                        calculateResults();
+                        await calculateResults();
+                        const resultsSection = document.getElementById('results-section');
+                        if (resultsSection) {
+                            resultsSection.scrollIntoView({ behavior: 'smooth' });
+                        }
                     } else {
                         alert('Veuillez répondre à toutes les questions avant de terminer.');
                     }
@@ -1980,16 +1984,13 @@ function displayResults(results) {
     
     const resultsSection = document.createElement('div');
     resultsSection.className = 'bg-blue-50 py-16 px-4 sm:px-6 lg:px-8';
+    resultsSection.id = 'results-section';
     resultsSection.innerHTML = resultsHTML;
     
     const autoEvalSection = document.getElementById('home-mbti');
     if (autoEvalSection) {
         autoEvalSection.parentNode.insertBefore(resultsSection, autoEvalSection.nextSibling);
         initCountUp(resultsSection);
-
-        setTimeout(() => {
-            resultsSection.scrollIntoView({ behavior: 'smooth' });
-        }, 100);
     }
     
     localStorage.setItem('personalityTestResults', JSON.stringify(results));


### PR DESCRIPTION
## Summary
- Scroll to results section when completing the test
- Give results container an id to anchor the scroll

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b03aff211c832189d5560881c1df9f