### PR TITLE
Improve MBTI functions chart spacing

### DIFF
--- a/public/blog.html
+++ b/public/blog.html
@@ -3593,13 +3593,19 @@ function showSupport() {
                     datasets: [{
                         data: mbtiData.map(d => d.value),
                         backgroundColor: '#93C5FD',
-                        borderRadius: 8
+                        borderRadius: 8,
+                        barThickness: 16,
+                        categoryPercentage: 0.6
                     }]
                 },
                 options: {
                     indexAxis: 'y',
                     scales: {
-                        x: { beginAtZero: true, max: 100 }
+                        x: { beginAtZero: true, max: 100 },
+                        y: { ticks: { autoSkip: false } }
+                    },
+                    layout: {
+                        padding: { top: 10, bottom: 10 }
                     },
                     plugins: {
                         legend: { display: false },

--- a/public/enneagramme.html
+++ b/public/enneagramme.html
@@ -4052,13 +4052,19 @@ function showSupport() {
                     datasets: [{
                         data: mbtiData.map(d => d.value),
                         backgroundColor: '#93C5FD',
-                        borderRadius: 8
+                        borderRadius: 8,
+                        barThickness: 16,
+                        categoryPercentage: 0.6
                     }]
                 },
                 options: {
                     indexAxis: 'y',
                     scales: {
-                        x: { beginAtZero: true, max: 100 }
+                        x: { beginAtZero: true, max: 100 },
+                        y: { ticks: { autoSkip: false } }
+                    },
+                    layout: {
+                        padding: { top: 10, bottom: 10 }
                     },
                     plugins: {
                         legend: { display: false },

--- a/public/index.html
+++ b/public/index.html
@@ -4310,13 +4310,19 @@ window.showSupport = showSupport;
                     datasets: [{
                         data: mbtiData.map(d => d.value),
                         backgroundColor: '#93C5FD',
-                        borderRadius: 8
+                        borderRadius: 8,
+                        barThickness: 16,
+                        categoryPercentage: 0.6
                     }]
                 },
                 options: {
                     indexAxis: 'y',
                     scales: {
-                        x: { beginAtZero: true, max: 100 }
+                        x: { beginAtZero: true, max: 100 },
+                        y: { ticks: { autoSkip: false } }
+                    },
+                    layout: {
+                        padding: { top: 10, bottom: 10 }
                     },
                     plugins: {
                         legend: { display: false },

--- a/public/mbti.html
+++ b/public/mbti.html
@@ -4166,13 +4166,19 @@ function showSupport() {
                     datasets: [{
                         data: mbtiData.map(d => d.value),
                         backgroundColor: '#93C5FD',
-                        borderRadius: 8
+                        borderRadius: 8,
+                        barThickness: 16,
+                        categoryPercentage: 0.6
                     }]
                 },
                 options: {
                     indexAxis: 'y',
                     scales: {
-                        x: { beginAtZero: true, max: 100 }
+                        x: { beginAtZero: true, max: 100 },
+                        y: { ticks: { autoSkip: false } }
+                    },
+                    layout: {
+                        padding: { top: 10, bottom: 10 }
                     },
                     plugins: {
                         legend: { display: false },


### PR DESCRIPTION
## Summary
- space MBTI function bars with thinner bars and reduced category width for clearer comparison
- ensure MBTI labels always display by disabling auto skipping and adding vertical padding

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b0e143967c8321a109054a36cfbef1