### PR TITLE
Improve auto-scroll reliability

### DIFF
--- a/public/blog.html
+++ b/public/blog.html
@@ -949,7 +949,7 @@ function displayQuestion(index) {
                         const icon = finishButton.querySelector('i');
                         if (icon) icon.remove();
                         if (typeof applyTranslations === 'function') { applyTranslations(); }
-                        setTimeout(scrollToResults, 100);
+                        scrollToResults();
                         location.hash = 'results-section';
                     } else {
                         alert('Veuillez répondre à toutes les questions avant de terminer.');
@@ -958,13 +958,56 @@ function displayQuestion(index) {
             }
         }
 
-        function scrollToResults() {
-            const resultEl = document.getElementById('results-section');
-            if (!resultEl) return;
-            const header = document.getElementById('site-header');
-            const headerHeight = header ? header.offsetHeight : 0;
-            const y = resultEl.getBoundingClientRect().top + window.pageYOffset - headerHeight;
-            window.scrollTo({ top: y, behavior: 'smooth' });
+        function getScrollableAncestor(el) {
+            let p = el.parentElement;
+            while (p) {
+                const style = getComputedStyle(p);
+                const canScroll = /(auto|scroll)/.test(style.overflowY) || p.scrollHeight > p.clientHeight;
+                if (canScroll) return p;
+                p = p.parentElement;
+            }
+            return document.scrollingElement || document.documentElement; // fallback window
+        }
+
+        function waitForVisible(selector, timeout = 2000) {
+            return new Promise((resolve, reject) => {
+                const start = performance.now();
+                const tick = () => {
+                    const el = document.querySelector(selector);
+                    if (el && el.offsetHeight > 0) return resolve(el);
+                    if (performance.now() - start > timeout) return reject(new Error('timeout'));
+                    requestAnimationFrame(tick);
+                };
+                tick();
+            });
+        }
+
+        async function scrollToResults() {
+            try {
+                const el = await waitForVisible('#results-section', 2500);
+                const header = document.querySelector('#site-header, header.sticky, .header.sticky');
+                const headerH = header ? header.offsetHeight : 0;
+                const scroller = getScrollableAncestor(el);
+                const rect = el.getBoundingClientRect();
+                const baseY = (scroller === document.scrollingElement || scroller === document.documentElement)
+                    ? window.pageYOffset
+                    : scroller.scrollTop;
+                const targetY = baseY + rect.top - headerH - 8;
+                requestAnimationFrame(() => {
+                    requestAnimationFrame(() => {
+                        if (scroller === document.scrollingElement || scroller === document.documentElement) {
+                            window.scrollTo({ top: Math.max(0, targetY), behavior: 'smooth' });
+                        } else {
+                            try { scroller.scrollTo({ top: Math.max(0, targetY), behavior: 'smooth' }); }
+                            catch { scroller.scrollTop = Math.max(0, targetY); }
+                        }
+                        try { history.replaceState(null, '', '#results-section'); } catch {}
+                    });
+                });
+            } catch (e) {
+                const el = document.getElementById('results-section');
+                if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            }
         }
 
         // Mise à jour des boutons de navigation

--- a/public/enneagramme.html
+++ b/public/enneagramme.html
@@ -1380,7 +1380,7 @@ function displayQuestion(index) {
                         const icon = finishButton.querySelector('i');
                         if (icon) icon.remove();
                         if (typeof applyTranslations === 'function') { applyTranslations(); }
-                        setTimeout(scrollToResults, 100);
+                        scrollToResults();
                         location.hash = 'results-section';
                     } else {
                         alert('Veuillez répondre à toutes les questions avant de terminer.');
@@ -1389,13 +1389,56 @@ function displayQuestion(index) {
             }
         }
 
-        function scrollToResults() {
-            const resultEl = document.getElementById('results-section');
-            if (!resultEl) return;
-            const header = document.getElementById('site-header');
-            const headerHeight = header ? header.offsetHeight : 0;
-            const y = resultEl.getBoundingClientRect().top + window.pageYOffset - headerHeight;
-            window.scrollTo({ top: y, behavior: 'smooth' });
+        function getScrollableAncestor(el) {
+            let p = el.parentElement;
+            while (p) {
+                const style = getComputedStyle(p);
+                const canScroll = /(auto|scroll)/.test(style.overflowY) || p.scrollHeight > p.clientHeight;
+                if (canScroll) return p;
+                p = p.parentElement;
+            }
+            return document.scrollingElement || document.documentElement; // fallback window
+        }
+
+        function waitForVisible(selector, timeout = 2000) {
+            return new Promise((resolve, reject) => {
+                const start = performance.now();
+                const tick = () => {
+                    const el = document.querySelector(selector);
+                    if (el && el.offsetHeight > 0) return resolve(el);
+                    if (performance.now() - start > timeout) return reject(new Error('timeout'));
+                    requestAnimationFrame(tick);
+                };
+                tick();
+            });
+        }
+
+        async function scrollToResults() {
+            try {
+                const el = await waitForVisible('#results-section', 2500);
+                const header = document.querySelector('#site-header, header.sticky, .header.sticky');
+                const headerH = header ? header.offsetHeight : 0;
+                const scroller = getScrollableAncestor(el);
+                const rect = el.getBoundingClientRect();
+                const baseY = (scroller === document.scrollingElement || scroller === document.documentElement)
+                    ? window.pageYOffset
+                    : scroller.scrollTop;
+                const targetY = baseY + rect.top - headerH - 8;
+                requestAnimationFrame(() => {
+                    requestAnimationFrame(() => {
+                        if (scroller === document.scrollingElement || scroller === document.documentElement) {
+                            window.scrollTo({ top: Math.max(0, targetY), behavior: 'smooth' });
+                        } else {
+                            try { scroller.scrollTo({ top: Math.max(0, targetY), behavior: 'smooth' }); }
+                            catch { scroller.scrollTop = Math.max(0, targetY); }
+                        }
+                        try { history.replaceState(null, '', '#results-section'); } catch {}
+                    });
+                });
+            } catch (e) {
+                const el = document.getElementById('results-section');
+                if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            }
         }
 
         // Mise à jour des boutons de navigation

--- a/public/index.html
+++ b/public/index.html
@@ -1495,7 +1495,7 @@ function displayQuestion(index) {
                 finishButton.addEventListener('click', async function () {
                     if (isSubmitting) return;
                     if (hasRendered) {
-                        setTimeout(scrollToResults, 100);
+                        scrollToResults();
                         location.hash = 'results-section';
                         return;
                     }
@@ -1516,19 +1516,62 @@ function displayQuestion(index) {
                     const icon = finishButton.querySelector('i');
                     if (icon) icon.remove();
                     if (typeof applyTranslations === 'function') { applyTranslations(); }
-                    setTimeout(scrollToResults, 100);
+                    scrollToResults();
                     location.hash = 'results-section';
                 });
             }
         }
 
-        function scrollToResults() {
-            const resultEl = document.getElementById('results-section');
-            if (!resultEl) return;
-            const header = document.getElementById('site-header');
-            const headerHeight = header ? header.offsetHeight : 0;
-            const y = resultEl.getBoundingClientRect().top + window.pageYOffset - headerHeight;
-            window.scrollTo({ top: y, behavior: 'smooth' });
+        function getScrollableAncestor(el) {
+            let p = el.parentElement;
+            while (p) {
+                const style = getComputedStyle(p);
+                const canScroll = /(auto|scroll)/.test(style.overflowY) || p.scrollHeight > p.clientHeight;
+                if (canScroll) return p;
+                p = p.parentElement;
+            }
+            return document.scrollingElement || document.documentElement; // fallback window
+        }
+
+        function waitForVisible(selector, timeout = 2000) {
+            return new Promise((resolve, reject) => {
+                const start = performance.now();
+                const tick = () => {
+                    const el = document.querySelector(selector);
+                    if (el && el.offsetHeight > 0) return resolve(el);
+                    if (performance.now() - start > timeout) return reject(new Error('timeout'));
+                    requestAnimationFrame(tick);
+                };
+                tick();
+            });
+        }
+
+        async function scrollToResults() {
+            try {
+                const el = await waitForVisible('#results-section', 2500);
+                const header = document.querySelector('#site-header, header.sticky, .header.sticky');
+                const headerH = header ? header.offsetHeight : 0;
+                const scroller = getScrollableAncestor(el);
+                const rect = el.getBoundingClientRect();
+                const baseY = (scroller === document.scrollingElement || scroller === document.documentElement)
+                    ? window.pageYOffset
+                    : scroller.scrollTop;
+                const targetY = baseY + rect.top - headerH - 8;
+                requestAnimationFrame(() => {
+                    requestAnimationFrame(() => {
+                        if (scroller === document.scrollingElement || scroller === document.documentElement) {
+                            window.scrollTo({ top: Math.max(0, targetY), behavior: 'smooth' });
+                        } else {
+                            try { scroller.scrollTo({ top: Math.max(0, targetY), behavior: 'smooth' }); }
+                            catch { scroller.scrollTop = Math.max(0, targetY); }
+                        }
+                        try { history.replaceState(null, '', '#results-section'); } catch {}
+                    });
+                });
+            } catch (e) {
+                const el = document.getElementById('results-section');
+                if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            }
         }
 
         // Mise à jour des boutons de navigation

--- a/public/mbti.html
+++ b/public/mbti.html
@@ -1476,7 +1476,7 @@ function displayQuestion(index) {
                         const icon = finishButton.querySelector('i');
                         if (icon) icon.remove();
                         if (typeof applyTranslations === 'function') { applyTranslations(); }
-                        setTimeout(scrollToResults, 100);
+                        scrollToResults();
                         location.hash = 'results-section';
                     } else {
                         alert('Veuillez répondre à toutes les questions avant de terminer.');
@@ -1485,13 +1485,56 @@ function displayQuestion(index) {
             }
         }
 
-        function scrollToResults() {
-            const resultEl = document.getElementById('results-section');
-            if (!resultEl) return;
-            const header = document.getElementById('site-header');
-            const headerHeight = header ? header.offsetHeight : 0;
-            const y = resultEl.getBoundingClientRect().top + window.pageYOffset - headerHeight;
-            window.scrollTo({ top: y, behavior: 'smooth' });
+        function getScrollableAncestor(el) {
+            let p = el.parentElement;
+            while (p) {
+                const style = getComputedStyle(p);
+                const canScroll = /(auto|scroll)/.test(style.overflowY) || p.scrollHeight > p.clientHeight;
+                if (canScroll) return p;
+                p = p.parentElement;
+            }
+            return document.scrollingElement || document.documentElement; // fallback window
+        }
+
+        function waitForVisible(selector, timeout = 2000) {
+            return new Promise((resolve, reject) => {
+                const start = performance.now();
+                const tick = () => {
+                    const el = document.querySelector(selector);
+                    if (el && el.offsetHeight > 0) return resolve(el);
+                    if (performance.now() - start > timeout) return reject(new Error('timeout'));
+                    requestAnimationFrame(tick);
+                };
+                tick();
+            });
+        }
+
+        async function scrollToResults() {
+            try {
+                const el = await waitForVisible('#results-section', 2500);
+                const header = document.querySelector('#site-header, header.sticky, .header.sticky');
+                const headerH = header ? header.offsetHeight : 0;
+                const scroller = getScrollableAncestor(el);
+                const rect = el.getBoundingClientRect();
+                const baseY = (scroller === document.scrollingElement || scroller === document.documentElement)
+                    ? window.pageYOffset
+                    : scroller.scrollTop;
+                const targetY = baseY + rect.top - headerH - 8;
+                requestAnimationFrame(() => {
+                    requestAnimationFrame(() => {
+                        if (scroller === document.scrollingElement || scroller === document.documentElement) {
+                            window.scrollTo({ top: Math.max(0, targetY), behavior: 'smooth' });
+                        } else {
+                            try { scroller.scrollTo({ top: Math.max(0, targetY), behavior: 'smooth' }); }
+                            catch { scroller.scrollTop = Math.max(0, targetY); }
+                        }
+                        try { history.replaceState(null, '', '#results-section'); } catch {}
+                    });
+                });
+            } catch (e) {
+                const el = document.getElementById('results-section');
+                if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            }
         }
 
         // Mise à jour des boutons de navigation


### PR DESCRIPTION
## Summary
- add getScrollableAncestor, waitForVisible, and async scrollToResults helpers
- replace delayed setTimeout calls with scrollToResults on results pages
- keep results injection targeting existing #results-section

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b05828a1dc8321b30103b8bdb47270