### PR TITLE
refactor: centralize supabase client across pages

### DIFF
--- a/public/blog-enneagramme-instincts.html
+++ b/public/blog-enneagramme-instincts.html
@@ -947,11 +947,7 @@
 <script src="i18n.js"></script>
 
 <script type="module">
-  import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
-
-  const SUPABASE_URL = "https://swjnpvfkloubshksobau.supabase.co";
-  const SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InN3am5wdmZrbG91YnNoa3NvYmF1Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTQwOTUxMzEsImV4cCI6MjA2OTY3MTEzMX0.A6rnIJyfIIxDT0c2XW_zGeUXpdYCgBFd6MTzBGFZ-Cg"; 
-  const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
+  import { supabase } from "./common.js";
 
   // -------- Utils --------
   const nowIso = () => new Date().toISOString();

--- a/public/blog-mbti-4-dimensions.html
+++ b/public/blog-mbti-4-dimensions.html
@@ -1031,11 +1031,7 @@ function viewResults(){ alert('Fonctionnalité à venir'); }
 </script>
 
  <script type="module">
-  import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
-
-  const SUPABASE_URL = "https://swjnpvfkloubshksobau.supabase.co";
-  const SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InN3am5wdmZrbG91YnNoa3NvYmF1Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTQwOTUxMzEsImV4cCI6MjA2OTY3MTEzMX0.A6rnIJyfIIxDT0c2XW_zGeUXpdYCgBFd6MTzBGFZ-Cg"; 
-  const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
+  import { supabase } from "./common.js";
 
   // -------- Utils --------
   const nowIso = () => new Date().toISOString();

--- a/public/blog.html
+++ b/public/blog.html
@@ -1060,13 +1060,6 @@ function displayQuestion(index) {
             return false;
         }
 
