### PR TITLE
Show auto-evaluation results only in modal

### DIFF
--- a/public/blog.html
+++ b/public/blog.html
@@ -949,8 +949,6 @@ function displayQuestion(index) {
                         const icon = finishButton.querySelector('i');
                         if (icon) icon.remove();
                         if (typeof applyTranslations === 'function') { applyTranslations(); }
-                        scrollToResults();
-                        location.hash = 'results-section';
                     } else {
                         alert('Veuillez répondre à toutes les questions avant de terminer.');
                     }
@@ -1511,12 +1509,22 @@ async function calculateResults() {
 function displayResults(results) {
     const resultsHTML = generateResultsHTML(results);
 
-    const resultsSection = document.getElementById('results-section');
-    if (resultsSection) {
-        resultsSection.className = 'bg-blue-50 py-16 px-4 sm:px-6 lg:px-8';
-        resultsSection.innerHTML = resultsHTML;
-        initCountUp(resultsSection);
-    }
+    const existing = document.getElementById('results-modal');
+    if (existing) existing.remove();
+
+    const modal = document.createElement('div');
+    modal.id = 'results-modal';
+    modal.className = 'modal show';
+    modal.innerHTML = `
+        <div class="modal-content" style="max-width: 800px;">
+            <div class="modal-header">
+                <h2 class="text-xl font-bold text-gray-900">Vos résultats</h2>
+                <span class="close" onclick="closeResultsModal()">&times;</span>
+            </div>
+            <div class="modal-body">${resultsHTML}</div>
+        </div>`;
+    document.body.appendChild(modal);
+    initCountUp(modal);
 
     localStorage.setItem('personalityTestResults', JSON.stringify(results));
     localStorage.removeItem('personalityTestProgress');
@@ -3819,6 +3827,15 @@ function showSupport() {
                 closeResultsModal();
             }
         }
+
+        document.addEventListener('keydown', function(event) {
+            const profileModal = document.getElementById('profile-modal');
+            const resultsModal = document.getElementById('results-modal');
+            if (event.key === 'Escape') {
+                if (resultsModal) { closeResultsModal(); }
+                if (profileModal) { closeProfileModal(); }
+            }
+        });
 
         // Permettre la saisie du code avec Entrée
         document.addEventListener('DOMContentLoaded', function() {

--- a/public/enneagramme.html
+++ b/public/enneagramme.html
@@ -1380,8 +1380,6 @@ function displayQuestion(index) {
                         const icon = finishButton.querySelector('i');
                         if (icon) icon.remove();
                         if (typeof applyTranslations === 'function') { applyTranslations(); }
-                        scrollToResults();
-                        location.hash = 'results-section';
                     } else {
                         alert('Veuillez répondre à toutes les questions avant de terminer.');
                     }
@@ -1942,12 +1940,22 @@ async function calculateResults() {
 function displayResults(results) {
     const resultsHTML = generateResultsHTML(results);
 
-    const resultsSection = document.getElementById('results-section');
-    if (resultsSection) {
-        resultsSection.className = 'bg-blue-50 py-16 px-4 sm:px-6 lg:px-8';
-        resultsSection.innerHTML = resultsHTML;
-        initCountUp(resultsSection);
-    }
+    const existing = document.getElementById('results-modal');
+    if (existing) existing.remove();
+
+    const modal = document.createElement('div');
+    modal.id = 'results-modal';
+    modal.className = 'modal show';
+    modal.innerHTML = `
+        <div class="modal-content" style="max-width: 800px;">
+            <div class="modal-header">
+                <h2 class="text-xl font-bold text-gray-900">Vos résultats</h2>
+                <span class="close" onclick="closeResultsModal()">&times;</span>
+            </div>
+            <div class="modal-body">${resultsHTML}</div>
+        </div>`;
+    document.body.appendChild(modal);
+    initCountUp(modal);
 
     localStorage.setItem('personalityTestResults', JSON.stringify(results));
     localStorage.removeItem('personalityTestProgress');
@@ -4266,6 +4274,15 @@ function showSupport() {
                 closeResultsModal();
             }
         }
+
+        document.addEventListener('keydown', function(event) {
+            const profileModal = document.getElementById('profile-modal');
+            const resultsModal = document.getElementById('results-modal');
+            if (event.key === 'Escape') {
+                if (resultsModal) { closeResultsModal(); }
+                if (profileModal) { closeProfileModal(); }
+            }
+        });
 
         // Permettre la saisie du code avec Entrée
         document.addEventListener('DOMContentLoaded', function() {

--- a/public/index.html
+++ b/public/index.html
@@ -1495,8 +1495,7 @@ function displayQuestion(index) {
                 finishButton.addEventListener('click', async function () {
                     if (isSubmitting) return;
                     if (hasRendered) {
-                        scrollToResults();
-                        location.hash = 'results-section';
+                        displayResults(window.finalResults || {});
                         return;
                     }
                     if (Object.keys(answers).length !== AUTO_QUESTIONS.length) {
@@ -1516,8 +1515,6 @@ function displayQuestion(index) {
                     const icon = finishButton.querySelector('i');
                     if (icon) icon.remove();
                     if (typeof applyTranslations === 'function') { applyTranslations(); }
-                    scrollToResults();
-                    location.hash = 'results-section';
                 });
             }
         }
@@ -2090,37 +2087,38 @@ function displayResults(results) {
     window.finalResults = results;
     const resultsHTML = generateResultsHTML(window.finalResults || {});
 
-    const resultsSection = document.getElementById('results-section');
-    if (resultsSection) {
-        resultsSection.className = 'bg-blue-50 py-16 px-4 sm:px-6 lg:px-8';
-        resultsSection.innerHTML = resultsHTML;
-        initCountUp(resultsSection);
+    const existing = document.getElementById('results-modal');
+    if (existing) existing.remove();
 
-        if (typeof applyTranslations === 'function') {
-            applyTranslations();
-            const finalResults = window.finalResults || {};
-            const lang = document.documentElement.lang || 'fr';
-            const mbti = (finalResults.mbtiType || "").toUpperCase();
-            const ennea = String(finalResults.enneagramType || "");
+    const modal = document.createElement('div');
+    modal.id = 'results-modal';
+    modal.className = 'modal show';
+    modal.innerHTML = `
+        <div class="modal-content" style="max-width: 800px;">
+            <div class="modal-header">
+                <h2 class="text-xl font-bold text-gray-900" data-i18n="results.summary.title">Vos résultats</h2>
+                <span class="close" onclick="closeResultsModal()">&times;</span>
+            </div>
+            <div class="modal-body">${resultsHTML}</div>
+        </div>`;
+    document.body.appendChild(modal);
+    initCountUp(modal);
 
-            // Choix du texte : MBTI > Ennéagramme > Fallback
-            let careerText =
-                (translations[lang].results.career.mbti &&
-                    translations[lang].results.career.mbti[mbti]) ||
-                (translations[lang].results.career.ennea &&
-                    translations[lang].results.career.ennea[ennea]) ||
-                translations[lang].results.career.fallback;
+    if (typeof applyTranslations === 'function') {
+        applyTranslations();
+        const finalResults = window.finalResults || {};
+        const lang = document.documentElement.lang || 'fr';
+        const mbti = (finalResults.mbtiType || "").toUpperCase();
+        const ennea = String(finalResults.enneagramType || "");
 
-            // Debug pour vérifier
-            console.log("MBTI demandé:", mbti);
-            console.log("Ennéagramme demandé:", ennea);
-            console.log("Clés MBTI trad dispo:", Object.keys(translations[lang].results.career.mbti));
-            console.log("Clés Ennéa trad dispo:", Object.keys(translations[lang].results.career.ennea));
-            console.log("Texte carrière choisi:", careerText);
-
-            // Injection dans le bloc
-            document.getElementById("careerProfileText").innerText = careerText;
-        }
+        let careerText =
+            (translations[lang].results.career.mbti &&
+                translations[lang].results.career.mbti[mbti]) ||
+            (translations[lang].results.career.ennea &&
+                translations[lang].results.career.ennea[ennea]) ||
+            translations[lang].results.career.fallback;
+        const careerEl = document.getElementById("careerProfileText");
+        if (careerEl) { careerEl.innerText = careerText; }
     }
 
     localStorage.setItem('personalityTestResults', JSON.stringify(results));
@@ -4575,6 +4573,15 @@ window.showSupport = showSupport;
                 closeResultsModal();
             }
         }
+
+        document.addEventListener('keydown', function(event) {
+            const profileModal = document.getElementById('profile-modal');
+            const resultsModal = document.getElementById('results-modal');
+            if (event.key === 'Escape') {
+                if (resultsModal) { closeResultsModal(); }
+                if (profileModal) { closeProfileModal(); }
+            }
+        });
 
         // Permettre la saisie du code avec Entrée
         document.addEventListener('DOMContentLoaded', function() {

--- a/public/mbti.html
+++ b/public/mbti.html
@@ -1476,8 +1476,6 @@ function displayQuestion(index) {
                         const icon = finishButton.querySelector('i');
                         if (icon) icon.remove();
                         if (typeof applyTranslations === 'function') { applyTranslations(); }
-                        scrollToResults();
-                        location.hash = 'results-section';
                     } else {
                         alert('Veuillez répondre à toutes les questions avant de terminer.');
                     }
@@ -2038,12 +2036,22 @@ async function calculateResults() {
 function displayResults(results) {
     const resultsHTML = generateResultsHTML(results);
 
-    const resultsSection = document.getElementById('results-section');
-    if (resultsSection) {
-        resultsSection.className = 'bg-blue-50 py-16 px-4 sm:px-6 lg:px-8';
-        resultsSection.innerHTML = resultsHTML;
-        initCountUp(resultsSection);
-    }
+    const existing = document.getElementById('results-modal');
+    if (existing) existing.remove();
+
+    const modal = document.createElement('div');
+    modal.id = 'results-modal';
+    modal.className = 'modal show';
+    modal.innerHTML = `
+        <div class="modal-content" style="max-width: 800px;">
+            <div class="modal-header">
+                <h2 class="text-xl font-bold text-gray-900">Vos résultats</h2>
+                <span class="close" onclick="closeResultsModal()">&times;</span>
+            </div>
+            <div class="modal-body">${resultsHTML}</div>
+        </div>`;
+    document.body.appendChild(modal);
+    initCountUp(modal);
 
     localStorage.setItem('personalityTestResults', JSON.stringify(results));
     localStorage.removeItem('personalityTestProgress');
@@ -4378,6 +4386,15 @@ function showSupport() {
                 closeResultsModal();
             }
         }
+
+        document.addEventListener('keydown', function(event) {
+            const profileModal = document.getElementById('profile-modal');
+            const resultsModal = document.getElementById('results-modal');
+            if (event.key === 'Escape') {
+                if (resultsModal) { closeResultsModal(); }
+                if (profileModal) { closeProfileModal(); }
+            }
+        });
 
         // Permettre la saisie du code avec Entrée
         document.addEventListener('DOMContentLoaded', function() {


### PR DESCRIPTION
## Summary
- Display auto-evaluation results in a centered modal and remove bottom results block
- Enable closing results modal via close button, outside click, or Escape key
- Apply modal-based result display across index, blog, MBTI, and Enneagram pages

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b0953b71d48321b0bbce40cf7bc461