### PR TITLE
refactor: centralize Supabase client setup

### DIFF
--- a/public/blog-enneagramme-instincts.html
+++ b/public/blog-enneagramme-instincts.html
@@ -816,8 +816,10 @@
         </div>
     </div>
 
-    <script src="common.js"></script>
-    <script>
+    <script type="module">
+      import { showModal, closeModal } from "./common.js";
+      window.closeModal = closeModal;
+
       function showPrivacyPolicy() {
         const lang = localStorage.getItem('lang') || 'fr';
         const date = new Date().toLocaleDateString(lang === 'fr' ? 'fr-FR' : 'en-US');
@@ -947,11 +949,7 @@
 <script src="i18n.js"></script>
 
 <script type="module">
-  import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
-
-  const SUPABASE_URL = "https://swjnpvfkloubshksobau.supabase.co";
-  const SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InN3am5wdmZrbG91YnNoa3NvYmF1Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTQwOTUxMzEsImV4cCI6MjA2OTY3MTEzMX0.A6rnIJyfIIxDT0c2XW_zGeUXpdYCgBFd6MTzBGFZ-Cg"; 
-  const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
+  import { supabase } from "./common.js";
 
   // -------- Utils --------
   const nowIso = () => new Date().toISOString();

--- a/public/blog-mbti-4-dimensions.html
+++ b/public/blog-mbti-4-dimensions.html
@@ -1031,11 +1031,7 @@ function viewResults(){ alert('Fonctionnalité à venir'); }
 </script>
 
  <script type="module">
-  import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
-
-  const SUPABASE_URL = "https://swjnpvfkloubshksobau.supabase.co";
-  const SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InN3am5wdmZrbG91YnNoa3NvYmF1Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTQwOTUxMzEsImV4cCI6MjA2OTY3MTEzMX0.A6rnIJyfIIxDT0c2XW_zGeUXpdYCgBFd6MTzBGFZ-Cg"; 
-  const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
+  import { supabase } from "./common.js";
 
   // -------- Utils --------
   const nowIso = () => new Date().toISOString();

--- a/public/blog.html
+++ b/public/blog.html
@@ -617,7 +617,8 @@
     <script src="questions-v2.js"></script>
    
       
-    <script>
+    <script type="module">
+        import { supabase } from "./common.js";
         // Configuration et données
                 // Récupère les questions externes depuis Supabase si l'utilisateur est un proche
 let questions = AUTO_QUESTIONS;
@@ -1059,15 +1060,8 @@ function displayQuestion(index) {
             }
             return false;
         }