-        // === Configuration Supabase ===
-
-        const SUPABASE_URL = 'https://swjnpvfkloubshksobau.supabase.co';
-const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InN3am5wdmZrbG91YnNoa3NvYmF1Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTQwOTUxMzEsImV4cCI6MjA2OTY3MTEzMX0.A6rnIJyfIIxDT0c2XW_zGeUXpdYCgBFd6MTzBGFZ-Cg';
-
-// Le client Supabase sera initialisé après le chargement du script
-
 
         /**
          * Enregistre le profil utilisateur (auto‑évaluation) dans Supabase.
@@ -3991,13 +3984,7 @@ function showSupport() {
   </script>
 
   <script type="module">
-  import { createClient } from "https://cdn.jsdelivr.net/npm/@supabase/supabase-js/+esm";
-
-  const supabaseUrl = "https://swjnpvfkloubshksobau.supabase.co";
-  const supabaseKey = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InN3am5wdmZrbG91YnNoa3NvYmF1Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTQwOTUxMzEsImV4cCI6MjA2OTY3MTEzMX0.A6rnIJyfIIxDT0c2XW_zGeUXpdYCgBFd6MTzBGFZ-Cg";
-
-  const supabase = createClient(supabaseUrl, supabaseKey);
-  window.supabase = supabase;
+  import { supabase } from "./common.js";
 
   const externalForm = document.getElementById("external-form");
 
@@ -4365,8 +4352,6 @@ addChatStyles();
   #pc-constellation{position:absolute; inset:0; width:100%; height:100%; display:block; pointer-events:none;}
 </style>
 
- <!-- Supabase UMD (expose window.supabase) -->
-<script src="https://unpkg.com/@supabase/supabase-js"></script>
 <script src="nav.js"></script>
 <script src="lang.js"></script>
 <script src="i18n.js"></script>

--- a/public/enneagramme.html
+++ b/public/enneagramme.html
@@ -1505,13 +1505,6 @@ function displayQuestion(index) {
             return false;
         }
 
-        // === Configuration Supabase ===
-
-        const SUPABASE_URL = 'https://swjnpvfkloubshksobau.supabase.co';
-const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InN3am5wdmZrbG91YnNoa3NvYmF1Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTQwOTUxMzEsImV4cCI6MjA2OTY3MTEzMX0.A6rnIJyfIIxDT0c2XW_zGeUXpdYCgBFd6MTzBGFZ-Cg';
-
-// Le client Supabase sera initialisé après le chargement du script
-
 
         /**
          * Enregistre le profil utilisateur (auto‑évaluation) dans Supabase.
@@ -4452,13 +4445,7 @@ function showSupport() {
   </script>
 
   <script type="module">
-  import { createClient } from "https://cdn.jsdelivr.net/npm/@supabase/supabase-js/+esm";
-
-  const supabaseUrl = "https://swjnpvfkloubshksobau.supabase.co";
-  const supabaseKey = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InN3am5wdmZrbG91YnNoa3NvYmF1Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTQwOTUxMzEsImV4cCI6MjA2OTY3MTEzMX0.A6rnIJyfIIxDT0c2XW_zGeUXpdYCgBFd6MTzBGFZ-Cg";
-
-  const supabase = createClient(supabaseUrl, supabaseKey);
-  window.supabase = supabase;
+  import { supabase } from "./common.js";
 
   const externalForm = document.getElementById("external-form");
 
@@ -4836,8 +4823,6 @@ addChatStyles();
   #pc-constellation{position:absolute; inset:0; width:100%; height:100%; display:block; pointer-events:none;}
 </style>
 
-<!-- Supabase UMD (expose window.supabase) -->
-<script src="https://unpkg.com/@supabase/supabase-js"></script>
 <script src="nav.js"></script>
 <script src="lang.js"></script>
 <script src="i18n.js"></script>
@@ -4864,11 +4849,7 @@ addChatStyles();
 </script>
 
 <script type="module">
-  import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
-
-  const SUPABASE_URL = "https://swjnpvfkloubshksobau.supabase.co";
-  const SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InN3am5wdmZrbG91YnNoa3NvYmF1Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTQwOTUxMzEsImV4cCI6MjA2OTY3MTEzMX0.A6rnIJyfIIxDT0c2XW_zGeUXpdYCgBFd6MTzBGFZ-Cg"; 
-  const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
+  import { supabase } from "./common.js";
 
   // -------- Utils --------
   const nowIso = () => new Date().toISOString();

--- a/public/mbti.html
+++ b/public/mbti.html
@@ -1599,13 +1599,6 @@ function displayQuestion(index) {
             return false;
         }
 
-        // === Configuration Supabase ===
-
-        const SUPABASE_URL = 'https://swjnpvfkloubshksobau.supabase.co';
-const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InN3am5wdmZrbG91YnNoa3NvYmF1Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTQwOTUxMzEsImV4cCI6MjA2OTY3MTEzMX0.A6rnIJyfIIxDT0c2XW_zGeUXpdYCgBFd6MTzBGFZ-Cg';
-
-// Le client Supabase sera initialisé après le chargement du script
-
 
         /**
          * Enregistre le profil utilisateur (auto‑évaluation) dans Supabase.
@@ -4564,13 +4557,7 @@ function showSupport() {
   </script>
 
   <script type="module">
-  import { createClient } from "https://cdn.jsdelivr.net/npm/@supabase/supabase-js/+esm";
-
-  const supabaseUrl = "https://swjnpvfkloubshksobau.supabase.co";
-  const supabaseKey = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InN3am5wdmZrbG91YnNoa3NvYmF1Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTQwOTUxMzEsImV4cCI6MjA2OTY3MTEzMX0.A6rnIJyfIIxDT0c2XW_zGeUXpdYCgBFd6MTzBGFZ-Cg";
-
-  const supabase = createClient(supabaseUrl, supabaseKey);
-  window.supabase = supabase;
+  import { supabase } from "./common.js";
 
   const externalForm = document.getElementById("external-form");
 
@@ -4948,8 +4935,6 @@ addChatStyles();
   #pc-constellation{position:absolute; inset:0; width:100%; height:100%; display:block; pointer-events:none;}
 </style>
 
-<!-- Supabase UMD (expose window.supabase) -->
-<script src="https://unpkg.com/@supabase/supabase-js"></script>
 <script src="nav.js"></script>
 <script src="lang.js"></script>
 <script src="i18n.js"></script>
@@ -4976,11 +4961,7 @@ addChatStyles();
 </script>
 
  <script type="module">
-  import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
-
-  const SUPABASE_URL = "https://swjnpvfkloubshksobau.supabase.co";
-  const SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InN3am5wdmZrbG91YnNoa3NvYmF1Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTQwOTUxMzEsImV4cCI6MjA2OTY3MTEzMX0.A6rnIJyfIIxDT0c2XW_zGeUXpdYCgBFd6MTzBGFZ-Cg"; 
-  const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
+  import { supabase } from "./common.js";
 
   // -------- Utils --------
   const nowIso = () => new Date().toISOString();


### PR DESCRIPTION
## Summary
- reuse shared Supabase client in MBTI, Ennéagramme and blog pages
- remove duplicate Supabase initialization blocks and CDN script

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b364bac2bc83219a6121b06df5e75d