### PR TITLE
Fix MBTI T/F percentage display in results chart

### DIFF
--- a/public/blog.html
+++ b/public/blog.html
@@ -3570,12 +3570,23 @@ function showSupport() {
                 { label: 'T / F', a: 'T', b: 'F' },
                 { label: 'J / P', a: 'J', b: 'P' }
             ];
+            const traitScores = {
+                E: (profile.mbtiScores.Fe || 0) + (profile.mbtiScores.Te || 0) + (profile.mbtiScores.Se || 0) + (profile.mbtiScores.Ne || 0),
+                I: (profile.mbtiScores.Fi || 0) + (profile.mbtiScores.Ti || 0) + (profile.mbtiScores.Si || 0) + (profile.mbtiScores.Ni || 0),
+                S: (profile.mbtiScores.Si || 0) + (profile.mbtiScores.Se || 0),
+                N: (profile.mbtiScores.Ni || 0) + (profile.mbtiScores.Ne || 0),
+                T: (profile.mbtiScores.Ti || 0) + (profile.mbtiScores.Te || 0),
+                F: (profile.mbtiScores.Fi || 0) + (profile.mbtiScores.Fe || 0),
+                J: (profile.mbtiScores.Te || 0) + (profile.mbtiScores.Fe || 0),
+                P: (profile.mbtiScores.Se || 0) + (profile.mbtiScores.Ne || 0)
+            };
+            const clamp = (val) => Math.min(100, Math.max(0, val));
             const mbtiData = mbtiPairs.map(pair => {
-                const aScore = profile.mbtiScores[pair.a];
-                const bScore = profile.mbtiScores[pair.b];
+                const aScore = traitScores[pair.a];
+                const bScore = traitScores[pair.b];
                 const dominant = aScore > bScore ? pair.a : pair.b;
-                const value = Math.round((Math.max(aScore, bScore) / (aScore + bScore)) * 100);
-                return { label: pair.label, value, dominant };
+                const rawValue = Math.round((Math.max(aScore, bScore) / (aScore + bScore)) * 100);
+                return { label: pair.label, value: clamp(rawValue), dominant };
             });
             const mbtiDescriptions = { E: 'Extraversion', I: 'Introversion', S: 'Sensation', N: 'Intuition', T: 'Pensée', F: 'Sentiment', J: 'Jugement', P: 'Perception' };
             Chart.register(ChartDataLabels);

--- a/public/enneagramme.html
+++ b/public/enneagramme.html
@@ -4029,12 +4029,23 @@ function showSupport() {
                 { label: 'T / F', a: 'T', b: 'F' },
                 { label: 'J / P', a: 'J', b: 'P' }
             ];
+            const traitScores = {
+                E: (profile.mbtiScores.Fe || 0) + (profile.mbtiScores.Te || 0) + (profile.mbtiScores.Se || 0) + (profile.mbtiScores.Ne || 0),
+                I: (profile.mbtiScores.Fi || 0) + (profile.mbtiScores.Ti || 0) + (profile.mbtiScores.Si || 0) + (profile.mbtiScores.Ni || 0),
+                S: (profile.mbtiScores.Si || 0) + (profile.mbtiScores.Se || 0),
+                N: (profile.mbtiScores.Ni || 0) + (profile.mbtiScores.Ne || 0),
+                T: (profile.mbtiScores.Ti || 0) + (profile.mbtiScores.Te || 0),
+                F: (profile.mbtiScores.Fi || 0) + (profile.mbtiScores.Fe || 0),
+                J: (profile.mbtiScores.Te || 0) + (profile.mbtiScores.Fe || 0),
+                P: (profile.mbtiScores.Se || 0) + (profile.mbtiScores.Ne || 0)
+            };
+            const clamp = (val) => Math.min(100, Math.max(0, val));
             const mbtiData = mbtiPairs.map(pair => {
-                const aScore = profile.mbtiScores[pair.a];
-                const bScore = profile.mbtiScores[pair.b];
+                const aScore = traitScores[pair.a];
+                const bScore = traitScores[pair.b];
                 const dominant = aScore > bScore ? pair.a : pair.b;
-                const value = Math.round((Math.max(aScore, bScore) / (aScore + bScore)) * 100);
-                return { label: pair.label, value, dominant };
+                const rawValue = Math.round((Math.max(aScore, bScore) / (aScore + bScore)) * 100);
+                return { label: pair.label, value: clamp(rawValue), dominant };
             });
             const mbtiDescriptions = { E: 'Extraversion', I: 'Introversion', S: 'Sensation', N: 'Intuition', T: 'Pensée', F: 'Sentiment', J: 'Jugement', P: 'Perception' };
             Chart.register(ChartDataLabels);

--- a/public/mbti.html
+++ b/public/mbti.html
@@ -4143,12 +4143,23 @@ function showSupport() {
                 { label: 'T / F', a: 'T', b: 'F' },
                 { label: 'J / P', a: 'J', b: 'P' }
             ];
+            const traitScores = {
+                E: (profile.mbtiScores.Fe || 0) + (profile.mbtiScores.Te || 0) + (profile.mbtiScores.Se || 0) + (profile.mbtiScores.Ne || 0),
+                I: (profile.mbtiScores.Fi || 0) + (profile.mbtiScores.Ti || 0) + (profile.mbtiScores.Si || 0) + (profile.mbtiScores.Ni || 0),
+                S: (profile.mbtiScores.Si || 0) + (profile.mbtiScores.Se || 0),
+                N: (profile.mbtiScores.Ni || 0) + (profile.mbtiScores.Ne || 0),
+                T: (profile.mbtiScores.Ti || 0) + (profile.mbtiScores.Te || 0),
+                F: (profile.mbtiScores.Fi || 0) + (profile.mbtiScores.Fe || 0),
+                J: (profile.mbtiScores.Te || 0) + (profile.mbtiScores.Fe || 0),
+                P: (profile.mbtiScores.Se || 0) + (profile.mbtiScores.Ne || 0)
+            };
+            const clamp = (val) => Math.min(100, Math.max(0, val));
             const mbtiData = mbtiPairs.map(pair => {
-                const aScore = profile.mbtiScores[pair.a];
-                const bScore = profile.mbtiScores[pair.b];
+                const aScore = traitScores[pair.a];
+                const bScore = traitScores[pair.b];
                 const dominant = aScore > bScore ? pair.a : pair.b;
-                const value = Math.round((Math.max(aScore, bScore) / (aScore + bScore)) * 100);
-                return { label: pair.label, value, dominant };
+                const rawValue = Math.round((Math.max(aScore, bScore) / (aScore + bScore)) * 100);
+                return { label: pair.label, value: clamp(rawValue), dominant };
             });
             const mbtiDescriptions = { E: 'Extraversion', I: 'Introversion', S: 'Sensation', N: 'Intuition', T: 'Pensée', F: 'Sentiment', J: 'Jugement', P: 'Perception' };
             Chart.register(ChartDataLabels);


### PR DESCRIPTION
## Summary
- compute trait-based MBTI scores from function scores before building chart datasets
- inject corrected T/F values into Chart.js datasets to show accurate percentages

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68b0d92cb7bc8321b9a77ec27eef1aff