### PR TITLE
feat: centralize Supabase client

### DIFF
--- a/public/common.js
+++ b/public/common.js
@@ -1,3 +1,11 @@
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const SUPABASE_URL = "https://swjnpvfkloubshksobau.supabase.co";
+const SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InN3am5wdmZrbG91YnNoa3NvYmF1Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTQwOTUxMzEsImV4cCI6MjA2OTY3MTEzMX0.A6rnIJyfIIxDT0c2XW_zGeUXpdYCgBFd6MTzBGFZ-Cg";
+
+export const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
+window.supabase = supabase;
+
 const mobileMenuButton = document.getElementById('mobile-menu-button');
 const mobileMenu = document.getElementById('mobile-menu');
 const menuIcon = document.getElementById('menu-icon');

--- a/public/index.html
+++ b/public/index.html
@@ -1128,7 +1128,9 @@
     </footer>
     <script src="questions-v2.js"></script>
       
-   <script>
+   <script type="module">
+import { supabase } from "./common.js";
+
         // Configuration et données
                 // Récupère les questions externes depuis Supabase si l'utilisateur est un proche
 let questions = AUTO_QUESTIONS;
@@ -1628,14 +1630,6 @@ function displayQuestion(index) {
             }
             return false;
         }
-
-        // === Configuration Supabase ===
-
-        const SUPABASE_URL = 'https://swjnpvfkloubshksobau.supabase.co';
-const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InN3am5wdmZrbG91YnNoa3NvYmF1Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTQwOTUxMzEsImV4cCI6MjA2OTY3MTEzMX0.A6rnIJyfIIxDT0c2XW_zGeUXpdYCgBFd6MTzBGFZ-Cg';
-
-// Le client Supabase sera initialisé après le chargement du script
-
 
         /**
          * Enregistre le profil utilisateur (auto‑évaluation) dans Supabase.
@@ -3253,6 +3247,18 @@ window.showTermsOfService = showTermsOfService;
 window.showLegalNotices = showLegalNotices;
 window.showCookies = showCookies;
 window.showSupport = showSupport;
+window.openProfileModal = openProfileModal;
+window.closeProfileModal = closeProfileModal;
+window.resetProfileModal = resetProfileModal;
+window.checkProfileCode = checkProfileCode;
+window.viewResults = viewResults;
+window.shareCode = shareCode;
+window.copyCode = copyCode;
+window.restartTest = restartTest;
+window.closeResultsModal = closeResultsModal;
+window.showAboutProject = showAboutProject;
+window.closeModal = closeModal;
+window.shareProfileResults = shareProfileResults;
 
         // Fonction pour démarrer l'évaluation externe
         function startExternalEvaluation() {
@@ -4734,13 +4740,7 @@ window.showSupport = showSupport;
   </script>
 
   <script type="module">
-  import { createClient } from "https://cdn.jsdelivr.net/npm/@supabase/supabase-js/+esm";
-
-  const supabaseUrl = "https://swjnpvfkloubshksobau.supabase.co";
-  const supabaseKey = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InN3am5wdmZrbG91YnNoa3NvYmF1Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTQwOTUxMzEsImV4cCI6MjA2OTY3MTEzMX0.A6rnIJyfIIxDT0c2XW_zGeUXpdYCgBFd6MTzBGFZ-Cg";
-
-  const supabase = createClient(supabaseUrl, supabaseKey);
-  window.supabase = supabase;
+import { supabase } from "./common.js";
 
   const externalForm = document.getElementById("external-form");
 
@@ -5111,8 +5111,6 @@ addChatStyles();
   #pc-constellation{position:absolute; inset:0; width:100%; height:100%; display:block; pointer-events:none;}
 </style>
 
-<!-- Supabase UMD (expose window.supabase) -->
-<script src="https://unpkg.com/@supabase/supabase-js"></script>
 <script src="nav.js"></script>
 <script src="lang.js"></script>
 <script src="i18n.js"></script>
@@ -5125,11 +5123,7 @@ window.addEventListener('scroll', () => {
 </script>
 
  <script type="module">
-  import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
-
-  const SUPABASE_URL = "https://swjnpvfkloubshksobau.supabase.co";
-  const SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InN3am5wdmZrbG91YnNoa3NvYmF1Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTQwOTUxMzEsImV4cCI6MjA2OTY3MTEzMX0.A6rnIJyfIIxDT0c2XW_zGeUXpdYCgBFd6MTzBGFZ-Cg"; 
-  const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
+import { supabase } from "./common.js";
 
   // -------- Utils --------
   const nowIso = () => new Date().toISOString();


### PR DESCRIPTION
## Summary
- centralize Supabase client setup in `public/common.js`
- import the shared `supabase` client in `index.html` modules and remove duplicate initialization
- expose required utility functions on `window` to support inline handlers

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b36000473c8321a42a6700a129a641