### PR TITLE
Fix auto evaluation scroll to profile

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1493,9 +1493,12 @@ function displayQuestion(index) {
                 finishButton.addEventListener('click', async function() {
                     if (Object.keys(answers).length === AUTO_QUESTIONS.length) {
                         await calculateResults();
-                        const resultsSection = document.getElementById('results-section');
-                        if (resultsSection) {
-                            resultsSection.scrollIntoView({ behavior: 'smooth' });
+                        const profileSection = document.getElementById('retourver-profil');
+                        if (profileSection) {
+                            // Attendre que le DOM soit mis à jour avant de lancer le scroll
+                            setTimeout(() => {
+                                profileSection.scrollIntoView({ behavior: 'smooth' });
+                            }, 100);
                         }
                     } else {
                         alert('Veuillez répondre à toutes les questions avant de terminer.');


### PR DESCRIPTION
## Summary
- Scroll to "Mon profil" section after finishing auto-evaluation
- Wait for DOM update before scrolling for smoother behavior

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_68b03d07cc8083218d7a3452cea9c579