### PR TITLE
Remove profile button from non-home pages

### DIFF
--- a/public/blog-enneagramme-instincts.html
+++ b/public/blog-enneagramme-instincts.html
@@ -459,9 +459,6 @@
             <a href="index.html#home-ia" class="text-gray-500 hover:text-gray-700 inline-flex items-center px-1 pt-1 text-sm font-medium" data-i18n="menu.ai">IA spécialisée</a>
             <a href="blog.html" class="text-gray-500 hover:text-gray-700 inline-flex items-center px-1 pt-1 text-sm font-medium" data-i18n="menu.blog">Blog</a>
             <a href="index.html#home-faq" class="text-gray-500 hover:text-gray-700 inline-flex items-center px-1 pt-1 text-sm font-medium" data-i18n="menu.faq">FAQ</a>
-            <button id="profile-btn-desktop" onclick="openProfileModal()" class="ml-4 inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-black hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black" data-i18n="menu.profile">
-                Mon profil
-            </button>
         </nav>
         <div class="-mr-2 flex items-center md:hidden">
             <button type="button" id="mobile-menu-button" class="inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500" aria-controls="mobile-menu" aria-expanded="false">
@@ -515,9 +512,6 @@
                 <a href="index.html#home-ia" class="text-gray-500 hover:text-gray-700 block px-3 py-2 rounded-md text-base font-medium" data-i18n="menu.ai">IA spécialisée</a>
                 <a href="blog.html" class="text-gray-500 hover:text-gray-700 block px-3 py-2 rounded-md text-base font-medium" data-i18n="menu.blog">Blog</a>
                 <a href="index.html#home-faq" class="text-gray-500 hover:text-gray-700 block px-3 py-2 rounded-md text-base font-medium" data-i18n="menu.faq">FAQ</a>
-                <button id="profile-btn-mobile" onclick="openProfileModal()" class="w-full mt-2 inline-flex items-center justify-center px-4 py-2 border border-transparent text-base font-medium rounded-md shadow-sm text-white bg-black hover:bg-gray-800" data-i18n="menu.profile">
-                    Mon profil
-                </button>
             </div>
         </div>
     </header>

--- a/public/blog-mbti-4-dimensions.html
+++ b/public/blog-mbti-4-dimensions.html
@@ -459,9 +459,6 @@
             <a href="index.html#home-ia" class="text-gray-500 hover:text-gray-700 inline-flex items-center px-1 pt-1 text-sm font-medium" data-i18n="menu.ai">IA spécialisée</a>
             <a href="blog.html" class="text-gray-500 hover:text-gray-700 inline-flex items-center px-1 pt-1 text-sm font-medium" data-i18n="menu.blog">Blog</a>
             <a href="index.html#home-faq" class="text-gray-500 hover:text-gray-700 inline-flex items-center px-1 pt-1 text-sm font-medium" data-i18n="menu.faq">FAQ</a>
-            <button id="profile-btn-desktop" onclick="openProfileModal()" class="ml-4 inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-black hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black" data-i18n="menu.profile">
-                Mon profil
-            </button>
         </nav>
         <div class="-mr-2 flex items-center md:hidden">
             <button type="button" id="mobile-menu-button" class="inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500" aria-controls="mobile-menu" aria-expanded="false">
@@ -515,9 +512,6 @@
                 <a href="index.html#home-ia" class="text-gray-500 hover:text-gray-700 block px-3 py-2 rounded-md text-base font-medium" data-i18n="menu.ai">IA spécialisée</a>
                 <a href="blog.html" class="text-gray-500 hover:text-gray-700 block px-3 py-2 rounded-md text-base font-medium" data-i18n="menu.blog">Blog</a>
                 <a href="index.html#home-faq" class="text-gray-500 hover:text-gray-700 block px-3 py-2 rounded-md text-base font-medium" data-i18n="menu.faq">FAQ</a>
-                <button id="profile-btn-mobile" onclick="openProfileModal()" class="w-full mt-2 inline-flex items-center justify-center px-4 py-2 border border-transparent text-base font-medium rounded-md shadow-sm text-white bg-black hover:bg-gray-800" data-i18n="menu.profile">
-                    Mon profil
-                </button>
             </div>
         </div>
     </header>

--- a/public/blog.html
+++ b/public/blog.html
@@ -459,9 +459,6 @@
             <a href="index.html#home-ia" class="text-gray-500 hover:text-gray-700 inline-flex items-center px-1 pt-1 text-sm font-medium" data-i18n="menu.ai">IA spécialisée</a>
             <a href="blog.html" class="text-gray-500 hover:text-gray-700 inline-flex items-center px-1 pt-1 text-sm font-medium" data-i18n="menu.blog">Blog</a>
             <a href="index.html#home-faq" class="text-gray-500 hover:text-gray-700 inline-flex items-center px-1 pt-1 text-sm font-medium" data-i18n="menu.faq">FAQ</a>
-            <button id="profile-btn-desktop" onclick="openProfileModal()" class="ml-4 inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-black hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black" data-i18n="menu.profile">
-                Mon profil
-            </button>
         </nav>
         <div class="-mr-2 flex items-center md:hidden">
             <button type="button" id="mobile-menu-button" class="inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500" aria-controls="mobile-menu" aria-expanded="false">
