### PR TITLE
Compare cognitive function pairs in MBTI chart

### DIFF
--- a/public/blog.html
+++ b/public/blog.html
@@ -3565,30 +3565,29 @@ function showSupport() {
 
             const mbtiCtx = mbtiCanvas.getContext('2d');
             const mbtiPairs = [
-                { label: 'E / I', a: 'E', b: 'I' },
-                { label: 'S / N', a: 'S', b: 'N' },
-                { label: 'T / F', a: 'T', b: 'F' },
-                { label: 'J / P', a: 'J', b: 'P' }
+                { label: 'Fi / Te', a: 'Fi', b: 'Te' },
+                { label: 'Fe / Ti', a: 'Fe', b: 'Ti' },
+                { label: 'Si / Ne', a: 'Si', b: 'Ne' },
+                { label: 'Se / Ni', a: 'Se', b: 'Ni' }
             ];
-            const traitScores = {
-                E: (profile.mbtiScores.Fe || 0) + (profile.mbtiScores.Te || 0) + (profile.mbtiScores.Se || 0) + (profile.mbtiScores.Ne || 0),
-                I: (profile.mbtiScores.Fi || 0) + (profile.mbtiScores.Ti || 0) + (profile.mbtiScores.Si || 0) + (profile.mbtiScores.Ni || 0),
-                S: (profile.mbtiScores.Si || 0) + (profile.mbtiScores.Se || 0),
-                N: (profile.mbtiScores.Ni || 0) + (profile.mbtiScores.Ne || 0),
-                T: (profile.mbtiScores.Ti || 0) + (profile.mbtiScores.Te || 0),
-                F: (profile.mbtiScores.Fi || 0) + (profile.mbtiScores.Fe || 0),
-                J: (profile.mbtiScores.Te || 0) + (profile.mbtiScores.Fe || 0),
-                P: (profile.mbtiScores.Se || 0) + (profile.mbtiScores.Ne || 0)
-            };
             const clamp = (val) => Math.min(100, Math.max(0, val));
             const mbtiData = mbtiPairs.map(pair => {
-                const aScore = traitScores[pair.a];
-                const bScore = traitScores[pair.b];
+                const aScore = profile.mbtiScores[pair.a] || 0;
+                const bScore = profile.mbtiScores[pair.b] || 0;
                 const dominant = aScore > bScore ? pair.a : pair.b;
-                const rawValue = Math.round((Math.max(aScore, bScore) / (aScore + bScore)) * 100);
+                const rawValue = (aScore + bScore) === 0 ? 0 : Math.round((Math.max(aScore, bScore) / (aScore + bScore)) * 100);
                 return { label: pair.label, value: clamp(rawValue), dominant };
             });
-            const mbtiDescriptions = { E: 'Extraversion', I: 'Introversion', S: 'Sensation', N: 'Intuition', T: 'Pensée', F: 'Sentiment', J: 'Jugement', P: 'Perception' };
+            const mbtiDescriptions = {
+                Fi: 'Sentiment Introverti',
+                Te: 'Pensée Extravertie',
+                Fe: 'Sentiment Extraverti',
+                Ti: 'Pensée Introvertie',
+                Si: 'Sensation Introvertie',
+                Ne: 'Intuition Extravertie',
+                Se: 'Sensation Extravertie',
+                Ni: 'Intuition Introvertie'
+            };
             Chart.register(ChartDataLabels);
             new Chart(mbtiCtx, {
                 type: 'bar',

--- a/public/enneagramme.html
+++ b/public/enneagramme.html
@@ -4024,30 +4024,29 @@ function showSupport() {
 
             const mbtiCtx = mbtiCanvas.getContext('2d');
             const mbtiPairs = [
-                { label: 'E / I', a: 'E', b: 'I' },
-                { label: 'S / N', a: 'S', b: 'N' },
-                { label: 'T / F', a: 'T', b: 'F' },
-                { label: 'J / P', a: 'J', b: 'P' }
+                { label: 'Fi / Te', a: 'Fi', b: 'Te' },
+                { label: 'Fe / Ti', a: 'Fe', b: 'Ti' },
+                { label: 'Si / Ne', a: 'Si', b: 'Ne' },
+                { label: 'Se / Ni', a: 'Se', b: 'Ni' }
             ];
-            const traitScores = {
-                E: (profile.mbtiScores.Fe || 0) + (profile.mbtiScores.Te || 0) + (profile.mbtiScores.Se || 0) + (profile.mbtiScores.Ne || 0),
-                I: (profile.mbtiScores.Fi || 0) + (profile.mbtiScores.Ti || 0) + (profile.mbtiScores.Si || 0) + (profile.mbtiScores.Ni || 0),
-                S: (profile.mbtiScores.Si || 0) + (profile.mbtiScores.Se || 0),
-                N: (profile.mbtiScores.Ni || 0) + (profile.mbtiScores.Ne || 0),
-                T: (profile.mbtiScores.Ti || 0) + (profile.mbtiScores.Te || 0),
-                F: (profile.mbtiScores.Fi || 0) + (profile.mbtiScores.Fe || 0),
-                J: (profile.mbtiScores.Te || 0) + (profile.mbtiScores.Fe || 0),
-                P: (profile.mbtiScores.Se || 0) + (profile.mbtiScores.Ne || 0)
-            };
             const clamp = (val) => Math.min(100, Math.max(0, val));
             const mbtiData = mbtiPairs.map(pair => {
-                const aScore = traitScores[pair.a];
-                const bScore = traitScores[pair.b];
+                const aScore = profile.mbtiScores[pair.a] || 0;
+                const bScore = profile.mbtiScores[pair.b] || 0;
                 const dominant = aScore > bScore ? pair.a : pair.b;
-                const rawValue = Math.round((Math.max(aScore, bScore) / (aScore + bScore)) * 100);
+                const rawValue = (aScore + bScore) === 0 ? 0 : Math.round((Math.max(aScore, bScore) / (aScore + bScore)) * 100);
                 return { label: pair.label, value: clamp(rawValue), dominant };
             });
-            const mbtiDescriptions = { E: 'Extraversion', I: 'Introversion', S: 'Sensation', N: 'Intuition', T: 'Pensée', F: 'Sentiment', J: 'Jugement', P: 'Perception' };
+            const mbtiDescriptions = {
+                Fi: 'Sentiment Introverti',
+                Te: 'Pensée Extravertie',
+                Fe: 'Sentiment Extraverti',
+                Ti: 'Pensée Introvertie',
+                Si: 'Sensation Introvertie',
+                Ne: 'Intuition Extravertie',
+                Se: 'Sensation Extravertie',
+                Ni: 'Intuition Introvertie'
+            };
             Chart.register(ChartDataLabels);
             new Chart(mbtiCtx, {
                 type: 'bar',

--- a/public/mbti.html
+++ b/public/mbti.html
@@ -4138,30 +4138,29 @@ function showSupport() {
 
             const mbtiCtx = mbtiCanvas.getContext('2d');
             const mbtiPairs = [
-                { label: 'E / I', a: 'E', b: 'I' },
-                { label: 'S / N', a: 'S', b: 'N' },
-                { label: 'T / F', a: 'T', b: 'F' },
-                { label: 'J / P', a: 'J', b: 'P' }
+                { label: 'Fi / Te', a: 'Fi', b: 'Te' },
+                { label: 'Fe / Ti', a: 'Fe', b: 'Ti' },
+                { label: 'Si / Ne', a: 'Si', b: 'Ne' },
+                { label: 'Se / Ni', a: 'Se', b: 'Ni' }
             ];
-            const traitScores = {
-                E: (profile.mbtiScores.Fe || 0) + (profile.mbtiScores.Te || 0) + (profile.mbtiScores.Se || 0) + (profile.mbtiScores.Ne || 0),
-                I: (profile.mbtiScores.Fi || 0) + (profile.mbtiScores.Ti || 0) + (profile.mbtiScores.Si || 0) + (profile.mbtiScores.Ni || 0),
-                S: (profile.mbtiScores.Si || 0) + (profile.mbtiScores.Se || 0),
-                N: (profile.mbtiScores.Ni || 0) + (profile.mbtiScores.Ne || 0),
-                T: (profile.mbtiScores.Ti || 0) + (profile.mbtiScores.Te || 0),
-                F: (profile.mbtiScores.Fi || 0) + (profile.mbtiScores.Fe || 0),
-                J: (profile.mbtiScores.Te || 0) + (profile.mbtiScores.Fe || 0),
-                P: (profile.mbtiScores.Se || 0) + (profile.mbtiScores.Ne || 0)
-            };
             const clamp = (val) => Math.min(100, Math.max(0, val));
             const mbtiData = mbtiPairs.map(pair => {
-                const aScore = traitScores[pair.a];
-                const bScore = traitScores[pair.b];
+                const aScore = profile.mbtiScores[pair.a] || 0;
+                const bScore = profile.mbtiScores[pair.b] || 0;
                 const dominant = aScore > bScore ? pair.a : pair.b;
-                const rawValue = Math.round((Math.max(aScore, bScore) / (aScore + bScore)) * 100);
+                const rawValue = (aScore + bScore) === 0 ? 0 : Math.round((Math.max(aScore, bScore) / (aScore + bScore)) * 100);
                 return { label: pair.label, value: clamp(rawValue), dominant };
             });
-            const mbtiDescriptions = { E: 'Extraversion', I: 'Introversion', S: 'Sensation', N: 'Intuition', T: 'Pensée', F: 'Sentiment', J: 'Jugement', P: 'Perception' };
+            const mbtiDescriptions = {
+                Fi: 'Sentiment Introverti',
+                Te: 'Pensée Extravertie',
+                Fe: 'Sentiment Extraverti',
+                Ti: 'Pensée Introvertie',
+                Si: 'Sensation Introvertie',
+                Ne: 'Intuition Extravertie',
+                Se: 'Sensation Extravertie',
+                Ni: 'Intuition Introvertie'
+            };
             Chart.register(ChartDataLabels);
             new Chart(mbtiCtx, {
                 type: 'bar',


### PR DESCRIPTION
## Summary
- Replace MBTI dichotomies with cognitive function pairs (Fi/Te, Fe/Ti, Si/Ne, Se/Ni).
- Compute chart values directly from corresponding function scores and update tooltips.

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b0dbd44e8883218a0b79163f8f7247