### PR TITLE
Fix scrolling to results across test pages

### DIFF
--- a/public/blog.html
+++ b/public/blog.html
@@ -556,6 +556,7 @@
             </div>
         </section>
     </main>
+<div id="results-section"></div>
 
        <!-- Footer -->
     <p class="text-xs text-gray-500 text-center mb-4">MBTI® est une marque déposée de The Myers-Briggs Company. Ce site propose une approche inspirée et n’est ni affilié, ni agréé, ni soutenu par cette société.</p>
@@ -948,7 +949,8 @@ function displayQuestion(index) {
                         const icon = finishButton.querySelector('i');
                         if (icon) icon.remove();
                         if (typeof applyTranslations === 'function') { applyTranslations(); }
-                        setTimeout(scrollToResults, 50);
+                        setTimeout(scrollToResults, 100);
+                        location.hash = 'results-section';
                     } else {
                         alert('Veuillez répondre à toutes les questions avant de terminer.');
                     }
@@ -958,9 +960,11 @@ function displayQuestion(index) {
 
         function scrollToResults() {
             const resultEl = document.getElementById('results-section');
-            if (resultEl) {
-                resultEl.scrollIntoView({ behavior: 'smooth' });
-            }
+            if (!resultEl) return;
+            const header = document.getElementById('site-header');
+            const headerHeight = header ? header.offsetHeight : 0;
+            const y = resultEl.getBoundingClientRect().top + window.pageYOffset - headerHeight;
+            window.scrollTo({ top: y, behavior: 'smooth' });
         }
 
         // Mise à jour des boutons de navigation
@@ -1463,18 +1467,14 @@ async function calculateResults() {
 
 function displayResults(results) {
     const resultsHTML = generateResultsHTML(results);
-    
-    const resultsSection = document.createElement('div');
-    resultsSection.className = 'bg-blue-50 py-16 px-4 sm:px-6 lg:px-8';
-    resultsSection.id = 'results-section';
-    resultsSection.innerHTML = resultsHTML;
-    
-    const autoEvalSection = document.getElementById('home-mbti');
-    if (autoEvalSection) {
-        autoEvalSection.parentNode.insertBefore(resultsSection, autoEvalSection.nextSibling);
+
+    const resultsSection = document.getElementById('results-section');
+    if (resultsSection) {
+        resultsSection.className = 'bg-blue-50 py-16 px-4 sm:px-6 lg:px-8';
+        resultsSection.innerHTML = resultsHTML;
         initCountUp(resultsSection);
     }
-    
+
     localStorage.setItem('personalityTestResults', JSON.stringify(results));
     localStorage.removeItem('personalityTestProgress');
 }
@@ -1646,10 +1646,11 @@ function displayResults(results) {
                 currentQuestionIndex = 0;
                 answers = {};
                 
-                // Supprimer la section des résultats si elle existe
-                const resultsSection = document.querySelector('.bg-blue-50');
-                if (resultsSection && resultsSection.innerHTML.includes('Vos résultats')) {
-                    resultsSection.remove();
+                // Réinitialiser la section des résultats si elle existe
+                const resultsSection = document.getElementById('results-section');
+                if (resultsSection) {
+                    resultsSection.innerHTML = '';
+                    resultsSection.className = '';
                 }
                 
                 displayQuestion(0);

--- a/public/enneagramme.html
+++ b/public/enneagramme.html
@@ -980,6 +980,7 @@
             </div>
         </div>
     </div>
+<div id="results-section"></div>
 
    <!-- Footer -->
     <p class="text-xs text-gray-500 text-center mb-4">MBTI® est une marque déposée de The Myers-Briggs Company. Ce site propose une approche inspirée et n’est ni affilié, ni agréé, ni soutenu par cette société.</p>
@@ -1379,7 +1380,8 @@ function displayQuestion(index) {
                         const icon = finishButton.querySelector('i');
                         if (icon) icon.remove();
                         if (typeof applyTranslations === 'function') { applyTranslations(); }
-                        setTimeout(scrollToResults, 50);
+                        setTimeout(scrollToResults, 100);
+                        location.hash = 'results-section';
                     } else {
                         alert('Veuillez répondre à toutes les questions avant de terminer.');
                     }
@@ -1389,9 +1391,11 @@ function displayQuestion(index) {
 
         function scrollToResults() {
             const resultEl = document.getElementById('results-section');
-            if (resultEl) {
-                resultEl.scrollIntoView({ behavior: 'smooth' });
-            }
+            if (!resultEl) return;
+            const header = document.getElementById('site-header');
+            const headerHeight = header ? header.offsetHeight : 0;
+            const y = resultEl.getBoundingClientRect().top + window.pageYOffset - headerHeight;
+            window.scrollTo({ top: y, behavior: 'smooth' });
         }
 
         // Mise à jour des boutons de navigation
@@ -1894,18 +1898,14 @@ async function calculateResults() {
 
 function displayResults(results) {
     const resultsHTML = generateResultsHTML(results);
-    
-    const resultsSection = document.createElement('div');
-    resultsSection.className = 'bg-blue-50 py-16 px-4 sm:px-6 lg:px-8';
-    resultsSection.id = 'results-section';
-    resultsSection.innerHTML = resultsHTML;
-    
-    const autoEvalSection = document.getElementById('home-mbti');
-    if (autoEvalSection) {
-        autoEvalSection.parentNode.insertBefore(resultsSection, autoEvalSection.nextSibling);
+
+    const resultsSection = document.getElementById('results-section');
+    if (resultsSection) {
+        resultsSection.className = 'bg-blue-50 py-16 px-4 sm:px-6 lg:px-8';
+        resultsSection.innerHTML = resultsHTML;
         initCountUp(resultsSection);
     }
-    
+
     localStorage.setItem('personalityTestResults', JSON.stringify(results));
     localStorage.removeItem('personalityTestProgress');
 }
@@ -2077,10 +2077,11 @@ function displayResults(results) {
                 currentQuestionIndex = 0;
                 answers = {};
                 
-                // Supprimer la section des résultats si elle existe
-                const resultsSection = document.querySelector('.bg-blue-50');
-                if (resultsSection && resultsSection.innerHTML.includes('Vos résultats')) {
-                    resultsSection.remove();
+                // Réinitialiser la section des résultats si elle existe
+                const resultsSection = document.getElementById('results-section');
+                if (resultsSection) {
+                    resultsSection.innerHTML = '';
+                    resultsSection.className = '';
                 }
                 
                 displayQuestion(0);

--- a/public/index.html
+++ b/public/index.html
@@ -1495,7 +1495,8 @@ function displayQuestion(index) {
                 finishButton.addEventListener('click', async function () {
                     if (isSubmitting) return;
                     if (hasRendered) {
-                        setTimeout(scrollToResults, 50);
+                        setTimeout(scrollToResults, 100);
+                        location.hash = 'results-section';
                         return;
                     }
                     if (Object.keys(answers).length !== AUTO_QUESTIONS.length) {
@@ -1515,16 +1516,19 @@ function displayQuestion(index) {
                     const icon = finishButton.querySelector('i');
                     if (icon) icon.remove();
                     if (typeof applyTranslations === 'function') { applyTranslations(); }
-                    setTimeout(scrollToResults, 50);
+                    setTimeout(scrollToResults, 100);
+                    location.hash = 'results-section';
                 });
             }
         }
 
         function scrollToResults() {
             const resultEl = document.getElementById('results-section');
-            if (resultEl) {
-                resultEl.scrollIntoView({ behavior: 'smooth' });
-            }
+            if (!resultEl) return;
+            const header = document.getElementById('site-header');
+            const headerHeight = header ? header.offsetHeight : 0;
+            const y = resultEl.getBoundingClientRect().top + window.pageYOffset - headerHeight;
+            window.scrollTo({ top: y, behavior: 'smooth' });
         }
 
         // Mise à jour des boutons de navigation
@@ -2223,10 +2227,11 @@ function displayResults(results) {
                 answers = {};
                 hasRendered = false;
 
-                // Supprimer la section des résultats si elle existe
-                const resultsSection = document.querySelector('.bg-blue-50');
-                if (resultsSection && resultsSection.innerHTML.includes('Vos résultats')) {
-                    resultsSection.remove();
+                // Réinitialiser la section des résultats si elle existe
+                const resultsSection = document.getElementById('results-section');
+                if (resultsSection) {
+                    resultsSection.innerHTML = '';
+                    resultsSection.className = '';
                 }
 
                 displayQuestion(0);

--- a/public/mbti.html
+++ b/public/mbti.html
@@ -1077,6 +1077,7 @@
             </div>
         </div>
     </div>
+<div id="results-section"></div>
 
      <!-- Footer -->
     <p class="text-xs text-gray-500 text-center mb-4">MBTI® est une marque déposée de The Myers-Briggs Company. Ce site propose une approche inspirée et n’est ni affilié, ni agréé, ni soutenu par cette société.</p>
@@ -1475,7 +1476,8 @@ function displayQuestion(index) {
                         const icon = finishButton.querySelector('i');
                         if (icon) icon.remove();
                         if (typeof applyTranslations === 'function') { applyTranslations(); }
-                        setTimeout(scrollToResults, 50);
+                        setTimeout(scrollToResults, 100);
+                        location.hash = 'results-section';
                     } else {
                         alert('Veuillez répondre à toutes les questions avant de terminer.');
                     }
@@ -1485,9 +1487,11 @@ function displayQuestion(index) {
 
         function scrollToResults() {
             const resultEl = document.getElementById('results-section');
-            if (resultEl) {
-                resultEl.scrollIntoView({ behavior: 'smooth' });
-            }
+            if (!resultEl) return;
+            const header = document.getElementById('site-header');
+            const headerHeight = header ? header.offsetHeight : 0;
+            const y = resultEl.getBoundingClientRect().top + window.pageYOffset - headerHeight;
+            window.scrollTo({ top: y, behavior: 'smooth' });
         }
 
         // Mise à jour des boutons de navigation
@@ -1990,18 +1994,14 @@ async function calculateResults() {
 
 function displayResults(results) {
     const resultsHTML = generateResultsHTML(results);
-    
-    const resultsSection = document.createElement('div');
-    resultsSection.className = 'bg-blue-50 py-16 px-4 sm:px-6 lg:px-8';
-    resultsSection.id = 'results-section';
-    resultsSection.innerHTML = resultsHTML;
-    
-    const autoEvalSection = document.getElementById('home-mbti');
-    if (autoEvalSection) {
-        autoEvalSection.parentNode.insertBefore(resultsSection, autoEvalSection.nextSibling);
+
+    const resultsSection = document.getElementById('results-section');
+    if (resultsSection) {
+        resultsSection.className = 'bg-blue-50 py-16 px-4 sm:px-6 lg:px-8';
+        resultsSection.innerHTML = resultsHTML;
         initCountUp(resultsSection);
     }
-    
+
     localStorage.setItem('personalityTestResults', JSON.stringify(results));
     localStorage.removeItem('personalityTestProgress');
 }
@@ -2173,10 +2173,11 @@ function displayResults(results) {
                 currentQuestionIndex = 0;
                 answers = {};
                 
-                // Supprimer la section des résultats si elle existe
-                const resultsSection = document.querySelector('.bg-blue-50');
-                if (resultsSection && resultsSection.innerHTML.includes('Vos résultats')) {
-                    resultsSection.remove();
+                // Réinitialiser la section des résultats si elle existe
+                const resultsSection = document.getElementById('results-section');
+                if (resultsSection) {
+                    resultsSection.innerHTML = '';
+                    resultsSection.className = '';
                 }
                 
                 displayQuestion(0);


### PR DESCRIPTION
## Summary
- add `scrollToResults()` globally to compute offsets and scroll smoothly
- defer scrolling and update `location.hash` after rendering results
- include missing `#results-section` containers on MBTI, Ennéagramme and blog pages

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b053dd43188321bdfa0f55bdcd7c73