-
-        // === Configuration Supabase ===
-
-        const SUPABASE_URL = 'https://swjnpvfkloubshksobau.supabase.co';
-const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InN3am5wdmZrbG91YnNoa3NvYmF1Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTQwOTUxMzEsImV4cCI6MjA2OTY3MTEzMX0.A6rnIJyfIIxDT0c2XW_zGeUXpdYCgBFd6MTzBGFZ-Cg';
-
-// Le client Supabase sera initialisé après le chargement du script
-
-
+        
+        // Supabase client imported from common.js
         /**
          * Enregistre le profil utilisateur (auto‑évaluation) dans Supabase.
          * Cette fonction insère un enregistrement dans la table "users".
@@ -3991,13 +3985,7 @@ function showSupport() {
   </script>
 
   <script type="module">
-  import { createClient } from "https://cdn.jsdelivr.net/npm/@supabase/supabase-js/+esm";
-
-  const supabaseUrl = "https://swjnpvfkloubshksobau.supabase.co";
-  const supabaseKey = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InN3am5wdmZrbG91YnNoa3NvYmF1Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTQwOTUxMzEsImV4cCI6MjA2OTY3MTEzMX0.A6rnIJyfIIxDT0c2XW_zGeUXpdYCgBFd6MTzBGFZ-Cg";
-
-  const supabase = createClient(supabaseUrl, supabaseKey);
-  window.supabase = supabase;
+  import { supabase } from "./common.js";
 
   const externalForm = document.getElementById("external-form");
 
@@ -4365,8 +4353,6 @@ addChatStyles();
   #pc-constellation{position:absolute; inset:0; width:100%; height:100%; display:block; pointer-events:none;}
 </style>
 
- <!-- Supabase UMD (expose window.supabase) -->
-<script src="https://unpkg.com/@supabase/supabase-js"></script>
 <script src="nav.js"></script>
 <script src="lang.js"></script>
 <script src="i18n.js"></script>

--- a/public/common.js
+++ b/public/common.js
@@ -1,3 +1,9 @@
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const SUPABASE_URL = "https://swjnpvfkloubshksobau.supabase.co";
+const SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InN3am5wdmZrbG91YnNoa3NvYmF1Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTQwOTUxMzEsImV4cCI6MjA2OTY3MTEzMX0.A6rnIJyfIIxDT0c2XW_zGeUXpdYCgBFd6MTzBGFZ-Cg";
+export const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
+
 const mobileMenuButton = document.getElementById('mobile-menu-button');
 const mobileMenu = document.getElementById('mobile-menu');
 const menuIcon = document.getElementById('menu-icon');
@@ -240,3 +246,5 @@ function showContact(){
   `;
   showModal('<span data-i18n="footer.contact.support.title">Support</span>', content);
 }
+
+export { showModal, closeModal };

--- a/public/enneagramme.html
+++ b/public/enneagramme.html
@@ -1056,7 +1056,8 @@
 
    
       
-    <script>
+    <script type="module">
+        import { supabase } from "./common.js";
         // Configuration et données
                 // Récupère les questions externes depuis Supabase si l'utilisateur est un proche
 let questions = AUTO_QUESTIONS;
@@ -1504,15 +1505,8 @@ function displayQuestion(index) {
             }
             return false;
         }
-
-        // === Configuration Supabase ===
-
-        const SUPABASE_URL = 'https://swjnpvfkloubshksobau.supabase.co';
-const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InN3am5wdmZrbG91YnNoa3NvYmF1Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTQwOTUxMzEsImV4cCI6MjA2OTY3MTEzMX0.A6rnIJyfIIxDT0c2XW_zGeUXpdYCgBFd6MTzBGFZ-Cg';
-
-// Le client Supabase sera initialisé après le chargement du script
-
-
+        
+        // Supabase client imported from common.js
         /**
          * Enregistre le profil utilisateur (auto‑évaluation) dans Supabase.
          * Cette fonction insère un enregistrement dans la table "users".
@@ -4452,13 +4446,7 @@ function showSupport() {
   </script>
 
   <script type="module">
-  import { createClient } from "https://cdn.jsdelivr.net/npm/@supabase/supabase-js/+esm";
-
-  const supabaseUrl = "https://swjnpvfkloubshksobau.supabase.co";
-  const supabaseKey = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InN3am5wdmZrbG91YnNoa3NvYmF1Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTQwOTUxMzEsImV4cCI6MjA2OTY3MTEzMX0.A6rnIJyfIIxDT0c2XW_zGeUXpdYCgBFd6MTzBGFZ-Cg";
-
-  const supabase = createClient(supabaseUrl, supabaseKey);
-  window.supabase = supabase;
+  import { supabase } from "./common.js";
 
   const externalForm = document.getElementById("external-form");
 
@@ -4836,8 +4824,6 @@ addChatStyles();
   #pc-constellation{position:absolute; inset:0; width:100%; height:100%; display:block; pointer-events:none;}
 </style>
 
-<!-- Supabase UMD (expose window.supabase) -->
-<script src="https://unpkg.com/@supabase/supabase-js"></script>
 <script src="nav.js"></script>
 <script src="lang.js"></script>
 <script src="i18n.js"></script>
@@ -4864,11 +4850,7 @@ addChatStyles();
 </script>
 
 <script type="module">
-  import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
-
-  const SUPABASE_URL = "https://swjnpvfkloubshksobau.supabase.co";
-  const SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InN3am5wdmZrbG91YnNoa3NvYmF1Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTQwOTUxMzEsImV4cCI6MjA2OTY3MTEzMX0.A6rnIJyfIIxDT0c2XW_zGeUXpdYCgBFd6MTzBGFZ-Cg"; 
-  const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
+  import { supabase } from "./common.js";
 
   // -------- Utils --------
   const nowIso = () => new Date().toISOString();

--- a/public/index.html
+++ b/public/index.html
@@ -1128,7 +1128,8 @@
     </footer>
     <script src="questions-v2.js"></script>
       
-   <script>
+   <script type="module">
+        import { supabase } from "./common.js";
         // Configuration et données
                 // Récupère les questions externes depuis Supabase si l'utilisateur est un proche
 let questions = AUTO_QUESTIONS;
@@ -1628,15 +1629,8 @@ function displayQuestion(index) {
             }
             return false;
         }
-
-        // === Configuration Supabase ===
-
-        const SUPABASE_URL = 'https://swjnpvfkloubshksobau.supabase.co';
-const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InN3am5wdmZrbG91YnNoa3NvYmF1Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTQwOTUxMzEsImV4cCI6MjA2OTY3MTEzMX0.A6rnIJyfIIxDT0c2XW_zGeUXpdYCgBFd6MTzBGFZ-Cg';
-
-// Le client Supabase sera initialisé après le chargement du script
-
-
+        
+        // Supabase client imported from common.js
         /**
          * Enregistre le profil utilisateur (auto‑évaluation) dans Supabase.
          * Cette fonction insère un enregistrement dans la table "users".
@@ -4734,13 +4728,7 @@ window.showSupport = showSupport;
   </script>
 
   <script type="module">
-  import { createClient } from "https://cdn.jsdelivr.net/npm/@supabase/supabase-js/+esm";
-
-  const supabaseUrl = "https://swjnpvfkloubshksobau.supabase.co";
-  const supabaseKey = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InN3am5wdmZrbG91YnNoa3NvYmF1Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTQwOTUxMzEsImV4cCI6MjA2OTY3MTEzMX0.A6rnIJyfIIxDT0c2XW_zGeUXpdYCgBFd6MTzBGFZ-Cg";
-
-  const supabase = createClient(supabaseUrl, supabaseKey);
-  window.supabase = supabase;
+  import { supabase } from "./common.js";
 
   const externalForm = document.getElementById("external-form");
 
@@ -5111,8 +5099,6 @@ addChatStyles();
   #pc-constellation{position:absolute; inset:0; width:100%; height:100%; display:block; pointer-events:none;}
 </style>
 
-<!-- Supabase UMD (expose window.supabase) -->
-<script src="https://unpkg.com/@supabase/supabase-js"></script>
 <script src="nav.js"></script>
 <script src="lang.js"></script>
 <script src="i18n.js"></script>
@@ -5125,11 +5111,7 @@ window.addEventListener('scroll', () => {
 </script>
 
  <script type="module">
-  import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
-
-  const SUPABASE_URL = "https://swjnpvfkloubshksobau.supabase.co";
-  const SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InN3am5wdmZrbG91YnNoa3NvYmF1Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTQwOTUxMzEsImV4cCI6MjA2OTY3MTEzMX0.A6rnIJyfIIxDT0c2XW_zGeUXpdYCgBFd6MTzBGFZ-Cg"; 
-  const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
+  import { supabase } from "./common.js";
 
   // -------- Utils --------
   const nowIso = () => new Date().toISOString();

--- a/public/mbti.html
+++ b/public/mbti.html
@@ -1150,7 +1150,8 @@
     <script src="questions-v2.js"></script>
    
       
-    <script>
+    <script type="module">
+        import { supabase } from "./common.js";
         // Configuration et données
                 // Récupère les questions externes depuis Supabase si l'utilisateur est un proche
 let questions = AUTO_QUESTIONS;
@@ -1598,15 +1599,8 @@ function displayQuestion(index) {
             }
             return false;
         }
-
-        // === Configuration Supabase ===
-
-        const SUPABASE_URL = 'https://swjnpvfkloubshksobau.supabase.co';
-const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InN3am5wdmZrbG91YnNoa3NvYmF1Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTQwOTUxMzEsImV4cCI6MjA2OTY3MTEzMX0.A6rnIJyfIIxDT0c2XW_zGeUXpdYCgBFd6MTzBGFZ-Cg';
-
-// Le client Supabase sera initialisé après le chargement du script
-
-
+        
+        // Supabase client imported from common.js
         /**
          * Enregistre le profil utilisateur (auto‑évaluation) dans Supabase.
          * Cette fonction insère un enregistrement dans la table "users".
@@ -4564,13 +4558,7 @@ function showSupport() {
   </script>
 
   <script type="module">
-  import { createClient } from "https://cdn.jsdelivr.net/npm/@supabase/supabase-js/+esm";
-
-  const supabaseUrl = "https://swjnpvfkloubshksobau.supabase.co";
-  const supabaseKey = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InN3am5wdmZrbG91YnNoa3NvYmF1Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTQwOTUxMzEsImV4cCI6MjA2OTY3MTEzMX0.A6rnIJyfIIxDT0c2XW_zGeUXpdYCgBFd6MTzBGFZ-Cg";
-
-  const supabase = createClient(supabaseUrl, supabaseKey);
-  window.supabase = supabase;
+  import { supabase } from "./common.js";
 
   const externalForm = document.getElementById("external-form");
 
@@ -4948,8 +4936,6 @@ addChatStyles();
   #pc-constellation{position:absolute; inset:0; width:100%; height:100%; display:block; pointer-events:none;}
 </style>
 
-<!-- Supabase UMD (expose window.supabase) -->
-<script src="https://unpkg.com/@supabase/supabase-js"></script>
 <script src="nav.js"></script>
 <script src="lang.js"></script>
 <script src="i18n.js"></script>
@@ -4976,11 +4962,7 @@ addChatStyles();
 </script>
 
  <script type="module">
-  import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
-
-  const SUPABASE_URL = "https://swjnpvfkloubshksobau.supabase.co";
-  const SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InN3am5wdmZrbG91YnNoa3NvYmF1Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTQwOTUxMzEsImV4cCI6MjA2OTY3MTEzMX0.A6rnIJyfIIxDT0c2XW_zGeUXpdYCgBFd6MTzBGFZ-Cg"; 
-  const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
+  import { supabase } from "./common.js";
 
   // -------- Utils --------
   const nowIso = () => new Date().toISOString();


### PR DESCRIPTION
## Summary
- add shared Supabase client export in `public/common.js`
- remove per-page Supabase initialization and import the shared client across HTML pages
- clean up redundant UMD script tags

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b35afdd0008321a79d45b82dd0070b