### PR TITLE
Limit grey background to Enneagram history section

### DIFF
--- a/public/enneagramme.html
+++ b/public/enneagramme.html
@@ -580,7 +580,7 @@
 </section>
 
 
-    <div id="ennea-types" data-aos="fade-left" class="section section-fonce py-16 px-4 sm:px-6 lg:px-8">
+    <div id="ennea-types" data-aos="fade-left" class="section section-clair py-16 px-4 sm:px-6 lg:px-8">
         <div class="max-w-7xl mx-auto">
             <div class="text-center">
                 <h2 class="text-3xl font-extrabold text-gray-900 sm:text-4xl" data-i18n="enneagramme.types.title">


### PR DESCRIPTION
## Summary
- Keep white background for all Enneagram page sections except the history section
- History remains gray while the types section now uses white

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b0cee5fe948321945d6a5782642d4d