@@ -515,9 +512,6 @@
                 <a href="index.html#home-ia" class="text-gray-500 hover:text-gray-700 block px-3 py-2 rounded-md text-base font-medium" data-i18n="menu.ai">IA spécialisée</a>
                 <a href="blog.html" class="text-gray-500 hover:text-gray-700 block px-3 py-2 rounded-md text-base font-medium" data-i18n="menu.blog">Blog</a>
                 <a href="index.html#home-faq" class="text-gray-500 hover:text-gray-700 block px-3 py-2 rounded-md text-base font-medium" data-i18n="menu.faq">FAQ</a>
-                <button id="profile-btn-mobile" onclick="openProfileModal()" class="w-full mt-2 inline-flex items-center justify-center px-4 py-2 border border-transparent text-base font-medium rounded-md shadow-sm text-white bg-black hover:bg-gray-800" data-i18n="menu.profile">
-                    Mon profil
-                </button>
             </div>
         </div>
     </header>

--- a/public/enneagramme.html
+++ b/public/enneagramme.html
@@ -459,7 +459,6 @@
             <a href="index.html#home-ia" class="text-gray-500 hover:text-gray-700 inline-flex items-center px-1 pt-1 text-sm font-medium" data-i18n="menu.ai">IA spécialisée</a>
             <a href="blog.html" class="text-gray-500 hover:text-gray-700 inline-flex items-center px-1 pt-1 text-sm font-medium" data-i18n="menu.blog">Blog</a>
             <a href="index.html#home-faq" class="text-gray-500 hover:text-gray-700 inline-flex items-center px-1 pt-1 text-sm font-medium" data-i18n="menu.faq">FAQ</a>
-            <button id="profile-btn-desktop" onclick="openProfileModal()" class="ml-4 inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-black hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black" data-i18n="menu.profile">Mon profil</button>
         </nav>
         <div class="-mr-2 flex items-center md:hidden">
             <button type="button" id="mobile-menu-button" class="inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500" aria-controls="mobile-menu" aria-expanded="false">
@@ -513,9 +512,6 @@
                 <a href="index.html#home-ia" class="text-gray-500 hover:text-gray-700 block px-3 py-2 rounded-md text-base font-medium" data-i18n="menu.ai">IA spécialisée</a>
                 <a href="blog.html" class="text-gray-500 hover:text-gray-700 block px-3 py-2 rounded-md text-base font-medium" data-i18n="menu.blog">Blog</a>
                 <a href="index.html#home-faq" class="text-gray-500 hover:text-gray-700 block px-3 py-2 rounded-md text-base font-medium" data-i18n="menu.faq">FAQ</a>
-                <button id="profile-btn-mobile" onclick="openProfileModal()" class="w-full mt-2 inline-flex items-center justify-center px-4 py-2 border border-transparent text-base font-medium rounded-md shadow-sm text-white bg-black hover:bg-gray-800" data-i18n="menu.profile">
-                    Mon profil
-                </button>
             </div>
         </div>
     </header>

--- a/public/mbti.html
+++ b/public/mbti.html
@@ -459,9 +459,6 @@
             <a href="index.html#home-ia" class="text-gray-500 hover:text-gray-700 inline-flex items-center px-1 pt-1 text-sm font-medium" data-i18n="menu.ai">IA spécialisée</a>
             <a href="blog.html" class="text-gray-500 hover:text-gray-700 inline-flex items-center px-1 pt-1 text-sm font-medium" data-i18n="menu.blog">Blog</a>
             <a href="index.html#home-faq" class="text-gray-500 hover:text-gray-700 inline-flex items-center px-1 pt-1 text-sm font-medium" data-i18n="menu.faq">FAQ</a>
-            <button id="profile-btn-desktop" onclick="openProfileModal()" class="ml-4 inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-black hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black" data-i18n="menu.profile">
-                Mon profil
-            </button>
         </nav>
         <div class="-mr-2 flex items-center md:hidden">
             <button type="button" id="mobile-menu-button" class="inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500" aria-controls="mobile-menu" aria-expanded="false">
@@ -515,9 +512,6 @@
                 <a href="index.html#home-ia" class="text-gray-500 hover:text-gray-700 block px-3 py-2 rounded-md text-base font-medium" data-i18n="menu.ai">IA spécialisée</a>
                 <a href="blog.html" class="text-gray-500 hover:text-gray-700 block px-3 py-2 rounded-md text-base font-medium" data-i18n="menu.blog">Blog</a>
                 <a href="index.html#home-faq" class="text-gray-500 hover:text-gray-700 block px-3 py-2 rounded-md text-base font-medium" data-i18n="menu.faq">FAQ</a>
-                <button id="profile-btn-mobile" onclick="openProfileModal()" class="w-full mt-2 inline-flex items-center justify-center px-4 py-2 border border-transparent text-base font-medium rounded-md shadow-sm text-white bg-black hover:bg-gray-800" data-i18n="menu.profile">
-                    Mon profil
-                </button>
             </div>
         </div>
     </header>


### PR DESCRIPTION
## Summary
- Hide "Mon profil" button from all pages except the home page
- Keep profile access on index.html only

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b0e4b2236083219956889366304513